### PR TITLE
update deprecated ingress annotation for auto-tls certs

### DIFF
--- a/kube/public-site-ingress.yml
+++ b/kube/public-site-ingress.yml
@@ -10,7 +10,7 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/proxy-body-size: "20m"
-    kubernetes.io/tls-acme: "true"
+    stable.k8s.psg.io/kcm.class: default
 spec:
   rules:
   - host: {{ .BASE_URL }}


### PR DESCRIPTION
remove deprecated annotation and include new one to ensure let's encrypt certificates are automatically issued and renewed by the cert-manager service running in kubernetes
