### PR TITLE
Create ClamAV service for Performance Testing

### DIFF
--- a/kube/public-site-service.yml
+++ b/kube/public-site-service.yml
@@ -13,3 +13,18 @@ spec:
     - name: public-prxy-prt
       port: 10443
       targetPort: 10443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pub-site-av-svc
+  labels:
+    name: pub-site-av-svc
+spec:
+  selector:
+    name: public-site-svc
+  type: ClusterIP
+  ports:
+    - name: pub-site-av-prt
+      port: 8080
+      targetPort: 8080

--- a/kube/public-site-service.yml
+++ b/kube/public-site-service.yml
@@ -22,7 +22,7 @@ metadata:
     name: pub-site-av-svc
 spec:
   selector:
-    name: public-site-svc
+    name: pub-site-av-svc
   type: ClusterIP
   ports:
     - name: pub-site-av-prt


### PR DESCRIPTION
**What changes does this PR bring?**
Create ClamAV service for Performance Testing
It will allow Performance pod to access ClamAV REST API service available only to Public-Site up to now.
Network policy allowing such access will be deployed along with Performance testing pod to avoid any accidental Production deployment of such policy

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
N/A - deployment change
- [X] Is the build confirmed to be passing on CI?
- [X] Have you added enough relevant unit tests for your change?
- [X] Have you added enough relevant E2E tests for your change?
- [X] Have you updated any relevant documentation as part of this change?
- [X] Has this change been tested against the Acceptance Criteria?
- [X] Have you considered how this will be deployed in SIT/Staging/Production?
