### PR TITLE
EGAR-742 disable input field autocomplete

### DIFF
--- a/src/app/aircraft/add/index.njk
+++ b/src/app/aircraft/add/index.njk
@@ -37,7 +37,7 @@
     {% include "common/templates/includes/errors.njk" %}
   {% endif %}
 
-      <form action="/aircraft/add" autocomplete="false" class="form-group"
+      <form action="/aircraft/add" autocomplete="off" class="form-group"
       method="post" role="form">
 
       <h1 class="govuk-heading-xl">

--- a/src/app/aircraft/edit/index.njk
+++ b/src/app/aircraft/edit/index.njk
@@ -37,7 +37,7 @@
     {% include "common/templates/includes/errors.njk" %}
   {% endif %}
 
-      <form action="/aircraft/edit" autocomplete="false" class="form-group"
+      <form action="/aircraft/edit" autocomplete="off" class="form-group"
       method="post" role="form" >
 
       <h1 class="govuk-heading-xl">

--- a/src/app/garfile/arrival/index.njk
+++ b/src/app/garfile/arrival/index.njk
@@ -27,7 +27,7 @@
   {% endif %}
   <div class="govuk-grid-row">
 	  <div class="govuk-grid-column-two-thirds">
-      <form action="/garfile/arrival" autocomplete="false" class="form-group" method="post" role="form">
+      <form action="/garfile/arrival" autocomplete="off" class="form-group" method="post" role="form">
 
         <!–– Start Arrival date -->
           <div class="govuk-form-group" id="arrivalDate">
@@ -121,7 +121,7 @@
 				</span>
 
           {{ m.error_message('arrivalPort', errors) }}
-          <input class="govuk-input" maxlength="4" id="arrivalPort" name="arrivalPort" autocomplete="false" type="text" value="{{cookie.getGarArrivalVoyage().arrivalPort}}"/>
+          <input class="govuk-input" maxlength="4" id="arrivalPort" name="arrivalPort" autocomplete="off" type="text" value="{{cookie.getGarArrivalVoyage().arrivalPort}}"/>
         </div>
         <!-- End arrival port -->
 
@@ -144,7 +144,7 @@
           </span>
 
           {{ m.error_message('arrivalLat', errors) }}
-          <input class="govuk-input" id="arrivalLat" name="arrivalLat" autocomplete="false" type="text" value="{{cookie.getGarArrivalVoyage().arrivalLat}}"/>
+          <input class="govuk-input" id="arrivalLat" name="arrivalLat" autocomplete="off" type="text" value="{{cookie.getGarArrivalVoyage().arrivalLat}}"/>
         </div>
 
         <div class="govuk-form-group {{ m.form_group_class('arrivalLong', errors) }}">
@@ -155,7 +155,7 @@
                 For example -0.4542
           </span>
           {{ m.error_message('arrivalLong', errors) }}
-          <input class="govuk-input" id="arrivalLong" name="arrivalLong" autocomplete="false" type="text" value="{{cookie.getGarArrivalVoyage().arrivalLong}}"/>
+          <input class="govuk-input" id="arrivalLong" name="arrivalLong" autocomplete="off" type="text" value="{{cookie.getGarArrivalVoyage().arrivalLong}}"/>
 
         </div>
         <!-- End arrival coords -->

--- a/src/app/garfile/craft/index.njk
+++ b/src/app/garfile/craft/index.njk
@@ -22,7 +22,7 @@
 	{% if errors %}
 		{% include "common/templates/includes/errors.njk" %}
 	{% endif %}
-		<form action="/garfile/craft" autocomplete="false" class="form-group"
+		<form action="/garfile/craft" autocomplete="off" class="form-group"
       method="post" role="form">
 			<span class="govuk-caption-xl">Section 3 of 8</span>
 			<h1 class="govuk-heading-xl">Aircraft details</h1>

--- a/src/app/garfile/customs/index.njk
+++ b/src/app/garfile/customs/index.njk
@@ -27,7 +27,7 @@
       {% include "common/templates/includes/errors.njk" %}
     {% endif %}
 
-    <form action="/garfile/customs" autocomplete="false" class="form-group"
+    <form action="/garfile/customs" autocomplete="off" class="form-group"
     method="post" role="form">
 
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/src/app/garfile/departure/index.njk
+++ b/src/app/garfile/departure/index.njk
@@ -27,7 +27,7 @@
   {% endif %}
   <div class="govuk-grid-row">
 	  <div class="govuk-grid-column-two-thirds">
-      <form action="/garfile/departure" autocomplete="false" class="form-group" method="post" role="form">
+      <form action="/garfile/departure" autocomplete="off" class="form-group" method="post" role="form">
 
         <!-- Start departure date -->
           <div class="govuk-form-group" id="departureDate">
@@ -121,7 +121,7 @@
 				</span>
 
           {{ m.error_message('departurePort', errors) }}
-          <input class="govuk-input" maxlength="4" id="departurePort" name="departurePort" autocomplete="false" type="text" value="{{cookie.getGarDepartureVoyage().departurePort}}"/>
+          <input class="govuk-input" maxlength="4" id="departurePort" name="departurePort" autocomplete="off" type="text" value="{{cookie.getGarDepartureVoyage().departurePort}}"/>
         </div>
         <!-- End departure port -->
 
@@ -144,7 +144,7 @@
           </span>
 
           {{ m.error_message('departureLat', errors) }}
-          <input class="govuk-input" id="departureLat" name="departureLat" autocomplete="false" type="text" value="{{cookie.getGarDepartureVoyage().departureLat}}"/>
+          <input class="govuk-input" id="departureLat" name="departureLat" autocomplete="off" type="text" value="{{cookie.getGarDepartureVoyage().departureLat}}"/>
         </div>
 
         <div class="govuk-form-group {{ m.form_group_class('departureLong', errors) }}">
@@ -155,7 +155,7 @@
               For example -0.4542
           </span>
           {{ m.error_message('departureLong', errors) }}
-          <input class="govuk-input" id="departureLong" name="departureLong" autocomplete="false" type="text" value="{{cookie.getGarDepartureVoyage().departureLong}}"/>
+          <input class="govuk-input" id="departureLong" name="departureLong" autocomplete="off" type="text" value="{{cookie.getGarDepartureVoyage().departureLong}}"/>
 
         </div>
         <!-- End departure coords -->

--- a/src/app/garfile/manifest/addnewperson/index.njk
+++ b/src/app/garfile/manifest/addnewperson/index.njk
@@ -34,7 +34,7 @@
     Details should be as displayed on the travel document
   <p>
 
-  <form action="/garfile/manifest/addnewperson" autocomplete="false" class="form-group" method="post" role="form">
+  <form action="/garfile/manifest/addnewperson" autocomplete="off" class="form-group" method="post" role="form">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
     {% include "person-details.njk" %}
     <br>

--- a/src/app/garfile/manifest/addnewperson/index.njk
+++ b/src/app/garfile/manifest/addnewperson/index.njk
@@ -34,14 +34,14 @@
       Details should be as displayed on the travel document
     <p>
 
-  <form action="/garfile/manifest/addnewperson" autocomplete="false" class="form-group" method="post" role="form">
+  <form action="/garfile/manifest/addnewperson" autocomplete="off" class="form-group" method="post" role="form">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
         <div class="govuk-form-group {{ m.form_group_class('first_name', errors) }}">
           <label class="govuk-label govuk-label--m" for="first_name">Given name(s)</label>
            {{ m.error_message('first_name', errors) }}
           <input class="govuk-input" id="first_name" name="first_name"
-          autocomplete="false" type="text" value="{{personDetails.firstName}}" />
+          autocomplete="off" type="text" value="{{personDetails.firstName}}" />
         </div>
 
         <div class="govuk-form-group {{ m.form_group_class('dob', errors) }}">
@@ -104,7 +104,7 @@
     <div class="govuk-form-group {{ m.form_group_class('surname', errors) }}">
       <label class="govuk-label govuk-label--m" for="surname">Surname</label>
       {{ m.error_message('surname', errors) }}
-      <input class="govuk-input" id="surname" name="surname" autocomplete="false"
+      <input class="govuk-input" id="surname" name="surname" autocomplete="off"
       type="text" value="{{ personDetails.lastName }}" />
     </div>
 

--- a/src/app/garfile/manifest/editperson/index.njk
+++ b/src/app/garfile/manifest/editperson/index.njk
@@ -34,14 +34,14 @@
       Details should be as displayed on travel document
     <p>
 
-  <form action="/garfile/manifest/editperson" autocomplete="false" class="form-group" method="post" role="form" >
+  <form action="/garfile/manifest/editperson" autocomplete="off" class="form-group" method="post" role="form" >
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
         <div class="govuk-form-group {{ m.form_group_class('first_name', errors) }}">
           <label class="govuk-label govuk-label--m" for="first_name">Given Name(s)</label>
            {{ m.error_message('first_name', errors) }}
           <input class="govuk-input" id="first_name" name="first_name"
-          autocomplete="false" type="text" value="{{personDetails.firstName}}" />
+          autocomplete="off" type="text" value="{{personDetails.firstName}}" />
         </div>
 
         <div class="govuk-form-group {{ m.form_group_class('dob', errors) }}">
@@ -104,7 +104,7 @@
     <div class="govuk-form-group {{ m.form_group_class('surname', errors) }}">
       <label class="govuk-label govuk-label--m" for="surname">Surname</label>
       {{ m.error_message('surname', errors) }}
-      <input class="govuk-input" id="surname" name="surname" autocomplete="false"
+      <input class="govuk-input" id="surname" name="surname" autocomplete="off"
       type="text" value="{{ personDetails.lastName }}" />
     </div>
 

--- a/src/app/garfile/manifest/editperson/index.njk
+++ b/src/app/garfile/manifest/editperson/index.njk
@@ -34,7 +34,7 @@
       Details should be as displayed on the travel document
     <p>
 
-  <form action="/garfile/manifest/editperson" autocomplete="false" class="form-group" method="post" role="form" >
+  <form action="/garfile/manifest/editperson" autocomplete="off" class="form-group" method="post" role="form" >
     <input type="hidden" id="garPeopleId" name="garPeopleId" value="{{person.garPeopleId}}" />
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
     {% include "person-details.njk" %}

--- a/src/app/garfile/responsibleperson/index.njk
+++ b/src/app/garfile/responsibleperson/index.njk
@@ -27,7 +27,7 @@ Create GAR | Responsible person | Submit a General Aviation Report (GAR)
 
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-      <form action="/garfile/responsibleperson" autocomplete="false" class="form-group"
+      <form action="/garfile/responsibleperson" autocomplete="off" class="form-group"
       method="post" role="form">
       <span class="govuk-caption-xl">Section 5 of 8</span>
       <h1 class="govuk-heading-xl">Responsible person</h1>

--- a/src/app/organisation/assignrole/index.njk
+++ b/src/app/organisation/assignrole/index.njk
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
 	  <div class="govuk-grid-column-two-thirds">
 
-    <form action="/organisation/assignrole" autocomplete="false" class="form-group"
+    <form action="/organisation/assignrole" autocomplete="off" class="form-group"
       method="post" role="form" >
 
        <div class="form-group {{ m.form_group_class('invite', errors) }}">

--- a/src/app/organisation/create/index.njk
+++ b/src/app/organisation/create/index.njk
@@ -26,7 +26,7 @@
   <p class="govuk-body-l">Creating an organisation enables you to collaborate with other users on creating and submitting GARs.</p>
 	<p class="govuk-body-m">There is no restriction on who can create an organisation and you retain full control over which users belong to, and can submit GARs on behalf of, your organisation.</p>
 
-    <form action="/organisation/create" autocomplete="false" class="form-group"
+    <form action="/organisation/create" autocomplete="off" class="form-group"
       method="post" role="form" >
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/src/app/organisation/editorganisation/index.njk
+++ b/src/app/organisation/editorganisation/index.njk
@@ -39,7 +39,7 @@
 	  <div class="govuk-grid-column-two-thirds">
 
     <div>
-    <form action="/organisation/editorganisation" autocomplete="false" class="form-group"
+    <form action="/organisation/editorganisation" autocomplete="off" class="form-group"
       method="post" role="form">
 
       <h1 class="govuk-heading-xl">Edit organisation</h1>

--- a/src/app/organisation/editusers/index.njk
+++ b/src/app/organisation/editusers/index.njk
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
 	  <div class="govuk-grid-column-two-thirds">
 
-    <form action="/organisation/users/edit" autocomplete="false" class="form-group"
+    <form action="/organisation/users/edit" autocomplete="off" class="form-group"
       method="post" role="form">
 
       <h1 class="govuk-heading-xl">Edit an organisation user</h1>

--- a/src/app/organisation/inviteusers/index.njk
+++ b/src/app/organisation/inviteusers/index.njk
@@ -27,7 +27,7 @@
   {% endif %}
   <div class="govuk-grid-row">
 	  <div class="govuk-grid-column-two-thirds">
-    <form action="/organisation/inviteusers" autocomplete="false" class="form-group"
+    <form action="/organisation/inviteusers" autocomplete="off" class="form-group"
       method="post" role="form">
 
       <h1 class="govuk-heading-xl">Invite a user</h1>

--- a/src/app/people/add/index.njk
+++ b/src/app/people/add/index.njk
@@ -36,7 +36,7 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-    <form action="/people/add" autocomplete="false" class="form-group" method="post" role="form">
+    <form action="/people/add" autocomplete="off" class="form-group" method="post" role="form">
 
     <h1 class="govuk-heading-xl">
       Add a person

--- a/src/app/people/edit/index.njk
+++ b/src/app/people/edit/index.njk
@@ -36,7 +36,7 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-      <form action="/people/edit" autocomplete="false" class="form-group" method="post" role="form">
+      <form action="/people/edit" autocomplete="off" class="form-group" method="post" role="form">
 
       <h1 class="govuk-heading-xl">
         Edit a person

--- a/src/app/user/login/index.njk
+++ b/src/app/user/login/index.njk
@@ -27,7 +27,7 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-		<form action="login" method="POST">
+		<form action="login" autocomplete="off" method="POST">
 			<h1 class="govuk-heading-xl">Sign in</h1>
 			<div class="govuk-form-group {{ m.form_group_class('Username', errors) }}">
 

--- a/src/app/user/register/index.njk
+++ b/src/app/user/register/index.njk
@@ -26,7 +26,7 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-      <form action="/user/register" autocomplete="false" method="post" role="form">
+      <form action="/user/register" autocomplete="off" method="post" role="form">
         <h1 class="govuk-heading-xl">Create an account</h1>
 
          <div class="govuk-form-group {{ m.form_group_class('userFname', errors) }}">

--- a/src/common/templates/includes/person-details.njk
+++ b/src/common/templates/includes/person-details.njk
@@ -17,7 +17,7 @@
   <span class="govuk-hint">
     Provide the 3 letter country code, for example GBR
   </span>
-  <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="false" type="text" value="{{ person['nationality'] or req.body['nationality'] }}" />
+  <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="off" type="text" value="{{ person['nationality'] or req.body['nationality'] }}" />
 </div>
 
 <div class="govuk-form-group {{ m.form_group_class('birthplace', errors) }}">
@@ -173,7 +173,7 @@
   <span class="govuk-hint">
     Provide the 3 letter code for the issuing state, for example GBR
   </span>
-  <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="false" type="text" value="{{person['issuingState'] or req.body['issuing-state']}}" />
+  <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="off" type="text" value="{{person['issuingState'] or req.body['issuing-state']}}" />
 </div>
 
   <div class="govuk-form-group {{ m.form_group_class('travel-document-type', errors) }}">

--- a/src/common/templates/includes/person-details.njk
+++ b/src/common/templates/includes/person-details.njk
@@ -2,25 +2,25 @@
 <div class="govuk-form-group {{ m.form_group_class('first-name', errors) }}">
   <label class="govuk-label govuk-label--m" for="first-name">Given name(s)</label>
     {{ m.error_message('first-name', errors) }}
-  <input class="govuk-input" id="first-name" name="first-name" autocomplete="false" type="text" value="{{person['firstName'] or req.body['first-name']}}" />
+  <input class="govuk-input" id="first-name" name="first-name" autocomplete="off" type="text" value="{{person['firstName'] or req.body['first-name']}}" />
 </div>
 
 <div class="govuk-form-group {{ m.form_group_class('last-name', errors) }}">
   <label class="govuk-label govuk-label--m" for="last-name">Surname</label>
   {{ m.error_message('last-name', errors) }}
-  <input class="govuk-input" id="last-name" name="last-name" autocomplete="false" type="text" value="{{ person['lastName'] or req.body['last-name'] }}" />
+  <input class="govuk-input" id="last-name" name="last-name" autocomplete="off" type="text" value="{{ person['lastName'] or req.body['last-name'] }}" />
 </div>
 
 <div class="govuk-form-group {{ m.form_group_class('nationality', errors) }}">
   <label class="govuk-label govuk-label--m" for="nationality">Nationality</label>
   {{ m.error_message('nationality', errors) }}
-  <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="false" type="text" value="{{ person['nationality'] or req.body['nationality'] }}" />
+  <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="off" type="text" value="{{ person['nationality'] or req.body['nationality'] }}" />
 </div>
 
 <div class="govuk-form-group {{ m.form_group_class('birthplace', errors) }}">
   <label class="govuk-label govuk-label--m" for="birthplace">Place of birth</label>
   {{ m.error_message('birthplace', errors) }}
-  <input class="govuk-input" id="birthplace" name="birthplace" autocomplete="false" type="text" value="{{ person['placeOfBirth'] or req.body['birthplace'] }}" />
+  <input class="govuk-input" id="birthplace" name="birthplace" autocomplete="off" type="text" value="{{ person['placeOfBirth'] or req.body['birthplace'] }}" />
   </div>
 
   <!–– Date of birth -->
@@ -158,7 +158,7 @@
 <div class="govuk-form-group {{ m.form_group_class('issuing-state', errors) }}">
   <label class="govuk-label govuk-label--m" for="issuing-state">Issuing state</label>
   {{ m.error_message('issuing-state', errors) }}
-  <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="false" type="text" value="{{person['issuingState'] or req.body['issuing-state']}}" />
+  <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="off" type="text" value="{{person['issuingState'] or req.body['issuing-state']}}" />
 </div>
 
   <div class="govuk-form-group {{ m.form_group_class('travel-document-type', errors) }}">


### PR DESCRIPTION
**What changes does this PR bring?**
Essentially sets the "false" property for "autocomplete" to "off". This is in line with standards, but opens a whole kettle of fish regarding browsers and how they handle autocomplete/autofill in general, where the use of "false" was a happy coincidence within Chrome, which simply disabled it as long as it was not "on" or "off".

There are suggestions on line regarding the use of other properties like "new-password" which may be another possible avenue, and so this pull request might be the start of a series.

Alternative extremes are munging input field names and/or URLs in order to "trick" the browser into believing it is a different page, which comes at an obvious cost of potential redesign.

This is locally tested on Chrome and Safari.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
