### PR TITLE
EGAR-588 nationality autocomplete

### DIFF
--- a/src/app/aircraft/add/post.controller.js
+++ b/src/app/aircraft/add/post.controller.js
@@ -15,7 +15,7 @@ module.exports = (req, res) => {
 
   // Define a validation chain for user registeration fields
   const craftRegChain = [
-    new ValidationRule(validator.notEmpty, 'craftreg', craftReg, 'Enter the registration deatils of the craft'),
+    new ValidationRule(validator.notEmpty, 'craftreg', craftReg, 'Enter the registration details of the craft'),
   ];
   const craftTypeChain = [
     new ValidationRule(validator.notEmpty, 'crafttype', craftType, 'Enter the craft type'),
@@ -41,7 +41,7 @@ module.exports = (req, res) => {
     })
     .catch((err) => {
       logger.info('Edit SavedCraft postcontroller - There was a problem with editing the saved craft');
-      logger.info(err);
+      logger.info(JSON.stringify(err));
       res.render('app/aircraft/add/index', { cookie, errors: err });
     });
 };

--- a/src/app/aircraft/add/post.controller.js
+++ b/src/app/aircraft/add/post.controller.js
@@ -13,7 +13,6 @@ module.exports = (req, res) => {
   const craftType = req.body.crafttype;
   const craftBase = _.toUpper(req.body.craftbase);
 
-
   // Define a validation chain for user registeration fields
   const craftRegChain = [
     new ValidationRule(validator.notEmpty, 'craftreg', craftReg, 'Enter the registration deatils of the craft'),

--- a/src/app/aircraft/get.controller.js
+++ b/src/app/aircraft/get.controller.js
@@ -1,4 +1,3 @@
-
 const CookieModel = require('../../common/models/Cookie.class');
 const logger = require('../../common/utils/logger')(__filename);
 const craftApi = require('../../common/services/craftApi');

--- a/src/app/aircraft/post.controller.js
+++ b/src/app/aircraft/post.controller.js
@@ -5,11 +5,11 @@ module.exports = (req, res) => {
   logger.debug('In user aircraft post controller');
   if (req.body.editCraft) {
     req.session.editCraftId = req.body.editCraft;
-    req.session.save(() => { res.redirect('/aircraft/edit'); });
+    req.session.save(() => res.redirect('/aircraft/edit'));
     return;
   }
   if (req.body.deleteCraft) {
     req.session.deleteCraftId = req.body.deleteCraft;
-    req.session.save(() => { res.redirect('/aircraft/delete'); });
+    req.session.save(() => res.redirect('/aircraft/delete'));
   }
 };

--- a/src/app/garfile/arrival/post.controller.js
+++ b/src/app/garfile/arrival/post.controller.js
@@ -131,7 +131,7 @@ module.exports = async (req, res) => {
     })
     .catch((err) => {
       logger.info('Validation failed');
-      logger.info(err);
+      logger.info(JSON.stringify(err));
       res.render('app/garfile/arrival/index', {
         cookie,
         errors: err,

--- a/src/app/garfile/departure/index.njk
+++ b/src/app/garfile/departure/index.njk
@@ -198,11 +198,11 @@
 </div>
 
 <script type="text/javascript" src="/javascripts/accessible-autocomplete.min.js"></script>
-<!-- <script type="text/javascript">
+{# <script type="text/javascript">
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#test'),
     minLength: 3,
   });
-</script> -->
+</script> #}
 
 {% endblock %}

--- a/src/app/garfile/departure/post.controller.js
+++ b/src/app/garfile/departure/post.controller.js
@@ -129,7 +129,7 @@ module.exports = async (req, res) => {
     })
     .catch((err) => {
       logger.info('Validation failed');
-      logger.info(err);
+      logger.info(JSON.stringify(err));
       res.render('app/garfile/departure/index', { cookie, errors: err });
     });
 };

--- a/src/app/user/login/post.controller.js
+++ b/src/app/user/login/post.controller.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const logger = require('../../../common/utils/logger')(__filename);
 const ValidationRule = require('../../../common/models/ValidationRule.class');
 const validator = require('../../../common/utils/validator');
@@ -12,7 +13,7 @@ const config = require('../../../common/config/index');
 module.exports = (req, res) => {
   logger.debug('In user / login post controller');
 
-  const usrname = req.body.Username;
+  const usrname = _.toLower(req.body.Username);
 
   // Start by clearing cookies and initialising
   const cookie = new CookieModel(req);

--- a/src/app/user/manageuserdetail/post.controller.js
+++ b/src/app/user/manageuserdetail/post.controller.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
     new ValidationRule(validator.notEmpty, 'firstname', firstName, 'Enter your given name'),
   ];
   const lnameChain = [
-    new ValidationRule(validator.notEmpty, 'lastname', lastName, 'Enter your surname name'),
+    new ValidationRule(validator.notEmpty, 'lastname', lastName, 'Enter your surname'),
   ];
 
   validator.validateChains([firstNameChain, lnameChain])
@@ -41,7 +41,7 @@ module.exports = (req, res) => {
     })
     .catch((err) => {
       logger.error('Validation failed');
-      logger.error(err);
+      logger.error(JSON.stringify(err));
       res.render('app/user/manageuserdetail/index', { cookie, errors: err });
     });
 };

--- a/src/app/verify/get.controller.js
+++ b/src/app/verify/get.controller.js
@@ -29,11 +29,14 @@ module.exports = async (req, res) => {
       const alphabet = '23456789abcdefghjkmnpqrstuvwxyz-';
       const alphabetToken = nanoid(alphabet, 13);
       const hashtoken = tokenService.generateHash(alphabetToken);
+      // TODO: A Promise.all should wrap these two asynchronous calls to ensure
+      // both the new token and email are sent otherwise users will not know if
+      // an issue has arisen
       tokenApi.updateToken(hashtoken, parsedResponse.userId);
       sendTokenService.send(
         parsedResponse.firstName,
         parsedResponse.email,
-        token,
+        alphabetToken,
       );
       message = i18n.__('verify_user_account_token_expired');
     }
@@ -42,6 +45,7 @@ module.exports = async (req, res) => {
     }
     return res.render('app/verify/registeruser/index', { message });
   } catch (err) {
+    logger.error('Error during user verification');
     logger.error(err);
     return res.render('app/verify/registeruser/index');
   }

--- a/src/app/verify/mfa/get.controller.js
+++ b/src/app/verify/mfa/get.controller.js
@@ -10,25 +10,27 @@ module.exports = (req, res) => {
   const cookie = new CookieModel(req);
   const mfaTokenLength = settings.MFA_TOKEN_LENGTH;
   const errMsg = { message: 'There was a problem creating your code. Try again' };
-  const context = { cookie, mfaTokenLength, successHeader: 'We have resent your code', successMsg: 'Check your email' };
+  const context = {
+    cookie, mfaTokenLength, successHeader: 'We have resent your code', successMsg: 'Check your email',
+  };
 
-  if (req.query.resend === 'true') {
-    if (cookie.getUserVerified()) {
-      const mfaToken = token.genMfaToken();
-      const email = cookie.getUserEmail();
-      tokenApi.setMfaToken(email, mfaToken, true)
-        .then(() => {
-          emailService.send(settings.NOTIFY_MFA_TEMPLATE_ID, email, { mfaToken });
-          return res.render('app/verify/mfa/index', context);
-        })
-        .catch((err) => {
-          logger.error(err);
-          return res.render('app/verify/mfa/index', { cookie, mfaTokenLength, errors: [errMsg] });
-        });
-    } else {
-      return res.render('app/verify/mfa/index', context);
-    }
+  if (req.query.resend !== 'true') {
+    res.render('app/verify/mfa/index', { cookie, mfaTokenLength });
+    return;
+  }
+  if (cookie.getUserVerified()) {
+    const mfaToken = token.genMfaToken();
+    const email = cookie.getUserEmail();
+    tokenApi.setMfaToken(email, mfaToken, true)
+      .then(() => {
+        emailService.send(settings.NOTIFY_MFA_TEMPLATE_ID, email, { mfaToken });
+        res.render('app/verify/mfa/index', context);
+      })
+      .catch((err) => {
+        logger.error(err);
+        res.render('app/verify/mfa/index', { cookie, mfaTokenLength, errors: [errMsg] });
+      });
   } else {
-    return res.render('app/verify/mfa/index', { cookie, mfaTokenLength });
+    res.render('app/verify/mfa/index', context);
   }
 };

--- a/src/app/verify/mfa/index.js
+++ b/src/app/verify/mfa/index.js
@@ -3,14 +3,12 @@ const express = require('express');
 
 // Middleware
 const flagpole = require('../../../common/middleware/flagpole');
-const csrfcheck = require('../../../common/middleware/csrfcheck')
+const csrfcheck = require('../../../common/middleware/csrfcheck');
 const parseForm = require('../../../common/middleware/parseForm');
-
 
 // Local dependencies
 const getController = require('./get.controller');
 const postController = require('./post.controller');
-
 
 // Initialisation
 const router = new express.Router();
@@ -20,11 +18,8 @@ const paths = {
 };
 
 // Routing
-router.get(paths.index, flagpole,  csrfcheck, getController);
-router.post(paths.index, flagpole,parseForm, csrfcheck, postController);
+router.get(paths.index, flagpole, csrfcheck, getController);
+router.post(paths.index, flagpole, parseForm, csrfcheck, postController);
 
 // Export
-module.exports = {
-  router,
-  paths,
-};
+module.exports = { router, paths };

--- a/src/app/verify/mfa/post.controller.js
+++ b/src/app/verify/mfa/post.controller.js
@@ -8,7 +8,6 @@ const settings = require('../../../common/config/index');
 
 module.exports = (req, res) => {
   logger.debug('In verify / mfa post controller');
-
   const token = req.body['mfa-authentication-code'];
 
   const mfaCodeChain = [
@@ -18,10 +17,12 @@ module.exports = (req, res) => {
   const cookie = new CookieModel(req);
 
   const mfaTokenLength = settings.MFA_TOKEN_LENGTH;
-
   const errMsg = { message: 'There was a problem verifying your token. Try again' };
+
   validator.validateChains([mfaCodeChain])
     .then(() => {
+      // TODO: validateMfaToken never resolves to false, so this if statement is
+      // redundant (let the catch blocks handle rejects)
       tokenApi.validateMfaToken(cookie.getUserEmail(), parseInt(token, 10))
         .then((valid) => {
           if (valid) {
@@ -45,13 +46,13 @@ module.exports = (req, res) => {
           }
         })
         .catch((err) => {
-          // Validation error
-          logger.info(err);
+          // Token API error
+          logger.error(err);
           res.render('app/verify/mfa/index', { cookie, mfaTokenLength, errors: [errMsg] });
         });
     }).catch((err) => {
-      // Validation error
-      logger.info(err);
+      // Page validation error
+      logger.info(JSON.stringify(err));
       res.render('app/verify/mfa/index', { cookie, mfaTokenLength, errors: err });
     });
 };

--- a/src/common/templates/includes/person-details.njk
+++ b/src/common/templates/includes/person-details.njk
@@ -17,13 +17,13 @@
   <span class="govuk-hint">
     {{ __('field_nationality_hint') }}
   </span>
-  <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="off" type="text" value="{{ (person['nationality'] or req.body['nationality']) | upper}}" />
-  {# <select class="govuk-select" id="nationality" name="nationality" value="{{ (person['nationality'] or req.body['nationality'])}}">
+  {# <input class="govuk-input" id="nationality"  maxlength="3" name="nationality" autocomplete="off" type="text" value="{{ (person['nationality'] or req.body['nationality']) | upper}}" /> #}
+  <select class="govuk-select" id="nationality" name="nationality" value="{{ (person['nationality'] or req.body['nationality'])}}">
     <option value="">{{ __('country_no_selection') }}</option>
     {% for country in countryList|sort(attribute='label') %}
       <option value="{{ country.code }}" {{ 'selected=selected' if (person['nationality'] or req.body['nationality']) == country.code }}>{{ country.label }}</option>
     {% endfor %}
-  </select> #}
+  </select>
 </div>
 
   <div class="govuk-form-group {{ m.form_group_class('birthplace', errors) }}">
@@ -151,13 +151,13 @@
   <label class="govuk-label govuk-label--m" for="issuing-state">{{ __('field_issuing_state') }}</label>
   {{ m.error_message('issuing-state', errors) }}
   <span class="govuk-hint">{{ __('field_issuing_state_hint') }}</span>
-  <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="off" type="text" value="{{(person['issuingState'] or req.body['issuing-state']) | upper}}" />
-  {# <select class="govuk-select" id="issuing-state" name="issuing-state" value="{{ (person['issuingState'] or req.body['issuing-state'])}}">
+  {# <input class="govuk-input" id="issuing-state" maxlength="3" name="issuing-state" autocomplete="off" type="text" value="{{(person['issuingState'] or req.body['issuing-state']) | upper}}" /> #}
+  <select class="govuk-select" id="issuing-state" name="issuing-state" value="{{ (person['issuingState'] or req.body['issuing-state'])}}">
     <option value="">{{ __('country_no_selection') }}</option>
     {% for country in countryList|sort(attribute='label') %}
       <option value="{{ country.code }}" {{ 'selected=selected' if (person['issuingState'] or req.body['issuing-state']) == country.code }}>{{ country.label }}</option>
     {% endfor %}
-  </select> #}
+  </select>
 </div>
 
   <div class="govuk-form-group {{ m.form_group_class('travel-document-type', errors) }}">
@@ -175,7 +175,7 @@
     </select>
   </div>
 
-<!-- <script type="text/javascript" src="/javascripts/accessible-autocomplete.min.js"></script>
+<script type="text/javascript" src="/javascripts/accessible-autocomplete.min.js"></script>
 <script type="text/javascript">
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#nationality')
@@ -183,4 +183,4 @@
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#issuing-state')
   });
-</script> -->
+</script>

--- a/src/common/utils/airport_codes_v2.json
+++ b/src/common/utils/airport_codes_v2.json
@@ -1,0 +1,38487 @@
+[
+  {
+    "id": "MAG",
+    "british": false,
+    "label": "Madang Airport (Papua New Guinea) (AYMD / MAG)"
+  },
+  {
+    "id": "HGU",
+    "british": false,
+    "label": "Mount Hagen Kagamuga Airport (Papua New Guinea) (AYMH / HGU)"
+  },
+  {
+    "id": "LAE",
+    "british": false,
+    "label": "Nadzab Airport (Papua New Guinea) (AYNZ / LAE)"
+  },
+  {
+    "id": "POM",
+    "british": false,
+    "label": "Port Moresby Jacksons International Airport (Papua New Guinea) (AYPY / POM)"
+  },
+  {
+    "id": "WWK",
+    "british": false,
+    "label": "Wewak International Airport (Papua New Guinea) (AYWK / WWK)"
+  },
+  {
+    "id": "UAK",
+    "british": false,
+    "label": "Narsarsuaq Airport (Greenland) (BGBW / UAK)"
+  },
+  {
+    "id": "GOH",
+    "british": false,
+    "label": "Godthaab / Nuuk Airport (Greenland) (BGGH / GOH)"
+  },
+  {
+    "id": "SFJ",
+    "british": false,
+    "label": "Kangerlussuaq Airport (Greenland) (BGSF / SFJ)"
+  },
+  {
+    "id": "THU",
+    "british": false,
+    "label": "Thule Air Base (Greenland) (BGTL / THU)"
+  },
+  {
+    "id": "AEY",
+    "british": false,
+    "label": "Akureyri Airport (Iceland) (BIAR / AEY)"
+  },
+  {
+    "id": "EGS",
+    "british": false,
+    "label": "Egilsstaðir Airport (Iceland) (BIEG / EGS)"
+  },
+  {
+    "id": "HFN",
+    "british": false,
+    "label": "Hornafjörður Airport (Iceland) (BIHN / HFN)"
+  },
+  {
+    "id": "HZK",
+    "british": false,
+    "label": "Húsavík Airport (Iceland) (BIHU / HZK)"
+  },
+  {
+    "id": "IFJ",
+    "british": false,
+    "label": "Ísafjörður Airport (Iceland) (BIIS / IFJ)"
+  },
+  {
+    "id": "KEF",
+    "british": false,
+    "label": "Keflavik International Airport (Iceland) (BIKF / KEF)"
+  },
+  {
+    "id": "PFJ",
+    "british": false,
+    "label": "Patreksfjörður Airport (Iceland) (BIPA / PFJ)"
+  },
+  {
+    "id": "RKV",
+    "british": false,
+    "label": "Reykjavik Airport (Iceland) (BIRK / RKV)"
+  },
+  {
+    "id": "SIJ",
+    "british": false,
+    "label": "Siglufjörður Airport (Iceland) (BISI / SIJ)"
+  },
+  {
+    "id": "VEY",
+    "british": false,
+    "label": "Vestmannaeyjar Airport (Iceland) (BIVM / VEY)"
+  },
+  {
+    "id": "YAM",
+    "british": false,
+    "label": "Sault Ste Marie Airport (Canada) (CYAM / YAM)"
+  },
+  {
+    "id": "CYAV",
+    "british": false,
+    "label": "Winnipeg / St. Andrews Airport (Canada) (CYAV)"
+  },
+  {
+    "id": "CYAW",
+    "british": false,
+    "label": "Halifax / CFB Shearwater Heliport (Canada) (CYAW)"
+  },
+  {
+    "id": "YAY",
+    "british": false,
+    "label": "St. Anthony Airport (Canada) (CYAY / YAY)"
+  },
+  {
+    "id": "YAZ",
+    "british": false,
+    "label": "Tofino / Long Beach Airport (Canada) (CYAZ / YAZ)"
+  },
+  {
+    "id": "YBB",
+    "british": false,
+    "label": "Kugaaruk Airport (Canada) (CYBB / YBB)"
+  },
+  {
+    "id": "YBC",
+    "british": false,
+    "label": "Baie Comeau Airport (Canada) (CYBC / YBC)"
+  },
+  {
+    "id": "YBG",
+    "british": false,
+    "label": "CFB Bagotville (Canada) (CYBG / YBG)"
+  },
+  {
+    "id": "YBK",
+    "british": false,
+    "label": "Baker Lake Airport (Canada) (CYBK / YBK)"
+  },
+  {
+    "id": "YBL",
+    "british": false,
+    "label": "Campbell River Airport (Canada) (CYBL / YBL)"
+  },
+  {
+    "id": "YBR",
+    "british": false,
+    "label": "Brandon Municipal Airport (Canada) (CYBR / YBR)"
+  },
+  {
+    "id": "YCB",
+    "british": false,
+    "label": "Cambridge Bay Airport (Canada) (CYCB / YCB)"
+  },
+  {
+    "id": "YCD",
+    "british": false,
+    "label": "Nanaimo Airport (Canada) (CYCD / YCD)"
+  },
+  {
+    "id": "YCG",
+    "british": false,
+    "label": "Castlegar/West Kootenay Regional Airport (Canada) (CYCG / YCG)"
+  },
+  {
+    "id": "YCH",
+    "british": false,
+    "label": "Miramichi Airport (Canada) (CYCH / YCH)"
+  },
+  {
+    "id": "YCL",
+    "british": false,
+    "label": "Charlo Airport (Canada) (CYCL / YCL)"
+  },
+  {
+    "id": "YCO",
+    "british": false,
+    "label": "Kugluktuk Airport (Canada) (CYCO / YCO)"
+  },
+  {
+    "id": "YCT",
+    "british": false,
+    "label": "Coronation Airport (Canada) (CYCT / YCT)"
+  },
+  {
+    "id": "YCW",
+    "british": false,
+    "label": "Chilliwack Airport (Canada) (CYCW / YCW)"
+  },
+  {
+    "id": "YCY",
+    "british": false,
+    "label": "Clyde River Airport (Canada) (CYCY / YCY)"
+  },
+  {
+    "id": "YZS",
+    "british": false,
+    "label": "Coral Harbour Airport (Canada) (CYZS / YZS)"
+  },
+  {
+    "id": "YDA",
+    "british": false,
+    "label": "Dawson City Airport (Canada) (CYDA / YDA)"
+  },
+  {
+    "id": "YDB",
+    "british": false,
+    "label": "Burwash Airport (Canada) (CYDB / YDB)"
+  },
+  {
+    "id": "CYDC",
+    "british": false,
+    "label": "Princeton Airport (Canada) (CYDC)"
+  },
+  {
+    "id": "YDF",
+    "british": false,
+    "label": "Deer Lake Airport (Canada) (CYDF / YDF)"
+  },
+  {
+    "id": "YDL",
+    "british": false,
+    "label": "Dease Lake Airport (Canada) (CYDL / YDL)"
+  },
+  {
+    "id": "YDN",
+    "british": false,
+    "label": "Dauphin Barker Airport (Canada) (CYDN / YDN)"
+  },
+  {
+    "id": "YDQ",
+    "british": false,
+    "label": "Dawson Creek Airport (Canada) (CYDQ / YDQ)"
+  },
+  {
+    "id": "YEG",
+    "british": false,
+    "label": "Edmonton International Airport (Canada) (CYEG / YEG)"
+  },
+  {
+    "id": "YEK",
+    "british": false,
+    "label": "Arviat Airport (Canada) (CYEK / YEK)"
+  },
+  {
+    "id": "YEN",
+    "british": false,
+    "label": "Estevan Airport (Canada) (CYEN / YEN)"
+  },
+  {
+    "id": "YET",
+    "british": false,
+    "label": "Edson Airport (Canada) (CYET / YET)"
+  },
+  {
+    "id": "YEU",
+    "british": false,
+    "label": "Eureka Airport (Canada) (CYEU / YEU)"
+  },
+  {
+    "id": "YEV",
+    "british": false,
+    "label": "Inuvik Mike Zubko Airport (Canada) (CYEV / YEV)"
+  },
+  {
+    "id": "YFB",
+    "british": false,
+    "label": "Iqaluit Airport (Canada) (CYFB / YFB)"
+  },
+  {
+    "id": "YFC",
+    "british": false,
+    "label": "Fredericton Airport (Canada) (CYFC / YFC)"
+  },
+  {
+    "id": "YFE",
+    "british": false,
+    "label": "Forestville Airport (Canada) (CYFE / YFE)"
+  },
+  {
+    "id": "YFO",
+    "british": false,
+    "label": "Flin Flon Airport (Canada) (CYFO / YFO)"
+  },
+  {
+    "id": "YFR",
+    "british": false,
+    "label": "Fort Resolution Airport (Canada) (CYFR / YFR)"
+  },
+  {
+    "id": "YFS",
+    "british": false,
+    "label": "Fort Simpson Airport (Canada) (CYFS / YFS)"
+  },
+  {
+    "id": "YGK",
+    "british": false,
+    "label": "Kingston Norman Rogers Airport (Canada) (CYGK / YGK)"
+  },
+  {
+    "id": "YGL",
+    "british": false,
+    "label": "La Grande Rivière Airport (Canada) (CYGL / YGL)"
+  },
+  {
+    "id": "YGP",
+    "british": false,
+    "label": "Gaspé (Michel-Pouliot) Airport (Canada) (CYGP / YGP)"
+  },
+  {
+    "id": "YGQ",
+    "british": false,
+    "label": "Geraldton Greenstone Regional Airport (Canada) (CYGQ / YGQ)"
+  },
+  {
+    "id": "YGR",
+    "british": false,
+    "label": "Îles-de-la-Madeleine Airport (Canada) (CYGR / YGR)"
+  },
+  {
+    "id": "YHB",
+    "british": false,
+    "label": "Hudson Bay Airport (Canada) (CYHB / YHB)"
+  },
+  {
+    "id": "YHD",
+    "british": false,
+    "label": "Dryden Regional Airport (Canada) (CYHD / YHD)"
+  },
+  {
+    "id": "YHI",
+    "british": false,
+    "label": "Ulukhaktok Holman Airport (Canada) (CYHI / YHI)"
+  },
+  {
+    "id": "YHK",
+    "british": false,
+    "label": "Gjoa Haven Airport (Canada) (CYHK / YHK)"
+  },
+  {
+    "id": "YHM",
+    "british": false,
+    "label": "John C. Munro Hamilton International Airport (Canada) (CYHM / YHM)"
+  },
+  {
+    "id": "YHU",
+    "british": false,
+    "label": "Montréal / Saint-Hubert Airport (Canada) (CYHU / YHU)"
+  },
+  {
+    "id": "YHY",
+    "british": false,
+    "label": "Hay River / Merlyn Carter Airport (Canada) (CYHY / YHY)"
+  },
+  {
+    "id": "YHZ",
+    "british": false,
+    "label": "Halifax / Stanfield International Airport (Canada) (CYHZ / YHZ)"
+  },
+  {
+    "id": "YIB",
+    "british": false,
+    "label": "Atikokan Municipal Airport (Canada) (CYIB / YIB)"
+  },
+  {
+    "id": "YIO",
+    "british": false,
+    "label": "Pond Inlet Airport (Canada) (CYIO / YIO)"
+  },
+  {
+    "id": "YJN",
+    "british": false,
+    "label": "St Jean Airport (Canada) (CYJN / YJN)"
+  },
+  {
+    "id": "YJT",
+    "british": false,
+    "label": "Stephenville Airport (Canada) (CYJT / YJT)"
+  },
+  {
+    "id": "YKA",
+    "british": false,
+    "label": "Kamloops Airport (Canada) (CYKA / YKA)"
+  },
+  {
+    "id": "YKF",
+    "british": false,
+    "label": "Waterloo Airport (Canada) (CYKF / YKF)"
+  },
+  {
+    "id": "YKL",
+    "british": false,
+    "label": "Schefferville Airport (Canada) (CYKL / YKL)"
+  },
+  {
+    "id": "YKY",
+    "british": false,
+    "label": "Kindersley Airport (Canada) (CYKY / YKY)"
+  },
+  {
+    "id": "YKZ",
+    "british": false,
+    "label": "Buttonville Municipal Airport (Canada) (CYKZ / YKZ)"
+  },
+  {
+    "id": "YLD",
+    "british": false,
+    "label": "Chapleau Airport (Canada) (CYLD / YLD)"
+  },
+  {
+    "id": "YLJ",
+    "british": false,
+    "label": "Meadow Lake Airport (Canada) (CYLJ / YLJ)"
+  },
+  {
+    "id": "YLL",
+    "british": false,
+    "label": "Lloydminster Airport (Canada) (CYLL / YLL)"
+  },
+  {
+    "id": "YLT",
+    "british": false,
+    "label": "Alert Airport (Canada) (CYLT / YLT)"
+  },
+  {
+    "id": "YLW",
+    "british": false,
+    "label": "Kelowna International Airport (Canada) (CYLW / YLW)"
+  },
+  {
+    "id": "YMA",
+    "british": false,
+    "label": "Mayo Airport (Canada) (CYMA / YMA)"
+  },
+  {
+    "id": "YMJ",
+    "british": false,
+    "label": "Moose Jaw Air Vice Marshal C. M. McEwen Airport (Canada) (CYMJ / YMJ)"
+  },
+  {
+    "id": "YMM",
+    "british": false,
+    "label": "Fort McMurray Airport (Canada) (CYMM / YMM)"
+  },
+  {
+    "id": "YMO",
+    "british": false,
+    "label": "Moosonee Airport (Canada) (CYMO / YMO)"
+  },
+  {
+    "id": "YMW",
+    "british": false,
+    "label": "Maniwaki Airport (Canada) (CYMW / YMW)"
+  },
+  {
+    "id": "YMX",
+    "british": false,
+    "label": "Montreal International (Mirabel) Airport (Canada) (CYMX / YMX)"
+  },
+  {
+    "id": "YNA",
+    "british": false,
+    "label": "Natashquan Airport (Canada) (CYNA / YNA)"
+  },
+  {
+    "id": "YND",
+    "british": false,
+    "label": "Ottawa / Gatineau Airport (Canada) (CYND / YND)"
+  },
+  {
+    "id": "YNM",
+    "british": false,
+    "label": "Matagami Airport (Canada) (CYNM / YNM)"
+  },
+  {
+    "id": "YOC",
+    "british": false,
+    "label": "Old Crow Airport (Canada) (CYOC / YOC)"
+  },
+  {
+    "id": "YOD",
+    "british": false,
+    "label": "CFB Cold Lake (Canada) (CYOD / YOD)"
+  },
+  {
+    "id": "YOJ",
+    "british": false,
+    "label": "High Level Airport (Canada) (CYOJ / YOJ)"
+  },
+  {
+    "id": "YOW",
+    "british": false,
+    "label": "Ottawa Macdonald-Cartier International Airport (Canada) (CYOW / YOW)"
+  },
+  {
+    "id": "YPA",
+    "british": false,
+    "label": "Prince Albert Glass Field (Canada) (CYPA / YPA)"
+  },
+  {
+    "id": "YPE",
+    "british": false,
+    "label": "Peace River Airport (Canada) (CYPE / YPE)"
+  },
+  {
+    "id": "YPG",
+    "british": false,
+    "label": "Southport Airport (Canada) (CYPG / YPG)"
+  },
+  {
+    "id": "CYPK",
+    "british": false,
+    "label": "Pitt Meadows Airport (Canada) (CYPK)"
+  },
+  {
+    "id": "YPL",
+    "british": false,
+    "label": "Pickle Lake Airport (Canada) (CYPL / YPL)"
+  },
+  {
+    "id": "YPN",
+    "british": false,
+    "label": "Port Menier Airport (Canada) (CYPN / YPN)"
+  },
+  {
+    "id": "YPQ",
+    "british": false,
+    "label": "Peterborough Airport (Canada) (CYPQ / YPQ)"
+  },
+  {
+    "id": "YPR",
+    "british": false,
+    "label": "Prince Rupert Airport (Canada) (CYPR / YPR)"
+  },
+  {
+    "id": "YPY",
+    "british": false,
+    "label": "Fort Chipewyan Airport (Canada) (CYPY / YPY)"
+  },
+  {
+    "id": "YQA",
+    "british": false,
+    "label": "Muskoka Airport (Canada) (CYQA / YQA)"
+  },
+  {
+    "id": "YQB",
+    "british": false,
+    "label": "Quebec Jean Lesage International Airport (Canada) (CYQB / YQB)"
+  },
+  {
+    "id": "YQF",
+    "british": false,
+    "label": "Red Deer Regional Airport (Canada) (CYQF / YQF)"
+  },
+  {
+    "id": "YQG",
+    "british": false,
+    "label": "Windsor Airport (Canada) (CYQG / YQG)"
+  },
+  {
+    "id": "YQH",
+    "british": false,
+    "label": "Watson Lake Airport (Canada) (CYQH / YQH)"
+  },
+  {
+    "id": "YQK",
+    "british": false,
+    "label": "Kenora Airport (Canada) (CYQK / YQK)"
+  },
+  {
+    "id": "YQL",
+    "british": false,
+    "label": "Lethbridge County Airport (Canada) (CYQL / YQL)"
+  },
+  {
+    "id": "YQM",
+    "british": false,
+    "label": "Greater Moncton International Airport (Canada) (CYQM / YQM)"
+  },
+  {
+    "id": "YQQ",
+    "british": false,
+    "label": "Comox Airport (Canada) (CYQQ / YQQ)"
+  },
+  {
+    "id": "YQR",
+    "british": false,
+    "label": "Regina International Airport (Canada) (CYQR / YQR)"
+  },
+  {
+    "id": "YQT",
+    "british": false,
+    "label": "Thunder Bay Airport (Canada) (CYQT / YQT)"
+  },
+  {
+    "id": "YQU",
+    "british": false,
+    "label": "Grande Prairie Airport (Canada) (CYQU / YQU)"
+  },
+  {
+    "id": "YQV",
+    "british": false,
+    "label": "Yorkton Municipal Airport (Canada) (CYQV / YQV)"
+  },
+  {
+    "id": "YQW",
+    "british": false,
+    "label": "North Battleford Airport (Canada) (CYQW / YQW)"
+  },
+  {
+    "id": "YQX",
+    "british": false,
+    "label": "Gander International Airport (Canada) (CYQX / YQX)"
+  },
+  {
+    "id": "YQY",
+    "british": false,
+    "label": "Sydney / J.A. Douglas McCurdy Airport (Canada) (CYQY / YQY)"
+  },
+  {
+    "id": "YQZ",
+    "british": false,
+    "label": "Quesnel Airport (Canada) (CYQZ / YQZ)"
+  },
+  {
+    "id": "YRB",
+    "british": false,
+    "label": "Resolute Bay Airport (Canada) (CYRB / YRB)"
+  },
+  {
+    "id": "YRI",
+    "british": false,
+    "label": "Rivière-du-Loup Airport (Canada) (CYRI / YRI)"
+  },
+  {
+    "id": "YRJ",
+    "british": false,
+    "label": "Roberval Airport (Canada) (CYRJ / YRJ)"
+  },
+  {
+    "id": "YRM",
+    "british": false,
+    "label": "Rocky Mountain House Airport (Canada) (CYRM / YRM)"
+  },
+  {
+    "id": "YRT",
+    "british": false,
+    "label": "Rankin Inlet Airport (Canada) (CYRT / YRT)"
+  },
+  {
+    "id": "YSB",
+    "british": false,
+    "label": "Sudbury Airport (Canada) (CYSB / YSB)"
+  },
+  {
+    "id": "YSC",
+    "british": false,
+    "label": "Sherbrooke Airport (Canada) (CYSC / YSC)"
+  },
+  {
+    "id": "YSJ",
+    "british": false,
+    "label": "Saint John Airport (Canada) (CYSJ / YSJ)"
+  },
+  {
+    "id": "YSM",
+    "british": false,
+    "label": "Fort Smith Airport (Canada) (CYSM / YSM)"
+  },
+  {
+    "id": "YSR",
+    "british": false,
+    "label": "Nanisivik Airport (Canada) (CYSR / YSR)"
+  },
+  {
+    "id": "YSU",
+    "british": false,
+    "label": "Summerside Airport (Canada) (CYSU / YSU)"
+  },
+  {
+    "id": "YSY",
+    "british": false,
+    "label": "Sachs Harbour (David Nasogaluak Jr. Saaryuaq) Airport (Canada) (CYSY / YSY)"
+  },
+  {
+    "id": "YTE",
+    "british": false,
+    "label": "Cape Dorset Airport (Canada) (CYTE / YTE)"
+  },
+  {
+    "id": "YTH",
+    "british": false,
+    "label": "Thompson Airport (Canada) (CYTH / YTH)"
+  },
+  {
+    "id": "YTR",
+    "british": false,
+    "label": "CFB Trenton (Canada) (CYTR / YTR)"
+  },
+  {
+    "id": "YTS",
+    "british": false,
+    "label": "Timmins/Victor M. Power (Canada) (CYTS / YTS)"
+  },
+  {
+    "id": "YTZ",
+    "british": false,
+    "label": "Billy Bishop Toronto City Centre Airport (Canada) (CYTZ / YTZ)"
+  },
+  {
+    "id": "YUB",
+    "british": false,
+    "label": "Tuktoyaktuk Airport (Canada) (CYUB / YUB)"
+  },
+  {
+    "id": "YUL",
+    "british": false,
+    "label": "Montreal / Pierre Elliott Trudeau International Airport (Canada) (CYUL / YUL)"
+  },
+  {
+    "id": "YUT",
+    "british": false,
+    "label": "Repulse Bay Airport (Canada) (CYUT / YUT)"
+  },
+  {
+    "id": "YUX",
+    "british": false,
+    "label": "Hall Beach Airport (Canada) (CYUX / YUX)"
+  },
+  {
+    "id": "YUY",
+    "british": false,
+    "label": "Rouyn Noranda Airport (Canada) (CYUY / YUY)"
+  },
+  {
+    "id": "YVC",
+    "british": false,
+    "label": "La Ronge Airport (Canada) (CYVC / YVC)"
+  },
+  {
+    "id": "YVG",
+    "british": false,
+    "label": "Vermilion Airport (Canada) (CYVG / YVG)"
+  },
+  {
+    "id": "YVM",
+    "british": false,
+    "label": "Qikiqtarjuaq Airport (Canada) (CYVM / YVM)"
+  },
+  {
+    "id": "YVO",
+    "british": false,
+    "label": "Val-d'Or Airport (Canada) (CYVO / YVO)"
+  },
+  {
+    "id": "YVP",
+    "british": false,
+    "label": "Kuujjuaq Airport (Canada) (CYVP / YVP)"
+  },
+  {
+    "id": "YVQ",
+    "british": false,
+    "label": "Norman Wells Airport (Canada) (CYVQ / YVQ)"
+  },
+  {
+    "id": "YVR",
+    "british": false,
+    "label": "Vancouver International Airport (Canada) (CYVR / YVR)"
+  },
+  {
+    "id": "YVT",
+    "british": false,
+    "label": "Buffalo Narrows Airport (Canada) (CYVT / YVT)"
+  },
+  {
+    "id": "YVV",
+    "british": false,
+    "label": "Wiarton Airport (Canada) (CYVV / YVV)"
+  },
+  {
+    "id": "YWA",
+    "british": false,
+    "label": "Petawawa Airport (Canada) (CYWA / YWA)"
+  },
+  {
+    "id": "YWG",
+    "british": false,
+    "label": "Winnipeg / James Armstrong Richardson International Airport (Canada) (CYWG / YWG)"
+  },
+  {
+    "id": "YWK",
+    "british": false,
+    "label": "Wabush Airport (Canada) (CYWK / YWK)"
+  },
+  {
+    "id": "YWL",
+    "british": false,
+    "label": "Williams Lake Airport (Canada) (CYWL / YWL)"
+  },
+  {
+    "id": "YWY",
+    "british": false,
+    "label": "Wrigley Airport (Canada) (CYWY / YWY)"
+  },
+  {
+    "id": "YXC",
+    "british": false,
+    "label": "Cranbrook/Canadian Rockies International Airport (Canada) (CYXC / YXC)"
+  },
+  {
+    "id": "YXD",
+    "british": false,
+    "label": "Edmonton City Centre (Blatchford Field) Airport (Canada) (CYXD / YXD)"
+  },
+  {
+    "id": "YXE",
+    "british": false,
+    "label": "Saskatoon John G. Diefenbaker International Airport (Canada) (CYXE / YXE)"
+  },
+  {
+    "id": "YXH",
+    "british": false,
+    "label": "Medicine Hat Airport (Canada) (CYXH / YXH)"
+  },
+  {
+    "id": "YXJ",
+    "british": false,
+    "label": "Fort St John Airport (Canada) (CYXJ / YXJ)"
+  },
+  {
+    "id": "YXL",
+    "british": false,
+    "label": "Sioux Lookout Airport (Canada) (CYXL / YXL)"
+  },
+  {
+    "id": "YXP",
+    "british": false,
+    "label": "Pangnirtung Airport (Canada) (CYXP / YXP)"
+  },
+  {
+    "id": "YXR",
+    "british": false,
+    "label": "Earlton (Timiskaming Regional) Airport (Canada) (CYXR / YXR)"
+  },
+  {
+    "id": "YXS",
+    "british": false,
+    "label": "Prince George Airport (Canada) (CYXS / YXS)"
+  },
+  {
+    "id": "YXT",
+    "british": false,
+    "label": "Northwest Regional Airport Terrace-Kitimat (Canada) (CYXT / YXT)"
+  },
+  {
+    "id": "YXU",
+    "british": false,
+    "label": "London Airport (Canada) (CYXU / YXU)"
+  },
+  {
+    "id": "YXX",
+    "british": false,
+    "label": "Abbotsford Airport (Canada) (CYXX / YXX)"
+  },
+  {
+    "id": "YXY",
+    "british": false,
+    "label": "Whitehorse / Erik Nielsen International Airport (Canada) (CYXY / YXY)"
+  },
+  {
+    "id": "YYB",
+    "british": false,
+    "label": "North Bay Jack Garland Airport (Canada) (CYYB / YYB)"
+  },
+  {
+    "id": "YYC",
+    "british": false,
+    "label": "Calgary International Airport (Canada) (CYYC / YYC)"
+  },
+  {
+    "id": "YYD",
+    "british": false,
+    "label": "Smithers Airport (Canada) (CYYD / YYD)"
+  },
+  {
+    "id": "YYE",
+    "british": false,
+    "label": "Fort Nelson Airport (Canada) (CYYE / YYE)"
+  },
+  {
+    "id": "YYF",
+    "british": false,
+    "label": "Penticton Airport (Canada) (CYYF / YYF)"
+  },
+  {
+    "id": "YYG",
+    "british": false,
+    "label": "Charlottetown Airport (Canada) (CYYG / YYG)"
+  },
+  {
+    "id": "YYH",
+    "british": false,
+    "label": "Taloyoak Airport (Canada) (CYYH / YYH)"
+  },
+  {
+    "id": "YYJ",
+    "british": false,
+    "label": "Victoria International Airport (Canada) (CYYJ / YYJ)"
+  },
+  {
+    "id": "YYL",
+    "british": false,
+    "label": "Lynn Lake Airport (Canada) (CYYL / YYL)"
+  },
+  {
+    "id": "YYN",
+    "british": false,
+    "label": "Swift Current Airport (Canada) (CYYN / YYN)"
+  },
+  {
+    "id": "YYQ",
+    "british": false,
+    "label": "Churchill Airport (Canada) (CYYQ / YYQ)"
+  },
+  {
+    "id": "YYR",
+    "british": false,
+    "label": "Goose Bay Airport (Canada) (CYYR / YYR)"
+  },
+  {
+    "id": "YYT",
+    "british": false,
+    "label": "St. John's International Airport (Canada) (CYYT / YYT)"
+  },
+  {
+    "id": "YYU",
+    "british": false,
+    "label": "Kapuskasing Airport (Canada) (CYYU / YYU)"
+  },
+  {
+    "id": "YYW",
+    "british": false,
+    "label": "Armstrong Airport (Canada) (CYYW / YYW)"
+  },
+  {
+    "id": "YYY",
+    "british": false,
+    "label": "Mont Joli Airport (Canada) (CYYY / YYY)"
+  },
+  {
+    "id": "YYZ",
+    "british": false,
+    "label": "Lester B. Pearson International Airport (Canada) (CYYZ / YYZ)"
+  },
+  {
+    "id": "YZD",
+    "british": false,
+    "label": "Downsview Airport (Canada) (CYZD / YZD)"
+  },
+  {
+    "id": "YZE",
+    "british": false,
+    "label": "Gore Bay Manitoulin Airport (Canada) (CYZE / YZE)"
+  },
+  {
+    "id": "YZF",
+    "british": false,
+    "label": "Yellowknife Airport (Canada) (CYZF / YZF)"
+  },
+  {
+    "id": "YZH",
+    "british": false,
+    "label": "Slave Lake Airport (Canada) (CYZH / YZH)"
+  },
+  {
+    "id": "YZP",
+    "british": false,
+    "label": "Sandspit Airport (Canada) (CYZP / YZP)"
+  },
+  {
+    "id": "YZR",
+    "british": false,
+    "label": "Chris Hadfield Airport (Canada) (CYZR / YZR)"
+  },
+  {
+    "id": "YZT",
+    "british": false,
+    "label": "Port Hardy Airport (Canada) (CYZT / YZT)"
+  },
+  {
+    "id": "YZU",
+    "british": false,
+    "label": "Whitecourt Airport (Canada) (CYZU / YZU)"
+  },
+  {
+    "id": "YZV",
+    "british": false,
+    "label": "Sept-Îles Airport (Canada) (CYZV / YZV)"
+  },
+  {
+    "id": "YZW",
+    "british": false,
+    "label": "Teslin Airport (Canada) (CYZW / YZW)"
+  },
+  {
+    "id": "YZX",
+    "british": false,
+    "label": "CFB Greenwood (Canada) (CYZX / YZX)"
+  },
+  {
+    "id": "ZFA",
+    "british": false,
+    "label": "Faro Airport (Canada) (CZFA / ZFA)"
+  },
+  {
+    "id": "ZFM",
+    "british": false,
+    "label": "Fort Mcpherson Airport (Canada) (CZFM / ZFM)"
+  },
+  {
+    "id": "QLD",
+    "british": false,
+    "label": "Blida Airport (Algeria) (DAAB / QLD)"
+  },
+  {
+    "id": "BUJ",
+    "british": false,
+    "label": "Bou Saada Airport (Algeria) (DAAD / BUJ)"
+  },
+  {
+    "id": "BJA",
+    "british": false,
+    "label": "Soummam Airport (Algeria) (DAAE / BJA)"
+  },
+  {
+    "id": "ALG",
+    "british": false,
+    "label": "Houari Boumediene Airport (Algeria) (DAAG / ALG)"
+  },
+  {
+    "id": "DJG",
+    "british": false,
+    "label": "Djanet Inedbirene Airport (Algeria) (DAAJ / DJG)"
+  },
+  {
+    "id": "DAAK",
+    "british": false,
+    "label": "Boufarik Airport (Algeria) (DAAK)"
+  },
+  {
+    "id": "DAAN",
+    "british": false,
+    "label": "Reggane Airport (Algeria) (DAAN)"
+  },
+  {
+    "id": "VVZ",
+    "british": false,
+    "label": "Illizi Takhamalt Airport (Algeria) (DAAP / VVZ)"
+  },
+  {
+    "id": "DAAQ",
+    "british": false,
+    "label": "Ain Oussera Airport (Algeria) (DAAQ)"
+  },
+  {
+    "id": "TMR",
+    "british": false,
+    "label": "Aguenar – Hadj Bey Akhamok Airport (Algeria) (DAAT / TMR)"
+  },
+  {
+    "id": "GJL",
+    "british": false,
+    "label": "Jijel Ferhat Abbas Airport (Algeria) (DAAV / GJL)"
+  },
+  {
+    "id": "MZW",
+    "british": false,
+    "label": "Mecheria Airport (Algeria) (DAAY / MZW)"
+  },
+  {
+    "id": "DAAZ",
+    "british": false,
+    "label": "Relizane Airport (Algeria) (DAAZ)"
+  },
+  {
+    "id": "AAE",
+    "british": false,
+    "label": "Rabah Bitat Airport (Algeria) (DABB / AAE)"
+  },
+  {
+    "id": "CZL",
+    "british": false,
+    "label": "Mohamed Boudiaf International Airport (Algeria) (DABC / CZL)"
+  },
+  {
+    "id": "TEE",
+    "british": false,
+    "label": "Cheikh Larbi Tébessi Airport (Algeria) (DABS / TEE)"
+  },
+  {
+    "id": "HRM",
+    "british": false,
+    "label": "Hassi R'Mel Airport (Algeria) (DAFH / HRM)"
+  },
+  {
+    "id": "TID",
+    "british": false,
+    "label": "Bou Chekif Airport (Algeria) (DAOB / TID)"
+  },
+  {
+    "id": "DAOE",
+    "british": false,
+    "label": "Bou Sfer Airport (Algeria) (DAOE)"
+  },
+  {
+    "id": "TIN",
+    "british": false,
+    "label": "Tindouf Airport (Algeria) (DAOF / TIN)"
+  },
+  {
+    "id": "CFK",
+    "british": false,
+    "label": "Ech Cheliff Airport (Algeria) (DAOI / CFK)"
+  },
+  {
+    "id": "TAF",
+    "british": false,
+    "label": "Tafaraoui Airport (Algeria) (DAOL / TAF)"
+  },
+  {
+    "id": "TLM",
+    "british": false,
+    "label": "Zenata – Messali El Hadj Airport (Algeria) (DAON / TLM)"
+  },
+  {
+    "id": "ORN",
+    "british": false,
+    "label": "Es Senia Airport (Algeria) (DAOO / ORN)"
+  },
+  {
+    "id": "BFW",
+    "british": false,
+    "label": "Sidi Bel Abbes Airport (Algeria) (DAOS / BFW)"
+  },
+  {
+    "id": "MUW",
+    "british": false,
+    "label": "Ghriss Airport (Algeria) (DAOV / MUW)"
+  },
+  {
+    "id": "AZR",
+    "british": false,
+    "label": "Touat Cheikh Sidi Mohamed Belkebir Airport (Algeria) (DAUA / AZR)"
+  },
+  {
+    "id": "BSK",
+    "british": false,
+    "label": "Biskra Airport (Algeria) (DAUB / BSK)"
+  },
+  {
+    "id": "ELG",
+    "british": false,
+    "label": "El Golea Airport (Algeria) (DAUE / ELG)"
+  },
+  {
+    "id": "GHA",
+    "british": false,
+    "label": "Noumérat - Moufdi Zakaria Airport (Algeria) (DAUG / GHA)"
+  },
+  {
+    "id": "HME",
+    "british": false,
+    "label": "Oued Irara Airport (Algeria) (DAUH / HME)"
+  },
+  {
+    "id": "INZ",
+    "british": false,
+    "label": "In Salah Airport (Algeria) (DAUI / INZ)"
+  },
+  {
+    "id": "TGR",
+    "british": false,
+    "label": "Touggourt Sidi Madhi Airport (Algeria) (DAUK / TGR)"
+  },
+  {
+    "id": "LOO",
+    "british": false,
+    "label": "Laghouat Airport (Algeria) (DAUL / LOO)"
+  },
+  {
+    "id": "TMX",
+    "british": false,
+    "label": "Timimoun Airport (Algeria) (DAUT / TMX)"
+  },
+  {
+    "id": "OGX",
+    "british": false,
+    "label": "Ain el Beida Airport (Algeria) (DAUU / OGX)"
+  },
+  {
+    "id": "IAM",
+    "british": false,
+    "label": "In Aménas Airport (Algeria) (DAUZ / IAM)"
+  },
+  {
+    "id": "COO",
+    "british": false,
+    "label": "Cadjehoun Airport (Benin) (DBBB / COO)"
+  },
+  {
+    "id": "OUA",
+    "british": false,
+    "label": "Ouagadougou Airport (Burkina Faso) (DFFD / OUA)"
+  },
+  {
+    "id": "BOY",
+    "british": false,
+    "label": "Bobo Dioulasso Airport (Burkina Faso) (DFOO / BOY)"
+  },
+  {
+    "id": "ACC",
+    "british": false,
+    "label": "Kotoka International Airport (Ghana) (DGAA / ACC)"
+  },
+  {
+    "id": "TML",
+    "british": false,
+    "label": "Tamale Airport (Ghana) (DGLE / TML)"
+  },
+  {
+    "id": "DGLW",
+    "british": false,
+    "label": "Wa Airport (Ghana) (DGLW)"
+  },
+  {
+    "id": "NYI",
+    "british": false,
+    "label": "Sunyani Airport (Ghana) (DGSN / NYI)"
+  },
+  {
+    "id": "TKD",
+    "british": false,
+    "label": "Takoradi Airport (Ghana) (DGTK / TKD)"
+  },
+  {
+    "id": "ABJ",
+    "british": false,
+    "label": "Port Bouet Airport (Cote d'Ivoire) (DIAP / ABJ)"
+  },
+  {
+    "id": "BYK",
+    "british": false,
+    "label": "Bouaké Airport (Cote d'Ivoire) (DIBK / BYK)"
+  },
+  {
+    "id": "DJO",
+    "british": false,
+    "label": "Daloa Airport (Cote d'Ivoire) (DIDL / DJO)"
+  },
+  {
+    "id": "HGO",
+    "british": false,
+    "label": "Korhogo Airport (Cote d'Ivoire) (DIKO / HGO)"
+  },
+  {
+    "id": "MJC",
+    "british": false,
+    "label": "Man Airport (Cote d'Ivoire) (DIMN / MJC)"
+  },
+  {
+    "id": "SPY",
+    "british": false,
+    "label": "San Pedro Airport (Cote d'Ivoire) (DISP / SPY)"
+  },
+  {
+    "id": "ASK",
+    "british": false,
+    "label": "Yamoussoukro Airport (Cote d'Ivoire) (DIYO / ASK)"
+  },
+  {
+    "id": "ABV",
+    "british": false,
+    "label": "Nnamdi Azikiwe International Airport (Nigeria) (DNAA / ABV)"
+  },
+  {
+    "id": "AKR",
+    "british": false,
+    "label": "Akure Airport (Nigeria) (DNAK / AKR)"
+  },
+  {
+    "id": "BNI",
+    "british": false,
+    "label": "Benin Airport (Nigeria) (DNBE / BNI)"
+  },
+  {
+    "id": "CBQ",
+    "british": false,
+    "label": "Margaret Ekpo International Airport (Nigeria) (DNCA / CBQ)"
+  },
+  {
+    "id": "ENU",
+    "british": false,
+    "label": "Akanu Ibiam International Airport (Nigeria) (DNEN / ENU)"
+  },
+  {
+    "id": "DNGU",
+    "british": false,
+    "label": "Gusau Airport (Nigeria) (DNGU)"
+  },
+  {
+    "id": "IBA",
+    "british": false,
+    "label": "Ibadan Airport (Nigeria) (DNIB / IBA)"
+  },
+  {
+    "id": "ILR",
+    "british": false,
+    "label": "Ilorin International Airport (Nigeria) (DNIL / ILR)"
+  },
+  {
+    "id": "JOS",
+    "british": false,
+    "label": "Yakubu Gowon Airport (Nigeria) (DNJO / JOS)"
+  },
+  {
+    "id": "KAD",
+    "british": false,
+    "label": "Kaduna Airport (Nigeria) (DNKA / KAD)"
+  },
+  {
+    "id": "KAN",
+    "british": false,
+    "label": "Mallam Aminu International Airport (Nigeria) (DNKN / KAN)"
+  },
+  {
+    "id": "MIU",
+    "british": false,
+    "label": "Maiduguri International Airport (Nigeria) (DNMA / MIU)"
+  },
+  {
+    "id": "MDI",
+    "british": false,
+    "label": "Makurdi Airport (Nigeria) (DNMK / MDI)"
+  },
+  {
+    "id": "LOS",
+    "british": false,
+    "label": "Murtala Muhammed International Airport (Nigeria) (DNMM / LOS)"
+  },
+  {
+    "id": "MXJ",
+    "british": false,
+    "label": "Minna Airport (Nigeria) (DNMN / MXJ)"
+  },
+  {
+    "id": "PHC",
+    "british": false,
+    "label": "Port Harcourt International Airport (Nigeria) (DNPO / PHC)"
+  },
+  {
+    "id": "SKO",
+    "british": false,
+    "label": "Sadiq Abubakar III International Airport (Nigeria) (DNSO / SKO)"
+  },
+  {
+    "id": "YOL",
+    "british": false,
+    "label": "Yola Airport (Nigeria) (DNYO / YOL)"
+  },
+  {
+    "id": "ZAR",
+    "british": false,
+    "label": "Zaria Airport (Nigeria) (DNZA / ZAR)"
+  },
+  {
+    "id": "MFQ",
+    "british": false,
+    "label": "Maradi Airport (Niger) (DRRM / MFQ)"
+  },
+  {
+    "id": "NIM",
+    "british": false,
+    "label": "Diori Hamani International Airport (Niger) (DRRN / NIM)"
+  },
+  {
+    "id": "THZ",
+    "british": false,
+    "label": "Tahoua Airport (Niger) (DRRT / THZ)"
+  },
+  {
+    "id": "AJY",
+    "british": false,
+    "label": "Mano Dayak International Airport (Niger) (DRZA / AJY)"
+  },
+  {
+    "id": "DRZD",
+    "british": false,
+    "label": "Dirkou Airport (Niger) (DRZD)"
+  },
+  {
+    "id": "DRZF",
+    "british": false,
+    "label": "Diffa Airport (Niger) (DRZF)"
+  },
+  {
+    "id": "ZND",
+    "british": false,
+    "label": "Zinder Airport (Niger) (DRZR / ZND)"
+  },
+  {
+    "id": "MIR",
+    "british": false,
+    "label": "Monastir Habib Bourguiba International Airport (Tunisia) (DTMB / MIR)"
+  },
+  {
+    "id": "TUN",
+    "british": false,
+    "label": "Tunis Carthage International Airport (Tunisia) (DTTA / TUN)"
+  },
+  {
+    "id": "DTTB",
+    "british": false,
+    "label": "Sidi Ahmed Air Base (Tunisia) (DTTB)"
+  },
+  {
+    "id": "DTTD",
+    "british": false,
+    "label": "Remada Air Base (Tunisia) (DTTD)"
+  },
+  {
+    "id": "GAF",
+    "british": false,
+    "label": "Gafsa Ksar International Airport (Tunisia) (DTTF / GAF)"
+  },
+  {
+    "id": "GAE",
+    "british": false,
+    "label": "Gabès Matmata International Airport (Tunisia) (DTTG / GAE)"
+  },
+  {
+    "id": "DTTI",
+    "british": false,
+    "label": "Borj El Amri Airport (Tunisia) (DTTI)"
+  },
+  {
+    "id": "DJE",
+    "british": false,
+    "label": "Djerba Zarzis International Airport (Tunisia) (DTTJ / DJE)"
+  },
+  {
+    "id": "EBM",
+    "british": false,
+    "label": "El Borma Airport (Tunisia) (DTTR / EBM)"
+  },
+  {
+    "id": "SFA",
+    "british": false,
+    "label": "Sfax Thyna International Airport (Tunisia) (DTTX / SFA)"
+  },
+  {
+    "id": "TOE",
+    "british": false,
+    "label": "Tozeur Nefta International Airport (Tunisia) (DTTZ / TOE)"
+  },
+  {
+    "id": "LRL",
+    "british": false,
+    "label": "Niamtougou International Airport (Togo) (DXNG / LRL)"
+  },
+  {
+    "id": "LFW",
+    "british": false,
+    "label": "Lomé-Tokoin Airport (Togo) (DXXX / LFW)"
+  },
+  {
+    "id": "ANR",
+    "british": false,
+    "label": "Antwerp International Airport (Deurne) (Belgium) (EBAW / ANR)"
+  },
+  {
+    "id": "EBBE",
+    "british": false,
+    "label": "Beauvechain Air Base (Belgium) (EBBE)"
+  },
+  {
+    "id": "EBBL",
+    "british": false,
+    "label": "Kleine Brogel Air Base (Belgium) (EBBL)"
+  },
+  {
+    "id": "BRU",
+    "british": false,
+    "label": "Brussels Airport (Belgium) (EBBR / BRU)"
+  },
+  {
+    "id": "EBBX",
+    "british": false,
+    "label": "Jehonville Air Base (Belgium) (EBBX)"
+  },
+  {
+    "id": "CRL",
+    "british": false,
+    "label": "Brussels South Charleroi Airport (Belgium) (EBCI / CRL)"
+  },
+  {
+    "id": "EBCV",
+    "british": false,
+    "label": "Chièvres Air Base (Belgium) (EBCV)"
+  },
+  {
+    "id": "EBFN",
+    "british": false,
+    "label": "Koksijde Air Base (Belgium) (EBFN)"
+  },
+  {
+    "id": "EBFS",
+    "british": false,
+    "label": "Florennes Air Base (Belgium) (EBFS)"
+  },
+  {
+    "id": "KJK",
+    "british": false,
+    "label": "Wevelgem Airport (Belgium) (EBKT / KJK)"
+  },
+  {
+    "id": "LGG",
+    "british": false,
+    "label": "Liège Airport (Belgium) (EBLG / LGG)"
+  },
+  {
+    "id": "OST",
+    "british": false,
+    "label": "Ostend-Bruges International Airport (Belgium) (EBOS / OST)"
+  },
+  {
+    "id": "EBSL",
+    "british": false,
+    "label": "Zutendaal Air Base (Belgium) (EBSL)"
+  },
+  {
+    "id": "EBST",
+    "british": false,
+    "label": "Brustem Airfield Sint Truiden (Belgium) (EBST)"
+  },
+  {
+    "id": "EBSU",
+    "british": false,
+    "label": "Saint Hubert Air Base (Belgium) (EBSU)"
+  },
+  {
+    "id": "EBUL",
+    "british": false,
+    "label": "Ursel Air Base (Belgium) (EBUL)"
+  },
+  {
+    "id": "EBWE",
+    "british": false,
+    "label": "Weelde Air Base (Belgium) (EBWE)"
+  },
+  {
+    "id": "OBL",
+    "british": false,
+    "label": "Zoersel (Oostmalle) Airfield (Belgium) (EBZR / OBL)"
+  },
+  {
+    "id": "EDAB",
+    "british": false,
+    "label": "Flugplatz Bautzen (Germany) (EDAB)"
+  },
+  {
+    "id": "AOC",
+    "british": false,
+    "label": "Altenburg-Nobitz Airport (Germany) (EDAC / AOC)"
+  },
+  {
+    "id": "EDAD",
+    "british": false,
+    "label": "Dessau Airfield (Germany) (EDAD)"
+  },
+  {
+    "id": "EDAE",
+    "british": false,
+    "label": "Eisenhüttenstadt Airfield (Germany) (EDAE)"
+  },
+  {
+    "id": "EDAK",
+    "british": false,
+    "label": "Großenhain Airport (Germany) (EDAK)"
+  },
+  {
+    "id": "EDAM",
+    "british": false,
+    "label": "Merseburg Airport (Germany) (EDAM)"
+  },
+  {
+    "id": "EDAQ",
+    "british": false,
+    "label": "Halle-Oppin Airport (Germany) (EDAQ)"
+  },
+  {
+    "id": "IES",
+    "british": false,
+    "label": "Riesa-Göhlis Airport (Germany) (EDAU / IES)"
+  },
+  {
+    "id": "REB",
+    "british": false,
+    "label": "Rechlin-Lärz Airport (Germany) (EDAX / REB)"
+  },
+  {
+    "id": "EDAY",
+    "british": false,
+    "label": "Strausberg Airport (Germany) (EDAY)"
+  },
+  {
+    "id": "QXH",
+    "british": false,
+    "label": "Schönhagen Airport (Germany) (EDAZ / QXH)"
+  },
+  {
+    "id": "BBH",
+    "british": false,
+    "label": "Barth Airport (Germany) (EDBH / BBH)"
+  },
+  {
+    "id": "EDBJ",
+    "british": false,
+    "label": "Jena-Schöngleina Airfield (Germany) (EDBJ)"
+  },
+  {
+    "id": "EDBK",
+    "british": false,
+    "label": "Kyritz Airport (Germany) (EDBK)"
+  },
+  {
+    "id": "ZMG",
+    "british": false,
+    "label": "Magdeburg \"City\" Airport (Germany) (EDBM / ZMG)"
+  },
+  {
+    "id": "EDBR",
+    "british": false,
+    "label": "Rothenburg/Görlitz Airport (Germany) (EDBR)"
+  },
+  {
+    "id": "EDCA",
+    "british": false,
+    "label": "Anklam Airfield (Germany) (EDCA)"
+  },
+  {
+    "id": "CBU",
+    "british": false,
+    "label": "Cottbus-Drewitz Airport (Germany) (EDCD / CBU)"
+  },
+  {
+    "id": "EDCM",
+    "british": false,
+    "label": "Kamenz Airport (Germany) (EDCM)"
+  },
+  {
+    "id": "SXF",
+    "british": false,
+    "label": "Berlin-Schönefeld Airport (Germany) (EDDB / SXF)"
+  },
+  {
+    "id": "DRS",
+    "british": false,
+    "label": "Dresden Airport (Germany) (EDDC / DRS)"
+  },
+  {
+    "id": "ERF",
+    "british": false,
+    "label": "Erfurt Airport (Germany) (EDDE / ERF)"
+  },
+  {
+    "id": "FRA",
+    "british": false,
+    "label": "Frankfurt am Main Airport (Germany) (EDDF / FRA)"
+  },
+  {
+    "id": "FMO",
+    "british": false,
+    "label": "Münster Osnabrück Airport (Germany) (EDDG / FMO)"
+  },
+  {
+    "id": "HAM",
+    "british": false,
+    "label": "Hamburg Airport (Germany) (EDDH / HAM)"
+  },
+  {
+    "id": "THF",
+    "british": false,
+    "label": "Berlin-Tempelhof International Airport (Germany) (EDDI / THF)"
+  },
+  {
+    "id": "CGN",
+    "british": false,
+    "label": "Cologne Bonn Airport (Germany) (EDDK / CGN)"
+  },
+  {
+    "id": "DUS",
+    "british": false,
+    "label": "Düsseldorf Airport (Germany) (EDDL / DUS)"
+  },
+  {
+    "id": "MUC",
+    "british": false,
+    "label": "Munich Airport (Germany) (EDDM / MUC)"
+  },
+  {
+    "id": "NUE",
+    "british": false,
+    "label": "Nuremberg Airport (Germany) (EDDN / NUE)"
+  },
+  {
+    "id": "LEJ",
+    "british": false,
+    "label": "Leipzig/Halle Airport (Germany) (EDDP / LEJ)"
+  },
+  {
+    "id": "SCN",
+    "british": false,
+    "label": "Saarbrücken Airport (Germany) (EDDR / SCN)"
+  },
+  {
+    "id": "STR",
+    "british": false,
+    "label": "Stuttgart Airport (Germany) (EDDS / STR)"
+  },
+  {
+    "id": "TXL",
+    "british": false,
+    "label": "Berlin-Tegel Airport (Germany) (EDDT / TXL)"
+  },
+  {
+    "id": "HAJ",
+    "british": false,
+    "label": "Hannover Airport (Germany) (EDDV / HAJ)"
+  },
+  {
+    "id": "BRE",
+    "british": false,
+    "label": "Bremen Airport (Germany) (EDDW / BRE)"
+  },
+  {
+    "id": "QEF",
+    "british": false,
+    "label": "Frankfurt-Egelsbach Airport (Germany) (EDFE / QEF)"
+  },
+  {
+    "id": "HHN",
+    "british": false,
+    "label": "Frankfurt-Hahn Airport (Germany) (EDFH / HHN)"
+  },
+  {
+    "id": "MHG",
+    "british": false,
+    "label": "Mannheim-City Airport (Germany) (EDFM / MHG)"
+  },
+  {
+    "id": "EDFQ",
+    "british": false,
+    "label": "Allendorf/Eder Airport (Germany) (EDFQ)"
+  },
+  {
+    "id": "EDFV",
+    "british": false,
+    "label": "Worms Airport (Germany) (EDFV)"
+  },
+  {
+    "id": "EDFZ",
+    "british": false,
+    "label": "Mainz-Finthen Airport (Germany) (EDFZ)"
+  },
+  {
+    "id": "EIB",
+    "british": false,
+    "label": "Eisenach-Kindel Airport (Germany) (EDGE / EIB)"
+  },
+  {
+    "id": "SGE",
+    "british": false,
+    "label": "Siegerland Airport (Germany) (EDGS / SGE)"
+  },
+  {
+    "id": "XFW",
+    "british": false,
+    "label": "Hamburg-Finkenwerder Airport (Germany) (EDHI / XFW)"
+  },
+  {
+    "id": "KEL",
+    "british": false,
+    "label": "Kiel-Holtenau Airport (Germany) (EDHK / KEL)"
+  },
+  {
+    "id": "LBC",
+    "british": false,
+    "label": "Lübeck Blankensee Airport (Germany) (EDHL / LBC)"
+  },
+  {
+    "id": "EDKV",
+    "british": false,
+    "label": "Flugplatz Dahlemer Binz (Germany) (EDKV)"
+  },
+  {
+    "id": "EDKZ",
+    "british": false,
+    "label": "Meinerzhagen Airport (Germany) (EDKZ)"
+  },
+  {
+    "id": "EDLA",
+    "british": false,
+    "label": "Arnsberg-Menden Airport (Germany) (EDLA)"
+  },
+  {
+    "id": "ESS",
+    "british": false,
+    "label": "Essen Mulheim Airport (Germany) (EDLE / ESS)"
+  },
+  {
+    "id": "BFE",
+    "british": false,
+    "label": "Bielefeld Airport (Germany) (EDLI / BFE)"
+  },
+  {
+    "id": "MGL",
+    "british": false,
+    "label": "Mönchengladbach Airport (Germany) (EDLN / MGL)"
+  },
+  {
+    "id": "PAD",
+    "british": false,
+    "label": "Paderborn Lippstadt Airport (Germany) (EDLP / PAD)"
+  },
+  {
+    "id": "EDLS",
+    "british": false,
+    "label": "Stadtlohn-Vreden Airport (Germany) (EDLS)"
+  },
+  {
+    "id": "DTM",
+    "british": false,
+    "label": "Dortmund Airport (Germany) (EDLW / DTM)"
+  },
+  {
+    "id": "AGB",
+    "british": false,
+    "label": "Augsburg Airport (Germany) (EDMA / AGB)"
+  },
+  {
+    "id": "EDMB",
+    "british": false,
+    "label": "Biberach a.d. Riß Airfield (Germany) (EDMB)"
+  },
+  {
+    "id": "EDME",
+    "british": false,
+    "label": "Eggenfelden Airport (Germany) (EDME)"
+  },
+  {
+    "id": "EDMN",
+    "british": false,
+    "label": "Mindelheim-Mattsies Airfield (Germany) (EDMN)"
+  },
+  {
+    "id": "OBF",
+    "british": false,
+    "label": "Oberpfaffenhofen Airport (Germany) (EDMO / OBF)"
+  },
+  {
+    "id": "RBM",
+    "british": false,
+    "label": "Straubing Airport (Germany) (EDMS / RBM)"
+  },
+  {
+    "id": "EDMV",
+    "british": false,
+    "label": "Vilshofen Airport (Germany) (EDMV)"
+  },
+  {
+    "id": "EDNL",
+    "british": false,
+    "label": "Leutkirch-Unterzeil Airport (Germany) (EDNL)"
+  },
+  {
+    "id": "FDH",
+    "british": false,
+    "label": "Friedrichshafen Airport (Germany) (EDNY / FDH)"
+  },
+  {
+    "id": "SZW",
+    "british": false,
+    "label": "Schwerin Parchim Airport (Germany) (EDOP / SZW)"
+  },
+  {
+    "id": "EDOV",
+    "british": false,
+    "label": "Stendal-Borstel Airport (Germany) (EDOV)"
+  },
+  {
+    "id": "EDPA",
+    "british": false,
+    "label": "Aalen-Heidenheim/Elchingen Airport (Germany) (EDPA)"
+  },
+  {
+    "id": "BYU",
+    "british": false,
+    "label": "Bayreuth Airport (Germany) (EDQD / BYU)"
+  },
+  {
+    "id": "URD",
+    "british": false,
+    "label": "Burg Feuerstein Airport (Germany) (EDQE / URD)"
+  },
+  {
+    "id": "HOQ",
+    "british": false,
+    "label": "Hof-Plauen Airport (Germany) (EDQM / HOQ)"
+  },
+  {
+    "id": "EDQT",
+    "british": false,
+    "label": "Haßfurt-Schweinfurt Airport (Germany) (EDQT)"
+  },
+  {
+    "id": "EDRK",
+    "british": false,
+    "label": "Koblenz-Winningen Airfield (Germany) (EDRK)"
+  },
+  {
+    "id": "EDRT",
+    "british": false,
+    "label": "Trier-Föhren Airport (Germany) (EDRT)"
+  },
+  {
+    "id": "EDRY",
+    "british": false,
+    "label": "Speyer Airfield (Germany) (EDRY)"
+  },
+  {
+    "id": "ZQW",
+    "british": false,
+    "label": "Zweibrücken Airport (Germany) (EDRZ / ZQW)"
+  },
+  {
+    "id": "ZQL",
+    "british": false,
+    "label": "Donaueschingen-Villingen Airport (Germany) (EDTD / ZQL)"
+  },
+  {
+    "id": "EDTF",
+    "british": false,
+    "label": "Freiburg i. Br. Airport (Germany) (EDTF)"
+  },
+  {
+    "id": "EDTM",
+    "british": false,
+    "label": "Mengen-Hohentengen Airport (Germany) (EDTM)"
+  },
+  {
+    "id": "EDTY",
+    "british": false,
+    "label": "Adolf Würth Airport (Germany) (EDTY)"
+  },
+  {
+    "id": "EDUS",
+    "british": false,
+    "label": "Finsterwalde/Schacksdorf Airport (Germany) (EDUS)"
+  },
+  {
+    "id": "BWE",
+    "british": false,
+    "label": "Braunschweig-Wolfsburg Airport (Germany) (EDVE / BWE)"
+  },
+  {
+    "id": "KSF",
+    "british": false,
+    "label": "Kassel-Calden Airport (Germany) (EDVK / KSF)"
+  },
+  {
+    "id": "EDVM",
+    "british": false,
+    "label": "Hildesheim Airport (Germany) (EDVM)"
+  },
+  {
+    "id": "BRV",
+    "british": false,
+    "label": "Bremerhaven Airport (Germany) (EDWB / BRV)"
+  },
+  {
+    "id": "EME",
+    "british": false,
+    "label": "Emden Airport (Germany) (EDWE / EME)"
+  },
+  {
+    "id": "EDWF",
+    "british": false,
+    "label": "Leer-Papenburg Airport (Germany) (EDWF)"
+  },
+  {
+    "id": "WVN",
+    "british": false,
+    "label": "Wilhelmshaven-Mariensiel Airport (Germany) (EDWI / WVN)"
+  },
+  {
+    "id": "BMK",
+    "british": false,
+    "label": "Borkum Airport (Germany) (EDWR / BMK)"
+  },
+  {
+    "id": "NRD",
+    "british": false,
+    "label": "Norderney Airport (Germany) (EDWY / NRD)"
+  },
+  {
+    "id": "FLF",
+    "british": false,
+    "label": "Flensburg-Schäferhaus Airport (Germany) (EDXF / FLF)"
+  },
+  {
+    "id": "EDXR",
+    "british": false,
+    "label": "Rendsburg-Schachtholm Airport (Germany) (EDXR)"
+  },
+  {
+    "id": "GWT",
+    "british": false,
+    "label": "Westerland Sylt Airport (Germany) (EDXW / GWT)"
+  },
+  {
+    "id": "EEEI",
+    "british": false,
+    "label": "Ämari Air Base (Estonia) (EEEI)"
+  },
+  {
+    "id": "KDL",
+    "british": false,
+    "label": "Kärdla Airport (Estonia) (EEKA / KDL)"
+  },
+  {
+    "id": "URE",
+    "british": false,
+    "label": "Kuressaare Airport (Estonia) (EEKE / URE)"
+  },
+  {
+    "id": "EPU",
+    "british": false,
+    "label": "Pärnu Airport (Estonia) (EEPU / EPU)"
+  },
+  {
+    "id": "TLL",
+    "british": false,
+    "label": "Lennart Meri Tallinn Airport (Estonia) (EETN / TLL)"
+  },
+  {
+    "id": "TAY",
+    "british": false,
+    "label": "Tartu Airport (Estonia) (EETU / TAY)"
+  },
+  {
+    "id": "ENF",
+    "british": false,
+    "label": "Enontekio Airport (Finland) (EFET / ENF)"
+  },
+  {
+    "id": "EFEU",
+    "british": false,
+    "label": "Eura Airport (Finland) (EFEU)"
+  },
+  {
+    "id": "KEV",
+    "british": false,
+    "label": "Halli Airport (Finland) (EFHA / KEV)"
+  },
+  {
+    "id": "HEM",
+    "british": false,
+    "label": "Helsinki Malmi Airport (Finland) (EFHF / HEM)"
+  },
+  {
+    "id": "HEL",
+    "british": false,
+    "label": "Helsinki Vantaa Airport (Finland) (EFHK / HEL)"
+  },
+  {
+    "id": "EFHM",
+    "british": false,
+    "label": "Hameenkyro Airport (Finland) (EFHM)"
+  },
+  {
+    "id": "EFHN",
+    "british": false,
+    "label": "Hanko Airport (Finland) (EFHN)"
+  },
+  {
+    "id": "HYV",
+    "british": false,
+    "label": "Hyvinkää Airfield (Finland) (EFHV / HYV)"
+  },
+  {
+    "id": "EFIK",
+    "british": false,
+    "label": "Kiikala Airport (Finland) (EFIK)"
+  },
+  {
+    "id": "EFIM",
+    "british": false,
+    "label": "Immola Airport (Finland) (EFIM)"
+  },
+  {
+    "id": "KTQ",
+    "british": false,
+    "label": "Kitee Airport (Finland) (EFIT / KTQ)"
+  },
+  {
+    "id": "IVL",
+    "british": false,
+    "label": "Ivalo Airport (Finland) (EFIV / IVL)"
+  },
+  {
+    "id": "JOE",
+    "british": false,
+    "label": "Joensuu Airport (Finland) (EFJO / JOE)"
+  },
+  {
+    "id": "JYV",
+    "british": false,
+    "label": "Jyvaskyla Airport (Finland) (EFJY / JYV)"
+  },
+  {
+    "id": "KAU",
+    "british": false,
+    "label": "Kauhava Airport (Finland) (EFKA / KAU)"
+  },
+  {
+    "id": "KEM",
+    "british": false,
+    "label": "Kemi-Tornio Airport (Finland) (EFKE / KEM)"
+  },
+  {
+    "id": "KAJ",
+    "british": false,
+    "label": "Kajaani Airport (Finland) (EFKI / KAJ)"
+  },
+  {
+    "id": "KHJ",
+    "british": false,
+    "label": "Kauhajoki Airport (Finland) (EFKJ / KHJ)"
+  },
+  {
+    "id": "KOK",
+    "british": false,
+    "label": "Kokkola-Pietarsaari Airport (Finland) (EFKK / KOK)"
+  },
+  {
+    "id": "EFKM",
+    "british": false,
+    "label": "Kemijarvi Airport (Finland) (EFKM)"
+  },
+  {
+    "id": "KAO",
+    "british": false,
+    "label": "Kuusamo Airport (Finland) (EFKS / KAO)"
+  },
+  {
+    "id": "KTT",
+    "british": false,
+    "label": "Kittilä Airport (Finland) (EFKT / KTT)"
+  },
+  {
+    "id": "KUO",
+    "british": false,
+    "label": "Kuopio Airport (Finland) (EFKU / KUO)"
+  },
+  {
+    "id": "QLF",
+    "british": false,
+    "label": "Lahti Vesivehmaa Airport (Finland) (EFLA / QLF)"
+  },
+  {
+    "id": "LPP",
+    "british": false,
+    "label": "Lappeenranta Airport (Finland) (EFLP / LPP)"
+  },
+  {
+    "id": "MHQ",
+    "british": false,
+    "label": "Mariehamn Airport (Finland) (EFMA / MHQ)"
+  },
+  {
+    "id": "EFME",
+    "british": false,
+    "label": "Menkijarvi Airport (Finland) (EFME)"
+  },
+  {
+    "id": "MIK",
+    "british": false,
+    "label": "Mikkeli Airport (Finland) (EFMI / MIK)"
+  },
+  {
+    "id": "EFNU",
+    "british": false,
+    "label": "Nummela Airport (Finland) (EFNU)"
+  },
+  {
+    "id": "OUL",
+    "british": false,
+    "label": "Oulu Airport (Finland) (EFOU / OUL)"
+  },
+  {
+    "id": "EFPI",
+    "british": false,
+    "label": "Piikajarvi Airport (Finland) (EFPI)"
+  },
+  {
+    "id": "POR",
+    "british": false,
+    "label": "Pori Airport (Finland) (EFPO / POR)"
+  },
+  {
+    "id": "EFPU",
+    "british": false,
+    "label": "Pudasjärvi Airport (Finland) (EFPU)"
+  },
+  {
+    "id": "EFPY",
+    "british": false,
+    "label": "Pyhäsalmi Airport (Finland) (EFPY)"
+  },
+  {
+    "id": "EFRH",
+    "british": false,
+    "label": "Raahe Pattijoki Airport (Finland) (EFRH)"
+  },
+  {
+    "id": "EFRN",
+    "british": false,
+    "label": "Rantasalmi Airport (Finland) (EFRN)"
+  },
+  {
+    "id": "RVN",
+    "british": false,
+    "label": "Rovaniemi Airport (Finland) (EFRO / RVN)"
+  },
+  {
+    "id": "EFRY",
+    "british": false,
+    "label": "Rayskala Airport (Finland) (EFRY)"
+  },
+  {
+    "id": "SVL",
+    "british": false,
+    "label": "Savonlinna Airport (Finland) (EFSA / SVL)"
+  },
+  {
+    "id": "EFSE",
+    "british": false,
+    "label": "Selanpaa Airport (Finland) (EFSE)"
+  },
+  {
+    "id": "SOT",
+    "british": false,
+    "label": "Sodankyla Airport (Finland) (EFSO / SOT)"
+  },
+  {
+    "id": "TMP",
+    "british": false,
+    "label": "Tampere-Pirkkala Airport (Finland) (EFTP / TMP)"
+  },
+  {
+    "id": "EFTS",
+    "british": false,
+    "label": "Teisko Airport (Finland) (EFTS)"
+  },
+  {
+    "id": "TKU",
+    "british": false,
+    "label": "Turku Airport (Finland) (EFTU / TKU)"
+  },
+  {
+    "id": "UTI",
+    "british": false,
+    "label": "Utti Air Base (Finland) (EFUT / UTI)"
+  },
+  {
+    "id": "VAA",
+    "british": false,
+    "label": "Vaasa Airport (Finland) (EFVA / VAA)"
+  },
+  {
+    "id": "VRK",
+    "british": false,
+    "label": "Varkaus Airport (Finland) (EFVR / VRK)"
+  },
+  {
+    "id": "YLI",
+    "british": false,
+    "label": "Ylivieska Airfield (Finland) (EFYL / YLI)"
+  },
+  {
+    "id": "BFS",
+    "british": true,
+    "label": "Belfast International Airport (United Kingdom) (EGAA / BFS)"
+  },
+  {
+    "id": "ENK",
+    "british": true,
+    "label": "St Angelo Airport (United Kingdom) (EGAB / ENK)"
+  },
+  {
+    "id": "BHD",
+    "british": true,
+    "label": "George Best Belfast City Airport (United Kingdom) (EGAC / BHD)"
+  },
+  {
+    "id": "LDY",
+    "british": true,
+    "label": "City of Derry Airport (United Kingdom) (EGAE / LDY)"
+  },
+  {
+    "id": "BHX",
+    "british": true,
+    "label": "Birmingham International Airport (United Kingdom) (EGBB / BHX)"
+  },
+  {
+    "id": "CVT",
+    "british": true,
+    "label": "Coventry Airport (United Kingdom) (EGBE / CVT)"
+  },
+  {
+    "id": "EGBG",
+    "british": true,
+    "label": "Leicester Airport (United Kingdom) (EGBG)"
+  },
+  {
+    "id": "GLO",
+    "british": true,
+    "label": "Gloucestershire Airport (United Kingdom) (EGBJ / GLO)"
+  },
+  {
+    "id": "EGBO",
+    "british": true,
+    "label": "Wolverhampton Halfpenny Green Airport (United Kingdom) (EGBO)"
+  },
+  {
+    "id": "GBA",
+    "british": true,
+    "label": "Cotswold Airport (United Kingdom) (EGBP / GBA)"
+  },
+  {
+    "id": "EGBT",
+    "british": true,
+    "label": "Turweston Airport (United Kingdom) (EGBT)"
+  },
+  {
+    "id": "EGBW",
+    "british": true,
+    "label": "Wellesbourne Mountford Airport (United Kingdom) (EGBW)"
+  },
+  {
+    "id": "MAN",
+    "british": true,
+    "label": "Manchester Airport (United Kingdom) (EGCC / MAN)"
+  },
+  {
+    "id": "EGCD",
+    "british": true,
+    "label": "Manchester Woodford Airport (United Kingdom) (EGCD)"
+  },
+  {
+    "id": "EGDC",
+    "british": true,
+    "label": "Royal Marines Base Chivenor Airport (United Kingdom) (EGDC)"
+  },
+  {
+    "id": "NQY",
+    "british": true,
+    "label": "Newquay Cornwall Airport (United Kingdom) (EGHQ / NQY)"
+  },
+  {
+    "id": "LYE",
+    "british": true,
+    "label": "RAF Lyneham (United Kingdom) (EGDL / LYE)"
+  },
+  {
+    "id": "EGDM",
+    "british": true,
+    "label": "MoD Boscombe Down Airport (United Kingdom) (EGDM)"
+  },
+  {
+    "id": "EGDR",
+    "british": true,
+    "label": "RNAS Culdrose (United Kingdom) (EGDR)"
+  },
+  {
+    "id": "EGDX",
+    "british": true,
+    "label": "MoD St. Athan (United Kingdom) (EGDX)"
+  },
+  {
+    "id": "YEO",
+    "british": true,
+    "label": "RNAS Yeovilton (United Kingdom) (EGDY / YEO)"
+  },
+  {
+    "id": "HAW",
+    "british": true,
+    "label": "Haverfordwest Airport (United Kingdom) (EGFE / HAW)"
+  },
+  {
+    "id": "CWL",
+    "british": true,
+    "label": "Cardiff International Airport (United Kingdom) (EGFF / CWL)"
+  },
+  {
+    "id": "SWS",
+    "british": true,
+    "label": "Swansea Airport (United Kingdom) (EGFH / SWS)"
+  },
+  {
+    "id": "BRS",
+    "british": true,
+    "label": "Bristol Airport (United Kingdom) (EGGD / BRS)"
+  },
+  {
+    "id": "LPL",
+    "british": true,
+    "label": "Liverpool John Lennon Airport (United Kingdom) (EGGP / LPL)"
+  },
+  {
+    "id": "LTN",
+    "british": true,
+    "label": "London Luton Airport (United Kingdom) (EGGW / LTN)"
+  },
+  {
+    "id": "PLH",
+    "british": true,
+    "label": "Plymouth City Airport (United Kingdom) (EGHD / PLH)"
+  },
+  {
+    "id": "BOH",
+    "british": true,
+    "label": "Bournemouth Airport (United Kingdom) (EGHH / BOH)"
+  },
+  {
+    "id": "SOU",
+    "british": true,
+    "label": "Southampton Airport (United Kingdom) (EGHI / SOU)"
+  },
+  {
+    "id": "QLA",
+    "british": true,
+    "label": "Lasham Airport (United Kingdom) (EGHL / QLA)"
+  },
+  {
+    "id": "ACI",
+    "british": false,
+    "label": "Alderney Airport (Guernsey) (EGJA / ACI)"
+  },
+  {
+    "id": "GCI",
+    "british": false,
+    "label": "Guernsey Airport (Guernsey) (EGJB / GCI)"
+  },
+  {
+    "id": "JER",
+    "british": false,
+    "label": "Jersey Airport (Jersey) (EGJJ / JER)"
+  },
+  {
+    "id": "ESH",
+    "british": true,
+    "label": "Shoreham Airport (United Kingdom) (EGKA / ESH)"
+  },
+  {
+    "id": "BQH",
+    "british": true,
+    "label": "London Biggin Hill Airport (United Kingdom) (EGKB / BQH)"
+  },
+  {
+    "id": "LGW",
+    "british": true,
+    "label": "London Gatwick Airport (United Kingdom) (EGKK / LGW)"
+  },
+  {
+    "id": "LCY",
+    "british": true,
+    "label": "London City Airport (United Kingdom) (EGLC / LCY)"
+  },
+  {
+    "id": "FAB",
+    "british": true,
+    "label": "Farnborough Airport (United Kingdom) (EGLF / FAB)"
+  },
+  {
+    "id": "EGLJ",
+    "british": true,
+    "label": "Chalgrove Airport (United Kingdom) (EGLJ)"
+  },
+  {
+    "id": "BBS",
+    "british": true,
+    "label": "Blackbushe Airport (United Kingdom) (EGLK / BBS)"
+  },
+  {
+    "id": "LHR",
+    "british": true,
+    "label": "London Heathrow Airport (United Kingdom) (EGLL / LHR)"
+  },
+  {
+    "id": "SEN",
+    "british": true,
+    "label": "Southend Airport (United Kingdom) (EGMC / SEN)"
+  },
+  {
+    "id": "LYX",
+    "british": true,
+    "label": "Lydd Airport (United Kingdom) (EGMD / LYX)"
+  },
+  {
+    "id": "MSE",
+    "british": true,
+    "label": "Kent International Airport (United Kingdom) (EGMH / MSE)"
+  },
+  {
+    "id": "EGNB",
+    "british": true,
+    "label": "Brough Airport (United Kingdom) (EGNB)"
+  },
+  {
+    "id": "CAX",
+    "british": true,
+    "label": "Carlisle Airport (United Kingdom) (EGNC / CAX)"
+  },
+  {
+    "id": "EGNE",
+    "british": true,
+    "label": "Retford Gamston Airport (United Kingdom) (EGNE)"
+  },
+  {
+    "id": "BLK",
+    "british": true,
+    "label": "Blackpool International Airport (United Kingdom) (EGNH / BLK)"
+  },
+  {
+    "id": "HUY",
+    "british": true,
+    "label": "Humberside Airport (United Kingdom) (EGNJ / HUY)"
+  },
+  {
+    "id": "BWF",
+    "british": true,
+    "label": "Barrow Walney Island Airport (United Kingdom) (EGNL / BWF)"
+  },
+  {
+    "id": "LBA",
+    "british": true,
+    "label": "Leeds Bradford Airport (United Kingdom) (EGNM / LBA)"
+  },
+  {
+    "id": "WRT",
+    "british": true,
+    "label": "Warton Airport (United Kingdom) (EGNO / WRT)"
+  },
+  {
+    "id": "CEG",
+    "british": true,
+    "label": "Hawarden Airport (United Kingdom) (EGNR / CEG)"
+  },
+  {
+    "id": "IOM",
+    "british": false,
+    "label": "Isle of Man Airport (Isle of Man) (EGNS / IOM)"
+  },
+  {
+    "id": "NCL",
+    "british": true,
+    "label": "Newcastle Airport (United Kingdom) (EGNT / NCL)"
+  },
+  {
+    "id": "MME",
+    "british": true,
+    "label": "Durham Tees Valley Airport (United Kingdom) (EGNV / MME)"
+  },
+  {
+    "id": "EMA",
+    "british": true,
+    "label": "East Midlands Airport (United Kingdom) (EGNX / EMA)"
+  },
+  {
+    "id": "EGOD",
+    "british": true,
+    "label": "Llanbedr Airport (United Kingdom) (EGOD)"
+  },
+  {
+    "id": "EGOE",
+    "british": true,
+    "label": "RAF Ternhill (United Kingdom) (EGOE)"
+  },
+  {
+    "id": "EGOS",
+    "british": true,
+    "label": "RAF Shawbury (United Kingdom) (EGOS)"
+  },
+  {
+    "id": "EGOW",
+    "british": true,
+    "label": "RAF Woodvale (United Kingdom) (EGOW)"
+  },
+  {
+    "id": "KOI",
+    "british": true,
+    "label": "Kirkwall Airport (United Kingdom) (EGPA / KOI)"
+  },
+  {
+    "id": "LSI",
+    "british": true,
+    "label": "Sumburgh Airport (United Kingdom) (EGPB / LSI)"
+  },
+  {
+    "id": "WIC",
+    "british": true,
+    "label": "Wick Airport (United Kingdom) (EGPC / WIC)"
+  },
+  {
+    "id": "ABZ",
+    "british": true,
+    "label": "Aberdeen Dyce Airport (United Kingdom) (EGPD / ABZ)"
+  },
+  {
+    "id": "INV",
+    "british": true,
+    "label": "Inverness Airport (United Kingdom) (EGPE / INV)"
+  },
+  {
+    "id": "GLA",
+    "british": true,
+    "label": "Glasgow International Airport (United Kingdom) (EGPF / GLA)"
+  },
+  {
+    "id": "EDI",
+    "british": true,
+    "label": "Edinburgh Airport (United Kingdom) (EGPH / EDI)"
+  },
+  {
+    "id": "ILY",
+    "british": true,
+    "label": "Islay Airport (United Kingdom) (EGPI / ILY)"
+  },
+  {
+    "id": "PIK",
+    "british": true,
+    "label": "Glasgow Prestwick Airport (United Kingdom) (EGPK / PIK)"
+  },
+  {
+    "id": "BEB",
+    "british": true,
+    "label": "Benbecula Airport (United Kingdom) (EGPL / BEB)"
+  },
+  {
+    "id": "SCS",
+    "british": true,
+    "label": "Scatsta Airport (United Kingdom) (EGPM / SCS)"
+  },
+  {
+    "id": "DND",
+    "british": true,
+    "label": "Dundee Airport (United Kingdom) (EGPN / DND)"
+  },
+  {
+    "id": "SYY",
+    "british": true,
+    "label": "Stornoway Airport (United Kingdom) (EGPO / SYY)"
+  },
+  {
+    "id": "TRE",
+    "british": true,
+    "label": "Tiree Airport (United Kingdom) (EGPU / TRE)"
+  },
+  {
+    "id": "ADX",
+    "british": true,
+    "label": "RAF Leuchars (United Kingdom) (EGQL / ADX)"
+  },
+  {
+    "id": "LMO",
+    "british": true,
+    "label": "RAF Lossiemouth (United Kingdom) (EGQS / LMO)"
+  },
+  {
+    "id": "CBG",
+    "british": true,
+    "label": "Cambridge Airport (United Kingdom) (EGSC / CBG)"
+  },
+  {
+    "id": "EGSF",
+    "british": true,
+    "label": "Peterborough Business Airport (United Kingdom) (EGSF)"
+  },
+  {
+    "id": "NWI",
+    "british": true,
+    "label": "Norwich International Airport (United Kingdom) (EGSH / NWI)"
+  },
+  {
+    "id": "STN",
+    "british": true,
+    "label": "London Stansted Airport (United Kingdom) (EGSS / STN)"
+  },
+  {
+    "id": "EGSX",
+    "british": true,
+    "label": "North Weald Airport (United Kingdom) (EGSX)"
+  },
+  {
+    "id": "EGSY",
+    "british": true,
+    "label": "Sheffield City Heliport (United Kingdom) (EGSY)"
+  },
+  {
+    "id": "EGTC",
+    "british": true,
+    "label": "Cranfield Airport (United Kingdom) (EGTC)"
+  },
+  {
+    "id": "EXT",
+    "british": true,
+    "label": "Exeter International Airport (United Kingdom) (EGTE / EXT)"
+  },
+  {
+    "id": "FZO",
+    "british": true,
+    "label": "Bristol Filton Airport (United Kingdom) (EGTG / FZO)"
+  },
+  {
+    "id": "OXF",
+    "british": true,
+    "label": "Oxford (Kidlington) Airport (United Kingdom) (EGTK / OXF)"
+  },
+  {
+    "id": "BEX",
+    "british": true,
+    "label": "RAF Benson (United Kingdom) (EGUB / BEX)"
+  },
+  {
+    "id": "LKZ",
+    "british": true,
+    "label": "RAF Lakenheath (United Kingdom) (EGUL / LKZ)"
+  },
+  {
+    "id": "MHZ",
+    "british": true,
+    "label": "RAF Mildenhall (United Kingdom) (EGUN / MHZ)"
+  },
+  {
+    "id": "EGUW",
+    "british": true,
+    "label": "RAF Wattisham (United Kingdom) (EGUW)"
+  },
+  {
+    "id": "QUY",
+    "british": true,
+    "label": "RAF Wyton (United Kingdom) (EGUY / QUY)"
+  },
+  {
+    "id": "FFD",
+    "british": true,
+    "label": "RAF Fairford (United Kingdom) (EGVA / FFD)"
+  },
+  {
+    "id": "BZZ",
+    "british": true,
+    "label": "RAF Brize Norton (United Kingdom) (EGVN / BZZ)"
+  },
+  {
+    "id": "ODH",
+    "british": true,
+    "label": "RAF Odiham (United Kingdom) (EGVO / ODH)"
+  },
+  {
+    "id": "EGWC",
+    "british": true,
+    "label": "DCAE Cosford Air Base (United Kingdom) (EGWC)"
+  },
+  {
+    "id": "NHT",
+    "british": true,
+    "label": "RAF Northolt (United Kingdom) (EGWU / NHT)"
+  },
+  {
+    "id": "QCY",
+    "british": true,
+    "label": "RAF Coningsby (United Kingdom) (EGXC / QCY)"
+  },
+  {
+    "id": "EGXD",
+    "british": true,
+    "label": "RAF Dishforth (United Kingdom) (EGXD)"
+  },
+  {
+    "id": "EGXE",
+    "british": true,
+    "label": "Leeming Airport (United Kingdom) (EGXE)"
+  },
+  {
+    "id": "EGXG",
+    "british": true,
+    "label": "Leeds East Airport (United Kingdom) (EGXG)"
+  },
+  {
+    "id": "BEQ",
+    "british": true,
+    "label": "RAF Honington (United Kingdom) (EGXH / BEQ)"
+  },
+  {
+    "id": "EGXJ",
+    "british": true,
+    "label": "RAF Cottesmore (United Kingdom) (EGXJ)"
+  },
+  {
+    "id": "SQZ",
+    "british": true,
+    "label": "RAF Scampton (United Kingdom) (EGXP / SQZ)"
+  },
+  {
+    "id": "EGXT",
+    "british": true,
+    "label": "RAF Wittering (United Kingdom) (EGXT)"
+  },
+  {
+    "id": "HRT",
+    "british": true,
+    "label": "RAF Linton-On-Ouse (United Kingdom) (EGXU / HRT)"
+  },
+  {
+    "id": "WTN",
+    "british": true,
+    "label": "RAF Waddington (United Kingdom) (EGXW / WTN)"
+  },
+  {
+    "id": "EGXZ",
+    "british": true,
+    "label": "RAF Topcliffe (United Kingdom) (EGXZ)"
+  },
+  {
+    "id": "EGYD",
+    "british": true,
+    "label": "RAF Cranwell (United Kingdom) (EGYD)"
+  },
+  {
+    "id": "EGYE",
+    "british": true,
+    "label": "RAF Barkston Heath (United Kingdom) (EGYE)"
+  },
+  {
+    "id": "KNF",
+    "british": true,
+    "label": "RAF Marham (United Kingdom) (EGYM / KNF)"
+  },
+  {
+    "id": "MPN",
+    "british": false,
+    "label": "Mount Pleasant Airport (Falkland Islands) (EGYP / MPN)"
+  },
+  {
+    "id": "AMS",
+    "british": false,
+    "label": "Amsterdam Airport Schiphol (Netherlands) (EHAM / AMS)"
+  },
+  {
+    "id": "EHBD",
+    "british": false,
+    "label": "Budel Airfield Kempen (Netherlands) (EHBD)"
+  },
+  {
+    "id": "MST",
+    "british": false,
+    "label": "Maastricht Aachen Airport (Netherlands) (EHBK / MST)"
+  },
+  {
+    "id": "EHDL",
+    "british": false,
+    "label": "Deelen Air Base (Netherlands) (EHDL)"
+  },
+  {
+    "id": "EHDR",
+    "british": false,
+    "label": "Drachten Airport (Netherlands) (EHDR)"
+  },
+  {
+    "id": "EIN",
+    "british": false,
+    "label": "Eindhoven Airport (Netherlands) (EHEH / EIN)"
+  },
+  {
+    "id": "GRQ",
+    "british": false,
+    "label": "Eelde Airport (Netherlands) (EHGG / GRQ)"
+  },
+  {
+    "id": "GLZ",
+    "british": false,
+    "label": "Gilze Rijen Air Base (Netherlands) (EHGR / GLZ)"
+  },
+  {
+    "id": "DHR",
+    "british": false,
+    "label": "De Kooy Airport (Netherlands) (EHKD / DHR)"
+  },
+  {
+    "id": "LEY",
+    "british": false,
+    "label": "Lelystad Airport (Netherlands) (EHLE / LEY)"
+  },
+  {
+    "id": "LWR",
+    "british": false,
+    "label": "Leeuwarden Air Base (Netherlands) (EHLW / LWR)"
+  },
+  {
+    "id": "RTM",
+    "british": false,
+    "label": "Rotterdam The Hague Airport (Netherlands) (EHRD / RTM)"
+  },
+  {
+    "id": "UTC",
+    "british": false,
+    "label": "Soesterberg Air Base (Netherlands) (EHSB / UTC)"
+  },
+  {
+    "id": "ENS",
+    "british": false,
+    "label": "Twente Airport (Netherlands) (EHTW / ENS)"
+  },
+  {
+    "id": "LID",
+    "british": false,
+    "label": "Valkenburg Naval Air Base (Netherlands) (EHVB / LID)"
+  },
+  {
+    "id": "WOE",
+    "british": false,
+    "label": "Woensdrecht Air Base (Netherlands) (EHWO / WOE)"
+  },
+  {
+    "id": "ORK",
+    "british": false,
+    "label": "Cork Airport (Ireland) (EICK / ORK)"
+  },
+  {
+    "id": "GWY",
+    "british": false,
+    "label": "Galway Airport (Ireland) (EICM / GWY)"
+  },
+  {
+    "id": "DUB",
+    "british": false,
+    "label": "Dublin Airport (Ireland) (EIDW / DUB)"
+  },
+  {
+    "id": "NOC",
+    "british": false,
+    "label": "Ireland West Knock Airport (Ireland) (EIKN / NOC)"
+  },
+  {
+    "id": "KIR",
+    "british": false,
+    "label": "Kerry Airport (Ireland) (EIKY / KIR)"
+  },
+  {
+    "id": "EIME",
+    "british": false,
+    "label": "Casement Air Base (Ireland) (EIME)"
+  },
+  {
+    "id": "SNN",
+    "british": false,
+    "label": "Shannon Airport (Ireland) (EINN / SNN)"
+  },
+  {
+    "id": "SXL",
+    "british": false,
+    "label": "Sligo Airport (Ireland) (EISG / SXL)"
+  },
+  {
+    "id": "WAT",
+    "british": false,
+    "label": "Waterford Airport (Ireland) (EIWF / WAT)"
+  },
+  {
+    "id": "AAR",
+    "british": false,
+    "label": "Aarhus Airport (Denmark) (EKAH / AAR)"
+  },
+  {
+    "id": "BLL",
+    "british": false,
+    "label": "Billund Airport (Denmark) (EKBI / BLL)"
+  },
+  {
+    "id": "CPH",
+    "british": false,
+    "label": "Copenhagen Kastrup Airport (Denmark) (EKCH / CPH)"
+  },
+  {
+    "id": "EBJ",
+    "british": false,
+    "label": "Esbjerg Airport (Denmark) (EKEB / EBJ)"
+  },
+  {
+    "id": "EKGH",
+    "british": false,
+    "label": "Grønholt Hillerød Airport (Denmark) (EKGH)"
+  },
+  {
+    "id": "KRP",
+    "british": false,
+    "label": "Karup Airport (Denmark) (EKKA / KRP)"
+  },
+  {
+    "id": "BYR",
+    "british": false,
+    "label": "Læsø Airport (Denmark) (EKLS / BYR)"
+  },
+  {
+    "id": "MRW",
+    "british": false,
+    "label": "Lolland Falster Maribo Airport (Denmark) (EKMB / MRW)"
+  },
+  {
+    "id": "ODE",
+    "british": false,
+    "label": "Odense Airport (Denmark) (EKOD / ODE)"
+  },
+  {
+    "id": "EKPB",
+    "british": false,
+    "label": "Kruså-Padborg Airport (Denmark) (EKPB)"
+  },
+  {
+    "id": "RKE",
+    "british": false,
+    "label": "Copenhagen Roskilde Airport (Denmark) (EKRK / RKE)"
+  },
+  {
+    "id": "RNN",
+    "british": false,
+    "label": "Bornholm Airport (Denmark) (EKRN / RNN)"
+  },
+  {
+    "id": "SGD",
+    "british": false,
+    "label": "Sønderborg Airport (Denmark) (EKSB / SGD)"
+  },
+  {
+    "id": "SKS",
+    "british": false,
+    "label": "Skrydstrup Air Base (Denmark) (EKSP / SKS)"
+  },
+  {
+    "id": "SQW",
+    "british": false,
+    "label": "Skive Airport (Denmark) (EKSV / SQW)"
+  },
+  {
+    "id": "TED",
+    "british": false,
+    "label": "Thisted Airport (Denmark) (EKTS / TED)"
+  },
+  {
+    "id": "EKVD",
+    "british": false,
+    "label": "Kolding Vamdrup Airfield (Denmark) (EKVD)"
+  },
+  {
+    "id": "FAE",
+    "british": false,
+    "label": "Vagar Airport (Faroe Islands) (EKVG / FAE)"
+  },
+  {
+    "id": "EKVH",
+    "british": false,
+    "label": "Vesthimmerlands Flyveplads (Denmark) (EKVH)"
+  },
+  {
+    "id": "STA",
+    "british": false,
+    "label": "Stauning Airport (Denmark) (EKVJ / STA)"
+  },
+  {
+    "id": "AAL",
+    "british": false,
+    "label": "Aalborg Airport (Denmark) (EKYT / AAL)"
+  },
+  {
+    "id": "LUX",
+    "british": false,
+    "label": "Luxembourg-Findel International Airport (Luxembourg) (ELLX / LUX)"
+  },
+  {
+    "id": "AES",
+    "british": false,
+    "label": "Ålesund Airport (Norway) (ENAL / AES)"
+  },
+  {
+    "id": "ANX",
+    "british": false,
+    "label": "Andøya Airport (Norway) (ENAN / ANX)"
+  },
+  {
+    "id": "ALF",
+    "british": false,
+    "label": "Alta Airport (Norway) (ENAT / ALF)"
+  },
+  {
+    "id": "ENBM",
+    "british": false,
+    "label": "Bømoen Airport (Norway) (ENBM)"
+  },
+  {
+    "id": "BNN",
+    "british": false,
+    "label": "Brønnøysund Airport (Norway) (ENBN / BNN)"
+  },
+  {
+    "id": "BOO",
+    "british": false,
+    "label": "Bodø Airport (Norway) (ENBO / BOO)"
+  },
+  {
+    "id": "BGO",
+    "british": false,
+    "label": "Bergen Airport Flesland (Norway) (ENBR / BGO)"
+  },
+  {
+    "id": "BJF",
+    "british": false,
+    "label": "Båtsfjord Airport (Norway) (ENBS / BJF)"
+  },
+  {
+    "id": "KRS",
+    "british": false,
+    "label": "Kristiansand Airport (Norway) (ENCN / KRS)"
+  },
+  {
+    "id": "DLD",
+    "british": false,
+    "label": "Geilo Airport Dagali (Norway) (ENDI / DLD)"
+  },
+  {
+    "id": "BDU",
+    "british": false,
+    "label": "Bardufoss Airport (Norway) (ENDU / BDU)"
+  },
+  {
+    "id": "EVE",
+    "british": false,
+    "label": "Harstad/Narvik Airport, Evenes (Norway) (ENEV / EVE)"
+  },
+  {
+    "id": "VDB",
+    "british": false,
+    "label": "Leirin Airport (Norway) (ENFG / VDB)"
+  },
+  {
+    "id": "FRO",
+    "british": false,
+    "label": "Florø Airport (Norway) (ENFL / FRO)"
+  },
+  {
+    "id": "OSL",
+    "british": false,
+    "label": "Oslo Lufthavn (Norway) (ENGM / OSL)"
+  },
+  {
+    "id": "HAU",
+    "british": false,
+    "label": "Haugesund Airport (Norway) (ENHD / HAU)"
+  },
+  {
+    "id": "HAA",
+    "british": false,
+    "label": "Hasvik Airport (Norway) (ENHK / HAA)"
+  },
+  {
+    "id": "KSU",
+    "british": false,
+    "label": "Kristiansund Airport (Kvernberget) (Norway) (ENKB / KSU)"
+  },
+  {
+    "id": "ENKJ",
+    "british": false,
+    "label": "Kjeller Airport (Norway) (ENKJ)"
+  },
+  {
+    "id": "KKN",
+    "british": false,
+    "label": "Kirkenes Airport (Høybuktmoen) (Norway) (ENKR / KKN)"
+  },
+  {
+    "id": "FAN",
+    "british": false,
+    "label": "Lista Airport (Norway) (ENLI / FAN)"
+  },
+  {
+    "id": "MOL",
+    "british": false,
+    "label": "Molde Airport (Norway) (ENML / MOL)"
+  },
+  {
+    "id": "MJF",
+    "british": false,
+    "label": "Mosjøen Airport (Kjærstad) (Norway) (ENMS / MJF)"
+  },
+  {
+    "id": "LKL",
+    "british": false,
+    "label": "Banak Airport (Norway) (ENNA / LKL)"
+  },
+  {
+    "id": "NTB",
+    "british": false,
+    "label": "Notodden Airport (Norway) (ENNO / NTB)"
+  },
+  {
+    "id": "OLA",
+    "british": false,
+    "label": "Ørland Airport (Norway) (ENOL / OLA)"
+  },
+  {
+    "id": "RRS",
+    "british": false,
+    "label": "Røros Airport (Norway) (ENRO / RRS)"
+  },
+  {
+    "id": "RYG",
+    "british": false,
+    "label": "Moss Airport, Rygge (Norway) (ENRY / RYG)"
+  },
+  {
+    "id": "LYR",
+    "british": false,
+    "label": "Svalbard Airport, Longyear (Norway) (ENSB / LYR)"
+  },
+  {
+    "id": "SKE",
+    "british": false,
+    "label": "Skien Airport (Norway) (ENSN / SKE)"
+  },
+  {
+    "id": "SRP",
+    "british": false,
+    "label": "Stord Airport (Norway) (ENSO / SRP)"
+  },
+  {
+    "id": "SSJ",
+    "british": false,
+    "label": "Sandnessjøen Airport (Stokka) (Norway) (ENST / SSJ)"
+  },
+  {
+    "id": "TOS",
+    "british": false,
+    "label": "Tromsø Airport, (Norway) (ENTC / TOS)"
+  },
+  {
+    "id": "TRF",
+    "british": false,
+    "label": "Sandefjord Airport, Torp (Norway) (ENTO / TRF)"
+  },
+  {
+    "id": "TRD",
+    "british": false,
+    "label": "Trondheim Airport Værnes (Norway) (ENVA / TRD)"
+  },
+  {
+    "id": "SVG",
+    "british": false,
+    "label": "Stavanger Airport Sola (Norway) (ENZV / SVG)"
+  },
+  {
+    "id": "EPBC",
+    "british": false,
+    "label": "Babice Airport (Poland) (EPBC)"
+  },
+  {
+    "id": "GDN",
+    "british": false,
+    "label": "Gdańsk Lech Wałęsa Airport (Poland) (EPGD / GDN)"
+  },
+  {
+    "id": "KRK",
+    "british": false,
+    "label": "Kraków John Paul II International Airport (Poland) (EPKK / KRK)"
+  },
+  {
+    "id": "EPKM",
+    "british": false,
+    "label": "Muchowiec Airport (Poland) (EPKM)"
+  },
+  {
+    "id": "KTW",
+    "british": false,
+    "label": "Katowice International Airport (Poland) (EPKT / KTW)"
+  },
+  {
+    "id": "EPML",
+    "british": false,
+    "label": "Mielec Airport (Poland) (EPML)"
+  },
+  {
+    "id": "POZ",
+    "british": false,
+    "label": "Poznań-Ławica Airport (Poland) (EPPO / POZ)"
+  },
+  {
+    "id": "RZE",
+    "british": false,
+    "label": "Rzeszów-Jasionka Airport (Poland) (EPRZ / RZE)"
+  },
+  {
+    "id": "SZZ",
+    "british": false,
+    "label": "Szczecin-Goleniów \"Solidarność\" Airport (Poland) (EPSC / SZZ)"
+  },
+  {
+    "id": "OSP",
+    "british": false,
+    "label": "Redzikowo Air Base (Poland) (EPSK / OSP)"
+  },
+  {
+    "id": "EPSN",
+    "british": false,
+    "label": "Swidwin Military Air Base (Poland) (EPSN)"
+  },
+  {
+    "id": "WAW",
+    "british": false,
+    "label": "Warsaw Chopin Airport (Poland) (EPWA / WAW)"
+  },
+  {
+    "id": "WRO",
+    "british": false,
+    "label": "Copernicus Wrocław Airport (Poland) (EPWR / WRO)"
+  },
+  {
+    "id": "IEG",
+    "british": false,
+    "label": "Zielona Góra-Babimost Airport (Poland) (EPZG / IEG)"
+  },
+  {
+    "id": "ESCF",
+    "british": false,
+    "label": "Malmen Air Base (Sweden) (ESCF)"
+  },
+  {
+    "id": "ESCK",
+    "british": false,
+    "label": "Bråvalla Air Base (Sweden) (ESCK)"
+  },
+  {
+    "id": "ESCM",
+    "british": false,
+    "label": "Uppsala Airport (Sweden) (ESCM)"
+  },
+  {
+    "id": "RNB",
+    "british": false,
+    "label": "Ronneby Airport (Sweden) (ESDF / RNB)"
+  },
+  {
+    "id": "ESFR",
+    "british": false,
+    "label": "Råda Air Base (Sweden) (ESFR)"
+  },
+  {
+    "id": "GOT",
+    "british": false,
+    "label": "Gothenburg-Landvetter Airport (Sweden) (ESGG / GOT)"
+  },
+  {
+    "id": "JKG",
+    "british": false,
+    "label": "Jönköping Airport (Sweden) (ESGJ / JKG)"
+  },
+  {
+    "id": "ESGK",
+    "british": false,
+    "label": "Falköping Airport (Sweden) (ESGK)"
+  },
+  {
+    "id": "LDK",
+    "british": false,
+    "label": "Lidköping-Hovby Airport (Sweden) (ESGL / LDK)"
+  },
+  {
+    "id": "GSE",
+    "british": false,
+    "label": "Gothenburg City Airport (Sweden) (ESGP / GSE)"
+  },
+  {
+    "id": "KVB",
+    "british": false,
+    "label": "Skövde Airport (Sweden) (ESGR / KVB)"
+  },
+  {
+    "id": "THN",
+    "british": false,
+    "label": "Trollhättan-Vänersborg Airport (Sweden) (ESGT / THN)"
+  },
+  {
+    "id": "ESIA",
+    "british": false,
+    "label": "Karlsborg Air Base (Sweden) (ESIA)"
+  },
+  {
+    "id": "ESIB",
+    "british": false,
+    "label": "Såtenäs Air Base (Sweden) (ESIB)"
+  },
+  {
+    "id": "ESKB",
+    "british": false,
+    "label": "Barkarby Airport (Sweden) (ESKB)"
+  },
+  {
+    "id": "KSK",
+    "british": false,
+    "label": "Karlskoga Airport (Sweden) (ESKK / KSK)"
+  },
+  {
+    "id": "MXX",
+    "british": false,
+    "label": "Mora Airport (Sweden) (ESKM / MXX)"
+  },
+  {
+    "id": "NYO",
+    "british": false,
+    "label": "Stockholm Skavsta Airport (Sweden) (ESKN / NYO)"
+  },
+  {
+    "id": "ESKV",
+    "british": false,
+    "label": "Arvika Airport (Sweden) (ESKV)"
+  },
+  {
+    "id": "ESMA",
+    "british": false,
+    "label": "Emmaboda Airfield (Sweden) (ESMA)"
+  },
+  {
+    "id": "ESMG",
+    "british": false,
+    "label": "Feringe Airport (Sweden) (ESMG)"
+  },
+  {
+    "id": "KID",
+    "british": false,
+    "label": "Kristianstad Airport (Sweden) (ESMK / KID)"
+  },
+  {
+    "id": "ESML",
+    "british": false,
+    "label": "Landskrona Airport (Sweden) (ESML)"
+  },
+  {
+    "id": "OSK",
+    "british": false,
+    "label": "Oskarshamn Airport (Sweden) (ESMO / OSK)"
+  },
+  {
+    "id": "ESMP",
+    "british": false,
+    "label": "Anderstorp Airport (Sweden) (ESMP)"
+  },
+  {
+    "id": "KLR",
+    "british": false,
+    "label": "Kalmar Airport (Sweden) (ESMQ / KLR)"
+  },
+  {
+    "id": "MMX",
+    "british": false,
+    "label": "Malmö Sturup Airport (Sweden) (ESMS / MMX)"
+  },
+  {
+    "id": "HAD",
+    "british": false,
+    "label": "Halmstad Airport (Sweden) (ESMT / HAD)"
+  },
+  {
+    "id": "ESMV",
+    "british": false,
+    "label": "Hagshult Air Base (Sweden) (ESMV)"
+  },
+  {
+    "id": "VXO",
+    "british": false,
+    "label": "Växjö Kronoberg Airport (Sweden) (ESMX / VXO)"
+  },
+  {
+    "id": "ESNA",
+    "british": false,
+    "label": "Hallviken Airport (Sweden) (ESNA)"
+  },
+  {
+    "id": "ESNC",
+    "british": false,
+    "label": "Hedlanda Airport (Sweden) (ESNC)"
+  },
+  {
+    "id": "EVG",
+    "british": false,
+    "label": "Sveg Airport (Sweden) (ESND / EVG)"
+  },
+  {
+    "id": "GEV",
+    "british": false,
+    "label": "Gällivare Airport (Sweden) (ESNG / GEV)"
+  },
+  {
+    "id": "HUV",
+    "british": false,
+    "label": "Hudiksvall Airport (Sweden) (ESNH / HUV)"
+  },
+  {
+    "id": "ESNJ",
+    "british": false,
+    "label": "Jokkmokk Airport (Sweden) (ESNJ)"
+  },
+  {
+    "id": "KRF",
+    "british": false,
+    "label": "Kramfors Sollefteå Airport (Sweden) (ESNK / KRF)"
+  },
+  {
+    "id": "LYC",
+    "british": false,
+    "label": "Lycksele Airport (Sweden) (ESNL / LYC)"
+  },
+  {
+    "id": "ESNM",
+    "british": false,
+    "label": "Optand Airport (Sweden) (ESNM)"
+  },
+  {
+    "id": "SDL",
+    "british": false,
+    "label": "Sundsvall-Härnösand Airport (Sweden) (ESNN / SDL)"
+  },
+  {
+    "id": "OER",
+    "british": false,
+    "label": "Örnsköldsvik Airport (Sweden) (ESNO / OER)"
+  },
+  {
+    "id": "ESNP",
+    "british": false,
+    "label": "Piteå Airport (Sweden) (ESNP)"
+  },
+  {
+    "id": "KRN",
+    "british": false,
+    "label": "Kiruna Airport (Sweden) (ESNQ / KRN)"
+  },
+  {
+    "id": "ESNR",
+    "british": false,
+    "label": "Orsa Airport (Sweden) (ESNR)"
+  },
+  {
+    "id": "SFT",
+    "british": false,
+    "label": "Skellefteå Airport (Sweden) (ESNS / SFT)"
+  },
+  {
+    "id": "ESNT",
+    "british": false,
+    "label": "Sättna Airport (Sweden) (ESNT)"
+  },
+  {
+    "id": "UME",
+    "british": false,
+    "label": "Umeå Airport (Sweden) (ESNU / UME)"
+  },
+  {
+    "id": "VHM",
+    "british": false,
+    "label": "Vilhelmina Airport (Sweden) (ESNV / VHM)"
+  },
+  {
+    "id": "AJR",
+    "british": false,
+    "label": "Arvidsjaur Airport (Sweden) (ESNX / AJR)"
+  },
+  {
+    "id": "ORB",
+    "british": false,
+    "label": "Örebro Airport (Sweden) (ESOE / ORB)"
+  },
+  {
+    "id": "VST",
+    "british": false,
+    "label": "Stockholm Västerås Airport (Sweden) (ESOW / VST)"
+  },
+  {
+    "id": "LLA",
+    "british": false,
+    "label": "Luleå Airport (Sweden) (ESPA / LLA)"
+  },
+  {
+    "id": "ESPE",
+    "british": false,
+    "label": "Vidsel Air Base (Sweden) (ESPE)"
+  },
+  {
+    "id": "ESQO",
+    "british": false,
+    "label": "Arboga Airport (Sweden) (ESQO)"
+  },
+  {
+    "id": "ARN",
+    "british": false,
+    "label": "Stockholm-Arlanda Airport (Sweden) (ESSA / ARN)"
+  },
+  {
+    "id": "BMA",
+    "british": false,
+    "label": "Stockholm-Bromma Airport (Sweden) (ESSB / BMA)"
+  },
+  {
+    "id": "BLE",
+    "british": false,
+    "label": "Borlange Airport (Sweden) (ESSD / BLE)"
+  },
+  {
+    "id": "HLF",
+    "british": false,
+    "label": "Hultsfred Airport (Sweden) (ESSF / HLF)"
+  },
+  {
+    "id": "GVX",
+    "british": false,
+    "label": "Gävle Sandviken Airport (Sweden) (ESSK / GVX)"
+  },
+  {
+    "id": "LPI",
+    "british": false,
+    "label": "Linköping City Airport (Sweden) (ESSL / LPI)"
+  },
+  {
+    "id": "NRK",
+    "british": false,
+    "label": "Norrköping Airport (Sweden) (ESSP / NRK)"
+  },
+  {
+    "id": "EKT",
+    "british": false,
+    "label": "Eskilstuna Airport (Sweden) (ESSU / EKT)"
+  },
+  {
+    "id": "VBY",
+    "british": false,
+    "label": "Visby Airport (Sweden) (ESSV / VBY)"
+  },
+  {
+    "id": "ESUK",
+    "british": false,
+    "label": "Kalixfors Airport (Sweden) (ESUK)"
+  },
+  {
+    "id": "SPM",
+    "british": false,
+    "label": "Spangdahlem Air Base (Germany) (ETAD / SPM)"
+  },
+  {
+    "id": "RMS",
+    "british": false,
+    "label": "Ramstein Air Base (Germany) (ETAR / RMS)"
+  },
+  {
+    "id": "GHF",
+    "british": false,
+    "label": "[Duplicate] Giebelstadt Army Air Field (Germany) (ETEU / GHF)"
+  },
+  {
+    "id": "ETHB",
+    "british": false,
+    "label": "Bückeburg Air Base (Germany) (ETHB)"
+  },
+  {
+    "id": "ZCN",
+    "british": false,
+    "label": "Celle Airport (Germany) (ETHC / ZCN)"
+  },
+  {
+    "id": "ETHE",
+    "british": false,
+    "label": "Rheine Bentlage Air Base (Germany) (ETHE)"
+  },
+  {
+    "id": "FRZ",
+    "british": false,
+    "label": "Fritzlar Airport (Germany) (ETHF / FRZ)"
+  },
+  {
+    "id": "ETHL",
+    "british": false,
+    "label": "Laupheim Air Base (Germany) (ETHL)"
+  },
+  {
+    "id": "ETHM",
+    "british": false,
+    "label": "Mendig Airfield (Germany) (ETHM)"
+  },
+  {
+    "id": "ETHN",
+    "british": false,
+    "label": "Niederstetten Army Air Base (Germany) (ETHN)"
+  },
+  {
+    "id": "ETHR",
+    "british": false,
+    "label": "Roth Airport (Germany) (ETHR)"
+  },
+  {
+    "id": "ETHS",
+    "british": false,
+    "label": "Fassberg Air Base (Germany) (ETHS)"
+  },
+  {
+    "id": "ETIC",
+    "british": false,
+    "label": "Grafenwohr Army Air Field (Germany) (ETIC)"
+  },
+  {
+    "id": "ZNF",
+    "british": false,
+    "label": "Hanau Army Air Field (Germany) (ETID / ZNF)"
+  },
+  {
+    "id": "ETIH",
+    "british": false,
+    "label": "Hohenfels Army Air Field (Germany) (ETIH)"
+  },
+  {
+    "id": "KZG",
+    "british": false,
+    "label": "Flugplatz Kitzingen (Germany) (ETIN / KZG)"
+  },
+  {
+    "id": "FCN",
+    "british": false,
+    "label": "Nordholz Naval Airbase (Germany) (ETMN / FCN)"
+  },
+  {
+    "id": "ETND",
+    "british": false,
+    "label": "Diepholz Air Base (Germany) (ETND)"
+  },
+  {
+    "id": "GKE",
+    "british": false,
+    "label": "Geilenkirchen Air Base (Germany) (ETNG / GKE)"
+  },
+  {
+    "id": "ETNH",
+    "british": false,
+    "label": "Hohn Air Base (Germany) (ETNH)"
+  },
+  {
+    "id": "ETNJ",
+    "british": false,
+    "label": "Jever Air Base (Germany) (ETNJ)"
+  },
+  {
+    "id": "RLG",
+    "british": false,
+    "label": "Rostock-Laage Airport (Germany) (ETNL / RLG)"
+  },
+  {
+    "id": "ETNN",
+    "british": false,
+    "label": "Nörvenich Air Base (Germany) (ETNN)"
+  },
+  {
+    "id": "WBG",
+    "british": false,
+    "label": "Schleswig Air Base (Germany) (ETNS / WBG)"
+  },
+  {
+    "id": "ETNT",
+    "british": false,
+    "label": "Wittmundhafen Airport (Germany) (ETNT)"
+  },
+  {
+    "id": "ETNW",
+    "british": false,
+    "label": "Wunstorf Air Base (Germany) (ETNW)"
+  },
+  {
+    "id": "ETOI",
+    "british": false,
+    "label": "Vilseck Army Air Field (Germany) (ETOI)"
+  },
+  {
+    "id": "ETOR",
+    "british": false,
+    "label": "Coleman Army Air Field (Germany) (ETOR)"
+  },
+  {
+    "id": "WIE",
+    "british": false,
+    "label": "Wiesbaden Army Airfield (Germany) (ETOU / WIE)"
+  },
+  {
+    "id": "ETSA",
+    "british": false,
+    "label": "Landsberg Lech Air Base (Germany) (ETSA)"
+  },
+  {
+    "id": "ETSB",
+    "british": false,
+    "label": "Büchel Air Base (Germany) (ETSB)"
+  },
+  {
+    "id": "ETSE",
+    "british": false,
+    "label": "Erding Airport (Germany) (ETSE)"
+  },
+  {
+    "id": "FEL",
+    "british": false,
+    "label": "Fürstenfeldbruck Air Base (Germany) (ETSF / FEL)"
+  },
+  {
+    "id": "ETSH",
+    "british": false,
+    "label": "Holzdorf Air Base (Germany) (ETSH)"
+  },
+  {
+    "id": "IGS",
+    "british": false,
+    "label": "Ingolstadt Manching Airport (Germany) (ETSI / IGS)"
+  },
+  {
+    "id": "ETSL",
+    "british": false,
+    "label": "Lechfeld Air Base (Germany) (ETSL)"
+  },
+  {
+    "id": "ETSN",
+    "british": false,
+    "label": "Neuburg AFB (Germany) (ETSN)"
+  },
+  {
+    "id": "GUT",
+    "british": false,
+    "label": "Gütersloh Air Base (Germany) (ETUO / GUT)"
+  },
+  {
+    "id": "ALJ",
+    "british": false,
+    "label": "Alexander Bay Airport (South Africa) (FAAB / ALJ)"
+  },
+  {
+    "id": "AGZ",
+    "british": false,
+    "label": "Aggeneys Airport (South Africa) (FAAG / AGZ)"
+  },
+  {
+    "id": "FABB",
+    "british": false,
+    "label": "Brakpan Airport (South Africa) (FABB)"
+  },
+  {
+    "id": "BIY",
+    "british": false,
+    "label": "Bisho Airport (South Africa) (FABE / BIY)"
+  },
+  {
+    "id": "BFN",
+    "british": false,
+    "label": "Bram Fischer International Airport (South Africa) (FABL / BFN)"
+  },
+  {
+    "id": "FABM",
+    "british": false,
+    "label": "Bethlehem Airport (South Africa) (FABM)"
+  },
+  {
+    "id": "FABO",
+    "british": false,
+    "label": "Hendrik Potgieter Airport (South Africa) (FABO)"
+  },
+  {
+    "id": "CPT",
+    "british": false,
+    "label": "Cape Town International Airport (South Africa) (FACT / CPT)"
+  },
+  {
+    "id": "FACV",
+    "british": false,
+    "label": "Calvinia Airport (South Africa) (FACV)"
+  },
+  {
+    "id": "DUR",
+    "british": false,
+    "label": "King Shaka International Airport (South Africa) (FALE / DUR)"
+  },
+  {
+    "id": "ELS",
+    "british": false,
+    "label": "Ben Schoeman Airport (South Africa) (FAEL / ELS)"
+  },
+  {
+    "id": "FAEO",
+    "british": false,
+    "label": "Ermelo Airport (South Africa) (FAEO)"
+  },
+  {
+    "id": "FCB",
+    "british": false,
+    "label": "Ficksburg Sentraoes Airport (South Africa) (FAFB / FCB)"
+  },
+  {
+    "id": "GCJ",
+    "british": false,
+    "label": "Grand Central Airport (South Africa) (FAGC / GCJ)"
+  },
+  {
+    "id": "GRJ",
+    "british": false,
+    "label": "George Airport (South Africa) (FAGG / GRJ)"
+  },
+  {
+    "id": "FAGR",
+    "british": false,
+    "label": "Graaff Reinet Airport (South Africa) (FAGR)"
+  },
+  {
+    "id": "FAGT",
+    "british": false,
+    "label": "Grahamstown Airport (South Africa) (FAGT)"
+  },
+  {
+    "id": "FAGY",
+    "british": false,
+    "label": "Greytown Airport (South Africa) (FAGY)"
+  },
+  {
+    "id": "FAHA",
+    "british": false,
+    "label": "Harmony Airport (South Africa) (FAHA)"
+  },
+  {
+    "id": "HRS",
+    "british": false,
+    "label": "Harrismith Airport (South Africa) (FAHR / HRS)"
+  },
+  {
+    "id": "HDS",
+    "british": false,
+    "label": "Hoedspruit Air Force Base Airport (South Africa) (FAHS / HDS)"
+  },
+  {
+    "id": "FAHV",
+    "british": false,
+    "label": "Gariep Dam Airport (South Africa) (FAHV)"
+  },
+  {
+    "id": "JNB",
+    "british": false,
+    "label": "OR Tambo International Airport (South Africa) (FAOR / JNB)"
+  },
+  {
+    "id": "KXE",
+    "british": false,
+    "label": "P C Pelser Airport (South Africa) (FAKD / KXE)"
+  },
+  {
+    "id": "KIM",
+    "british": false,
+    "label": "Kimberley Airport (South Africa) (FAKM / KIM)"
+  },
+  {
+    "id": "FAKR",
+    "british": false,
+    "label": "Krugersdorp Airport (South Africa) (FAKR)"
+  },
+  {
+    "id": "FAKS",
+    "british": false,
+    "label": "Kroonstad Airport (South Africa) (FAKS)"
+  },
+  {
+    "id": "KMH",
+    "british": false,
+    "label": "Johan Pienaar Airport (South Africa) (FAKU / KMH)"
+  },
+  {
+    "id": "KLZ",
+    "british": false,
+    "label": "Kleinsee Airport (South Africa) (FAKZ / KLZ)"
+  },
+  {
+    "id": "HLA",
+    "british": false,
+    "label": "Lanseria Airport (South Africa) (FALA / HLA)"
+  },
+  {
+    "id": "FALI",
+    "british": false,
+    "label": "Lichtenburg Airport (South Africa) (FALI)"
+  },
+  {
+    "id": "FALM",
+    "british": false,
+    "label": "Makhado Air Force Base Airport (South Africa) (FALM)"
+  },
+  {
+    "id": "SDB",
+    "british": false,
+    "label": "Langebaanweg Airport (South Africa) (FALW / SDB)"
+  },
+  {
+    "id": "LAY",
+    "british": false,
+    "label": "Ladysmith Airport (South Africa) (FALY / LAY)"
+  },
+  {
+    "id": "FAMB",
+    "british": false,
+    "label": "Middelburg Airport (South Africa) (FAMB)"
+  },
+  {
+    "id": "MGH",
+    "british": false,
+    "label": "Margate Airport (South Africa) (FAMG / MGH)"
+  },
+  {
+    "id": "FAMI",
+    "british": false,
+    "label": "Marble Hall Airport (South Africa) (FAMI)"
+  },
+  {
+    "id": "FAMJ",
+    "british": false,
+    "label": "Majuba Power Station Airport (South Africa) (FAMJ)"
+  },
+  {
+    "id": "LLE",
+    "british": false,
+    "label": "Riverside Airport (South Africa) (FAMN / LLE)"
+  },
+  {
+    "id": "FAMS",
+    "british": false,
+    "label": "Morningside Farm Airport (South Africa) (FAMS)"
+  },
+  {
+    "id": "MZQ",
+    "british": false,
+    "label": "Mkuze Airport (South Africa) (FAMU / MZQ)"
+  },
+  {
+    "id": "NCS",
+    "british": false,
+    "label": "Newcastle Airport (South Africa) (FANC / NCS)"
+  },
+  {
+    "id": "FANY",
+    "british": false,
+    "label": "Nylstroom Airfield (South Africa) (FANY)"
+  },
+  {
+    "id": "OVG",
+    "british": false,
+    "label": "Overberg Airport (South Africa) (FAOB / OVG)"
+  },
+  {
+    "id": "OUH",
+    "british": false,
+    "label": "Oudtshoorn Airport (South Africa) (FAOH / OUH)"
+  },
+  {
+    "id": "PLZ",
+    "british": false,
+    "label": "Port Elizabeth Airport (South Africa) (FAPE / PLZ)"
+  },
+  {
+    "id": "PBZ",
+    "british": false,
+    "label": "Plettenberg Bay Airport (South Africa) (FAPG / PBZ)"
+  },
+  {
+    "id": "PHW",
+    "british": false,
+    "label": "Hendrik Van Eck Airport (South Africa) (FAPH / PHW)"
+  },
+  {
+    "id": "FAPI",
+    "british": false,
+    "label": "Pietersburg Municipal Airport (South Africa) (FAPI)"
+  },
+  {
+    "id": "JOH",
+    "british": false,
+    "label": "Port St Johns Airport (South Africa) (FAPJ / JOH)"
+  },
+  {
+    "id": "PZB",
+    "british": false,
+    "label": "Pietermaritzburg Airport (South Africa) (FAPM / PZB)"
+  },
+  {
+    "id": "NTY",
+    "british": false,
+    "label": "Pilanesberg International Airport (South Africa) (FAPN / NTY)"
+  },
+  {
+    "id": "PTG",
+    "british": false,
+    "label": "Polokwane International Airport (South Africa) (FAPP / PTG)"
+  },
+  {
+    "id": "PCF",
+    "british": false,
+    "label": "Potchefstroom Airport (South Africa) (FAPS / PCF)"
+  },
+  {
+    "id": "FAPY",
+    "british": false,
+    "label": "Parys Airport (South Africa) (FAPY)"
+  },
+  {
+    "id": "UTW",
+    "british": false,
+    "label": "Queenstown Airport (South Africa) (FAQT / UTW)"
+  },
+  {
+    "id": "RCB",
+    "british": false,
+    "label": "Richards Bay Airport (South Africa) (FARB / RCB)"
+  },
+  {
+    "id": "FARG",
+    "british": false,
+    "label": "Rustenburg Airport (South Africa) (FARG)"
+  },
+  {
+    "id": "ROD",
+    "british": false,
+    "label": "Robertson Airport (South Africa) (FARS / ROD)"
+  },
+  {
+    "id": "SBU",
+    "british": false,
+    "label": "Springbok Airport (South Africa) (FASB / SBU)"
+  },
+  {
+    "id": "ZEC",
+    "british": false,
+    "label": "Secunda Airport (South Africa) (FASC / ZEC)"
+  },
+  {
+    "id": "FASD",
+    "british": false,
+    "label": "Saldanha /Vredenburg Airport (South Africa) (FASD)"
+  },
+  {
+    "id": "FASI",
+    "british": false,
+    "label": "Springs Airfield (South Africa) (FASI)"
+  },
+  {
+    "id": "FASK",
+    "british": false,
+    "label": "Swartkop Air Force Base (South Africa) (FASK)"
+  },
+  {
+    "id": "SIS",
+    "british": false,
+    "label": "Sishen Airport (South Africa) (FASS / SIS)"
+  },
+  {
+    "id": "FASX",
+    "british": false,
+    "label": "Hendrik Swellengrebel Airport (South Africa) (FASX)"
+  },
+  {
+    "id": "SZK",
+    "british": false,
+    "label": "Skukuza Airport (South Africa) (FASZ / SZK)"
+  },
+  {
+    "id": "FATF",
+    "british": false,
+    "label": "Tommys Field Airport (South Africa) (FATF)"
+  },
+  {
+    "id": "FATP",
+    "british": false,
+    "label": "New Tempe Airport (South Africa) (FATP)"
+  },
+  {
+    "id": "FATT",
+    "british": false,
+    "label": "Tutuka Power Station Airport (South Africa) (FATT)"
+  },
+  {
+    "id": "LTA",
+    "british": false,
+    "label": "Tzaneen Airport (South Africa) (FATZ / LTA)"
+  },
+  {
+    "id": "ULD",
+    "british": false,
+    "label": "Prince Mangosuthu Buthelezi Airport (South Africa) (FAUL / ULD)"
+  },
+  {
+    "id": "UTN",
+    "british": false,
+    "label": "Pierre Van Ryneveld Airport (South Africa) (FAUP / UTN)"
+  },
+  {
+    "id": "UTT",
+    "british": false,
+    "label": "K. D. Matanzima Airport (South Africa) (FAUT / UTT)"
+  },
+  {
+    "id": "VRU",
+    "british": false,
+    "label": "Vryburg Airport (South Africa) (FAVB / VRU)"
+  },
+  {
+    "id": "VIR",
+    "british": false,
+    "label": "Virginia Airport (South Africa) (FAVG / VIR)"
+  },
+  {
+    "id": "VRE",
+    "british": false,
+    "label": "Vredendal Airport (South Africa) (FAVR / VRE)"
+  },
+  {
+    "id": "FAVV",
+    "british": false,
+    "label": "Vereeniging Airport (South Africa) (FAVV)"
+  },
+  {
+    "id": "PRY",
+    "british": false,
+    "label": "Wonderboom Airport (South Africa) (FAWB / PRY)"
+  },
+  {
+    "id": "FAWI",
+    "british": false,
+    "label": "Witbank Airport (South Africa) (FAWI)"
+  },
+  {
+    "id": "WKF",
+    "british": false,
+    "label": "Waterkloof Air Force Base (South Africa) (FAWK / WKF)"
+  },
+  {
+    "id": "FAWM",
+    "british": false,
+    "label": "Welkom Airport (South Africa) (FAWM)"
+  },
+  {
+    "id": "FAYP",
+    "british": false,
+    "label": "Ysterplaat Air Force Base (South Africa) (FAYP)"
+  },
+  {
+    "id": "FAZR",
+    "british": false,
+    "label": "Zeerust Airport (South Africa) (FAZR)"
+  },
+  {
+    "id": "FRW",
+    "british": false,
+    "label": "Francistown Airport (Botswana) (FBFT / FRW)"
+  },
+  {
+    "id": "JWA",
+    "british": false,
+    "label": "Jwaneng Airport (Botswana) (FBJW / JWA)"
+  },
+  {
+    "id": "BBK",
+    "british": false,
+    "label": "Kasane Airport (Botswana) (FBKE / BBK)"
+  },
+  {
+    "id": "MUB",
+    "british": false,
+    "label": "Maun Airport (Botswana) (FBMN / MUB)"
+  },
+  {
+    "id": "GBE",
+    "british": false,
+    "label": "Sir Seretse Khama International Airport (Botswana) (FBSK / GBE)"
+  },
+  {
+    "id": "PKW",
+    "british": false,
+    "label": "Selebi Phikwe Airport (Botswana) (FBSP / PKW)"
+  },
+  {
+    "id": "BZV",
+    "british": false,
+    "label": "Maya-Maya Airport (Congo (Brazzaville)) (FCBB / BZV)"
+  },
+  {
+    "id": "FTX",
+    "british": false,
+    "label": "Owando Airport (Congo (Kinshasa)) (FCOO / FTX)"
+  },
+  {
+    "id": "OUE",
+    "british": false,
+    "label": "Ouesso Airport (Congo (Kinshasa)) (FCOU / OUE)"
+  },
+  {
+    "id": "PNR",
+    "british": false,
+    "label": "Pointe Noire Airport (Congo (Brazzaville)) (FCPP / PNR)"
+  },
+  {
+    "id": "MTS",
+    "british": false,
+    "label": "Matsapha Airport (Swaziland) (FDMS / MTS)"
+  },
+  {
+    "id": "BGF",
+    "british": false,
+    "label": "Bangui M'Poko International Airport (Central African Republic) (FEFF / BGF)"
+  },
+  {
+    "id": "BBT",
+    "british": false,
+    "label": "Berbérati Airport (Central African Republic) (FEFT / BBT)"
+  },
+  {
+    "id": "BSG",
+    "british": false,
+    "label": "Bata Airport (Equatorial Guinea) (FGBT / BSG)"
+  },
+  {
+    "id": "SSG",
+    "british": false,
+    "label": "Malabo Airport (Equatorial Guinea) (FGSL / SSG)"
+  },
+  {
+    "id": "ASI",
+    "british": false,
+    "label": "RAF Ascension Island (Saint Helena) (FHAW / ASI)"
+  },
+  {
+    "id": "MRU",
+    "british": false,
+    "label": "Sir Seewoosagur Ramgoolam International Airport (Mauritius) (FIMP / MRU)"
+  },
+  {
+    "id": "RRG",
+    "british": false,
+    "label": "Sir Charles Gaetan Duval Airport (Mauritius) (FIMR / RRG)"
+  },
+  {
+    "id": "NKW",
+    "british": false,
+    "label": "Diego Garcia Naval Support Facility (British Indian Ocean Territory) (FJDG / NKW)"
+  },
+  {
+    "id": "TKC",
+    "british": false,
+    "label": "Tiko Airport (Cameroon) (FKKC / TKC)"
+  },
+  {
+    "id": "DLA",
+    "british": false,
+    "label": "Douala International Airport (Cameroon) (FKKD / DLA)"
+  },
+  {
+    "id": "MVR",
+    "british": false,
+    "label": "Salak Airport (Cameroon) (FKKL / MVR)"
+  },
+  {
+    "id": "FOM",
+    "british": false,
+    "label": "Foumban Nkounja Airport (Cameroon) (FKKM / FOM)"
+  },
+  {
+    "id": "NGE",
+    "british": false,
+    "label": "N'Gaoundéré Airport (Cameroon) (FKKN / NGE)"
+  },
+  {
+    "id": "GOU",
+    "british": false,
+    "label": "Garoua International Airport (Cameroon) (FKKR / GOU)"
+  },
+  {
+    "id": "BFX",
+    "british": false,
+    "label": "Bafoussam Airport (Cameroon) (FKKU / BFX)"
+  },
+  {
+    "id": "BPC",
+    "british": false,
+    "label": "Bamenda Airport (Cameroon) (FKKV / BPC)"
+  },
+  {
+    "id": "YAO",
+    "british": false,
+    "label": "Yaoundé Airport (Cameroon) (FKKY / YAO)"
+  },
+  {
+    "id": "CGJ",
+    "british": false,
+    "label": "Kasompe Airport (Zambia) (FLKE / CGJ)"
+  },
+  {
+    "id": "LVI",
+    "british": false,
+    "label": "Livingstone Airport (Zambia) (FLLI / LVI)"
+  },
+  {
+    "id": "LUN",
+    "british": false,
+    "label": "Kenneth Kaunda International Airport Lusaka (Zambia) (FLLS / LUN)"
+  },
+  {
+    "id": "MFU",
+    "british": false,
+    "label": "Mfuwe Airport (Zambia) (FLMF / MFU)"
+  },
+  {
+    "id": "MNR",
+    "british": false,
+    "label": "Mongu Airport (Zambia) (FLMG / MNR)"
+  },
+  {
+    "id": "NLA",
+    "british": false,
+    "label": "Simon Mwansa Kapwepwe International Airport (Zambia) (FLND / NLA)"
+  },
+  {
+    "id": "KIW",
+    "british": false,
+    "label": "Southdowns Airport (Zambia) (FLSO / KIW)"
+  },
+  {
+    "id": "HAH",
+    "british": false,
+    "label": "Prince Said Ibrahim International Airport (Comoros) (FMCH / HAH)"
+  },
+  {
+    "id": "NWA",
+    "british": false,
+    "label": "Mohéli Bandar Es Eslam Airport (Comoros) (FMCI / NWA)"
+  },
+  {
+    "id": "AJN",
+    "british": false,
+    "label": "Ouani Airport (Comoros) (FMCV / AJN)"
+  },
+  {
+    "id": "DZA",
+    "british": false,
+    "label": "Dzaoudzi Pamandzi International Airport (Mayotte) (FMCZ / DZA)"
+  },
+  {
+    "id": "RUN",
+    "british": false,
+    "label": "Roland Garros Airport (Reunion) (FMEE / RUN)"
+  },
+  {
+    "id": "ZSE",
+    "british": false,
+    "label": "Pierrefonds Airport (Reunion) (FMEP / ZSE)"
+  },
+  {
+    "id": "TNR",
+    "british": false,
+    "label": "Ivato Airport (Madagascar) (FMMI / TNR)"
+  },
+  {
+    "id": "ZVA",
+    "british": false,
+    "label": "Miandrivazo Airport (Madagascar) (FMMN / ZVA)"
+  },
+  {
+    "id": "SMS",
+    "british": false,
+    "label": "Sainte Marie Airport (Madagascar) (FMMS / SMS)"
+  },
+  {
+    "id": "TMM",
+    "british": false,
+    "label": "Toamasina Airport (Madagascar) (FMMT / TMM)"
+  },
+  {
+    "id": "MOQ",
+    "british": false,
+    "label": "Morondava Airport (Madagascar) (FMMV / MOQ)"
+  },
+  {
+    "id": "DIE",
+    "british": false,
+    "label": "Arrachart Airport (Madagascar) (FMNA / DIE)"
+  },
+  {
+    "id": "WMR",
+    "british": false,
+    "label": "Mananara Nord Airport (Madagascar) (FMNC / WMR)"
+  },
+  {
+    "id": "ZWA",
+    "british": false,
+    "label": "Andapa Airport (Madagascar) (FMND / ZWA)"
+  },
+  {
+    "id": "AMB",
+    "british": false,
+    "label": "Ambilobe Airport (Madagascar) (FMNE / AMB)"
+  },
+  {
+    "id": "ANM",
+    "british": false,
+    "label": "Antsirabato Airport (Madagascar) (FMNH / ANM)"
+  },
+  {
+    "id": "HVA",
+    "british": false,
+    "label": "Analalava Airport (Madagascar) (FMNL / HVA)"
+  },
+  {
+    "id": "MJN",
+    "british": false,
+    "label": "Amborovy Airport (Madagascar) (FMNM / MJN)"
+  },
+  {
+    "id": "NOS",
+    "british": false,
+    "label": "Fascene Airport (Madagascar) (FMNN / NOS)"
+  },
+  {
+    "id": "BPY",
+    "british": false,
+    "label": "Besalampy Airport (Madagascar) (FMNQ / BPY)"
+  },
+  {
+    "id": "WMN",
+    "british": false,
+    "label": "Maroantsetra Airport (Madagascar) (FMNR / WMN)"
+  },
+  {
+    "id": "SVB",
+    "british": false,
+    "label": "Sambava Airport (Madagascar) (FMNS / SVB)"
+  },
+  {
+    "id": "VOH",
+    "british": false,
+    "label": "Vohimarina Airport (Madagascar) (FMNV / VOH)"
+  },
+  {
+    "id": "WAI",
+    "british": false,
+    "label": "Ambalabe Airport (Madagascar) (FMNW / WAI)"
+  },
+  {
+    "id": "IVA",
+    "british": false,
+    "label": "Ampampamena Airport (Madagascar) (FMNZ / IVA)"
+  },
+  {
+    "id": "FTU",
+    "british": false,
+    "label": "Tôlanaro Airport (Madagascar) (FMSD / FTU)"
+  },
+  {
+    "id": "WFI",
+    "british": false,
+    "label": "Fianarantsoa Airport (Madagascar) (FMSF / WFI)"
+  },
+  {
+    "id": "RVA",
+    "british": false,
+    "label": "Farafangana Airport (Madagascar) (FMSG / RVA)"
+  },
+  {
+    "id": "WVK",
+    "british": false,
+    "label": "Manakara Airport (Madagascar) (FMSK / WVK)"
+  },
+  {
+    "id": "MNJ",
+    "british": false,
+    "label": "Mananjary Airport (Madagascar) (FMSM / MNJ)"
+  },
+  {
+    "id": "MXM",
+    "british": false,
+    "label": "Morombe Airport (Madagascar) (FMSR / MXM)"
+  },
+  {
+    "id": "TLE",
+    "british": false,
+    "label": "Toliara Airport (Madagascar) (FMST / TLE)"
+  },
+  {
+    "id": "SSY",
+    "british": false,
+    "label": "Mbanza Congo Airport (Angola) (FNBC / SSY)"
+  },
+  {
+    "id": "BUG",
+    "british": false,
+    "label": "Benguela Airport (Angola) (FNBG / BUG)"
+  },
+  {
+    "id": "CAB",
+    "british": false,
+    "label": "Cabinda Airport (Angola) (FNCA / CAB)"
+  },
+  {
+    "id": "NOV",
+    "british": false,
+    "label": "Nova Lisboa Airport (Angola) (FNHU / NOV)"
+  },
+  {
+    "id": "SVP",
+    "british": false,
+    "label": "Kuito Airport (Angola) (FNKU / SVP)"
+  },
+  {
+    "id": "FNLB",
+    "british": false,
+    "label": "Lobito Airport (Angola) (FNLB)"
+  },
+  {
+    "id": "LAD",
+    "british": false,
+    "label": "Quatro de Fevereiro Airport (Angola) (FNLU / LAD)"
+  },
+  {
+    "id": "MEG",
+    "british": false,
+    "label": "Malanje Airport (Angola) (FNMA / MEG)"
+  },
+  {
+    "id": "SPP",
+    "british": false,
+    "label": "Menongue Airport (Angola) (FNME / SPP)"
+  },
+  {
+    "id": "GXG",
+    "british": false,
+    "label": "Negage Airport (Angola) (FNNG / GXG)"
+  },
+  {
+    "id": "PBN",
+    "british": false,
+    "label": "Porto Amboim Airport (Angola) (FNPA / PBN)"
+  },
+  {
+    "id": "VHC",
+    "british": false,
+    "label": "Saurimo Airport (Angola) (FNSA / VHC)"
+  },
+  {
+    "id": "SZA",
+    "british": false,
+    "label": "Soyo Airport (Angola) (FNSO / SZA)"
+  },
+  {
+    "id": "SDD",
+    "british": false,
+    "label": "Lubango Airport (Angola) (FNUB / SDD)"
+  },
+  {
+    "id": "LUO",
+    "british": false,
+    "label": "Luena Airport (Angola) (FNUE / LUO)"
+  },
+  {
+    "id": "UGO",
+    "british": false,
+    "label": "Uige Airport (Angola) (FNUG / UGO)"
+  },
+  {
+    "id": "XGN",
+    "british": false,
+    "label": "Xangongo Airport (Angola) (FNXA / XGN)"
+  },
+  {
+    "id": "OYE",
+    "british": false,
+    "label": "Oyem Airport (Gabon) (FOGO / OYE)"
+  },
+  {
+    "id": "OKN",
+    "british": false,
+    "label": "Okondja Airport (Gabon) (FOGQ / OKN)"
+  },
+  {
+    "id": "LBQ",
+    "british": false,
+    "label": "Lambarene Airport (Gabon) (FOGR / LBQ)"
+  },
+  {
+    "id": "BMM",
+    "british": false,
+    "label": "Bitam Airport (Gabon) (FOOB / BMM)"
+  },
+  {
+    "id": "POG",
+    "british": false,
+    "label": "Port Gentil Airport (Gabon) (FOOG / POG)"
+  },
+  {
+    "id": "OMB",
+    "british": false,
+    "label": "Omboue Hopital Airport (Gabon) (FOOH / OMB)"
+  },
+  {
+    "id": "MKU",
+    "british": false,
+    "label": "Makokou Airport (Gabon) (FOOK / MKU)"
+  },
+  {
+    "id": "LBV",
+    "british": false,
+    "label": "Libreville Leon M'ba International Airport (Gabon) (FOOL / LBV)"
+  },
+  {
+    "id": "MVB",
+    "british": false,
+    "label": "M'Vengue El Hadj Omar Bongo Ondimba International Airport (Gabon) (FOON / MVB)"
+  },
+  {
+    "id": "PCP",
+    "british": false,
+    "label": "Principe Airport (Sao Tome and Principe) (FPPR / PCP)"
+  },
+  {
+    "id": "TMS",
+    "british": false,
+    "label": "São Tomé International Airport (Sao Tome and Principe) (FPST / TMS)"
+  },
+  {
+    "id": "BEW",
+    "british": false,
+    "label": "Beira Airport (Mozambique) (FQBR / BEW)"
+  },
+  {
+    "id": "INH",
+    "british": false,
+    "label": "Inhambane Airport (Mozambique) (FQIN / INH)"
+  },
+  {
+    "id": "VXC",
+    "british": false,
+    "label": "Lichinga Airport (Mozambique) (FQLC / VXC)"
+  },
+  {
+    "id": "LFB",
+    "british": false,
+    "label": "Lumbo Airport (Mozambique) (FQLU / LFB)"
+  },
+  {
+    "id": "MPM",
+    "british": false,
+    "label": "Maputo Airport (Mozambique) (FQMA / MPM)"
+  },
+  {
+    "id": "MUD",
+    "british": false,
+    "label": "Mueda Airport (Mozambique) (FQMD / MUD)"
+  },
+  {
+    "id": "MZB",
+    "british": false,
+    "label": "Mocímboa da Praia Airport (Mozambique) (FQMP / MZB)"
+  },
+  {
+    "id": "FQMR",
+    "british": false,
+    "label": "Marrupa Airport (Mozambique) (FQMR)"
+  },
+  {
+    "id": "MNC",
+    "british": false,
+    "label": "Nacala Airport (Mozambique) (FQNC / MNC)"
+  },
+  {
+    "id": "APL",
+    "british": false,
+    "label": "Nampula Airport (Mozambique) (FQNP / APL)"
+  },
+  {
+    "id": "POL",
+    "british": false,
+    "label": "Pemba Airport (Mozambique) (FQPB / POL)"
+  },
+  {
+    "id": "UEL",
+    "british": false,
+    "label": "Quelimane Airport (Mozambique) (FQQL / UEL)"
+  },
+  {
+    "id": "FQSG",
+    "british": false,
+    "label": "Songo Airport (Mozambique) (FQSG)"
+  },
+  {
+    "id": "TET",
+    "british": false,
+    "label": "Chingozi Airport (Mozambique) (FQTT / TET)"
+  },
+  {
+    "id": "FQUG",
+    "british": false,
+    "label": "Ulongwe Airport (Mozambique) (FQUG)"
+  },
+  {
+    "id": "VNX",
+    "british": false,
+    "label": "Vilankulo Airport (Mozambique) (FQVL / VNX)"
+  },
+  {
+    "id": "FSAL",
+    "british": false,
+    "label": "Alphonse Airport (Seychelles) (FSAL)"
+  },
+  {
+    "id": "DES",
+    "british": false,
+    "label": "Desroches Airport (Seychelles) (FSDR / DES)"
+  },
+  {
+    "id": "FSFA",
+    "british": false,
+    "label": "Farquhar Airport (Seychelles) (FSFA)"
+  },
+  {
+    "id": "SEZ",
+    "british": false,
+    "label": "Seychelles International Airport (Seychelles) (FSIA / SEZ)"
+  },
+  {
+    "id": "PRI",
+    "british": false,
+    "label": "Praslin Airport (Seychelles) (FSPP / PRI)"
+  },
+  {
+    "id": "FSSC",
+    "british": false,
+    "label": "Coetivy Airport (Seychelles) (FSSC)"
+  },
+  {
+    "id": "AEH",
+    "british": false,
+    "label": "Abeche Airport (Chad) (FTTC / AEH)"
+  },
+  {
+    "id": "MQQ",
+    "british": false,
+    "label": "Moundou Airport (Chad) (FTTD / MQQ)"
+  },
+  {
+    "id": "NDJ",
+    "british": false,
+    "label": "N'Djamena International Airport (Chad) (FTTJ / NDJ)"
+  },
+  {
+    "id": "FYT",
+    "british": false,
+    "label": "Faya Largeau Airport (Chad) (FTTY / FYT)"
+  },
+  {
+    "id": "BUQ",
+    "british": false,
+    "label": "Joshua Mqabuko Nkomo International Airport (Zimbabwe) (FVBU / BUQ)"
+  },
+  {
+    "id": "FVCP",
+    "british": false,
+    "label": "Charles Prince Airport (Zimbabwe) (FVCP)"
+  },
+  {
+    "id": "BFO",
+    "british": false,
+    "label": "Buffalo Range Airport (Zimbabwe) (FVCZ / BFO)"
+  },
+  {
+    "id": "VFA",
+    "british": false,
+    "label": "Victoria Falls International Airport (Zimbabwe) (FVFA / VFA)"
+  },
+  {
+    "id": "HRE",
+    "british": false,
+    "label": "Robert Gabriel Mugabe International Airport (Zimbabwe) (FVHA / HRE)"
+  },
+  {
+    "id": "KAB",
+    "british": false,
+    "label": "Kariba International Airport (Zimbabwe) (FVKB / KAB)"
+  },
+  {
+    "id": "FVMT",
+    "british": false,
+    "label": "Mutoko Airport (Zimbabwe) (FVMT)"
+  },
+  {
+    "id": "UTA",
+    "british": false,
+    "label": "Mutare Airport (Zimbabwe) (FVMU / UTA)"
+  },
+  {
+    "id": "MVZ",
+    "british": false,
+    "label": "Masvingo International Airport (Zimbabwe) (FVMV / MVZ)"
+  },
+  {
+    "id": "FVSH",
+    "british": false,
+    "label": "Zvishavane Airport (Zimbabwe) (FVSH)"
+  },
+  {
+    "id": "GWE",
+    "british": false,
+    "label": "Thornhill Air Base (Zimbabwe) (FVTL / GWE)"
+  },
+  {
+    "id": "HWN",
+    "british": false,
+    "label": "Hwange National Park Airport (Zimbabwe) (FVWN / HWN)"
+  },
+  {
+    "id": "BLZ",
+    "british": false,
+    "label": "Chileka International Airport (Malawi) (FWCL / BLZ)"
+  },
+  {
+    "id": "KGJ",
+    "british": false,
+    "label": "Karonga Airport (Malawi) (FWKA / KGJ)"
+  },
+  {
+    "id": "KBQ",
+    "british": false,
+    "label": "Kasungu Airport (Malawi) (FWKG / KBQ)"
+  },
+  {
+    "id": "LLW",
+    "british": false,
+    "label": "Lilongwe International Airport (Malawi) (FWKI / LLW)"
+  },
+  {
+    "id": "ZZU",
+    "british": false,
+    "label": "Mzuzu Airport (Malawi) (FWUU / ZZU)"
+  },
+  {
+    "id": "MSU",
+    "british": false,
+    "label": "Moshoeshoe I International Airport (Lesotho) (FXMM / MSU)"
+  },
+  {
+    "id": "FXMU",
+    "british": false,
+    "label": "Mejametalana Airbase (Lesotho) (FXMU)"
+  },
+  {
+    "id": "FIH",
+    "british": false,
+    "label": "Ndjili International Airport (Congo (Kinshasa)) (FZAA / FIH)"
+  },
+  {
+    "id": "NLO",
+    "british": false,
+    "label": "Ndolo Airport (Congo (Kinshasa)) (FZAB / NLO)"
+  },
+  {
+    "id": "MNB",
+    "british": false,
+    "label": "Muanda Airport (Congo (Kinshasa)) (FZAG / MNB)"
+  },
+  {
+    "id": "FZAI",
+    "british": false,
+    "label": "Kitona Base Airport (Congo (Kinshasa)) (FZAI)"
+  },
+  {
+    "id": "FDU",
+    "british": false,
+    "label": "Bandundu Airport (Congo (Kinshasa)) (FZBO / FDU)"
+  },
+  {
+    "id": "KKW",
+    "british": false,
+    "label": "Kikwit Airport (Congo (Kinshasa)) (FZCA / KKW)"
+  },
+  {
+    "id": "MDK",
+    "british": false,
+    "label": "Mbandaka Airport (Congo (Kinshasa)) (FZEA / MDK)"
+  },
+  {
+    "id": "BDT",
+    "british": false,
+    "label": "Gbadolite Airport (Congo (Kinshasa)) (FZFD / BDT)"
+  },
+  {
+    "id": "GMA",
+    "british": false,
+    "label": "Gemena Airport (Congo (Kinshasa)) (FZFK / GMA)"
+  },
+  {
+    "id": "KLI",
+    "british": false,
+    "label": "Kotakoli Airport (Congo (Kinshasa)) (FZFP / KLI)"
+  },
+  {
+    "id": "LIQ",
+    "british": false,
+    "label": "Lisala Airport (Congo (Kinshasa)) (FZGA / LIQ)"
+  },
+  {
+    "id": "FKI",
+    "british": false,
+    "label": "Bangoka International Airport (Congo (Kinshasa)) (FZIC / FKI)"
+  },
+  {
+    "id": "IRP",
+    "british": false,
+    "label": "Matari Airport (Congo (Kinshasa)) (FZJH / IRP)"
+  },
+  {
+    "id": "BUX",
+    "british": false,
+    "label": "Bunia Airport (Congo (Kinshasa)) (FZKA / BUX)"
+  },
+  {
+    "id": "BZU",
+    "british": false,
+    "label": "Buta Zega Airport (Congo (Kinshasa)) (FZKJ / BZU)"
+  },
+  {
+    "id": "BKY",
+    "british": false,
+    "label": "Bukavu Kavumu Airport (Congo (Kinshasa)) (FZMA / BKY)"
+  },
+  {
+    "id": "GOM",
+    "british": false,
+    "label": "Goma International Airport (Congo (Kinshasa)) (FZNA / GOM)"
+  },
+  {
+    "id": "KND",
+    "british": false,
+    "label": "Kindu Airport (Congo (Kinshasa)) (FZOA / KND)"
+  },
+  {
+    "id": "FBM",
+    "british": false,
+    "label": "Lubumbashi International Airport (Congo (Kinshasa)) (FZQA / FBM)"
+  },
+  {
+    "id": "KWZ",
+    "british": false,
+    "label": "Kolwezi Airport (Congo (Kinshasa)) (FZQM / KWZ)"
+  },
+  {
+    "id": "FMI",
+    "british": false,
+    "label": "Kalemie Airport (Congo (Kinshasa)) (FZRF / FMI)"
+  },
+  {
+    "id": "KMN",
+    "british": false,
+    "label": "Kamina Base Airport (Congo (Kinshasa)) (FZSA / KMN)"
+  },
+  {
+    "id": "KGA",
+    "british": false,
+    "label": "Kananga Airport (Congo (Kinshasa)) (FZUA / KGA)"
+  },
+  {
+    "id": "MJM",
+    "british": false,
+    "label": "Mbuji Mayi Airport (Congo (Kinshasa)) (FZWA / MJM)"
+  },
+  {
+    "id": "BKO",
+    "british": false,
+    "label": "Modibo Keita International Airport (Mali) (GABS / BKO)"
+  },
+  {
+    "id": "GAQ",
+    "british": false,
+    "label": "Gao Airport (Mali) (GAGO / GAQ)"
+  },
+  {
+    "id": "KYS",
+    "british": false,
+    "label": "Kayes Dag Dag Airport (Mali) (GAKY / KYS)"
+  },
+  {
+    "id": "MZI",
+    "british": false,
+    "label": "Mopti Airport (Mali) (GAMB / MZI)"
+  },
+  {
+    "id": "TOM",
+    "british": false,
+    "label": "Timbuktu Airport (Mali) (GATB / TOM)"
+  },
+  {
+    "id": "GATS",
+    "british": false,
+    "label": "Tessalit Airport (Mali) (GATS)"
+  },
+  {
+    "id": "BJL",
+    "british": false,
+    "label": "Banjul International Airport (Gambia) (GBYD / BJL)"
+  },
+  {
+    "id": "FUE",
+    "british": false,
+    "label": "Fuerteventura Airport (Spain) (GCFV / FUE)"
+  },
+  {
+    "id": "VDE",
+    "british": false,
+    "label": "Hierro Airport (Spain) (GCHI / VDE)"
+  },
+  {
+    "id": "SPC",
+    "british": false,
+    "label": "La Palma Airport (Spain) (GCLA / SPC)"
+  },
+  {
+    "id": "LPA",
+    "british": false,
+    "label": "Gran Canaria Airport (Spain) (GCLP / LPA)"
+  },
+  {
+    "id": "ACE",
+    "british": false,
+    "label": "Lanzarote Airport (Spain) (GCRR / ACE)"
+  },
+  {
+    "id": "TFS",
+    "british": false,
+    "label": "Tenerife South Airport (Spain) (GCTS / TFS)"
+  },
+  {
+    "id": "TFN",
+    "british": false,
+    "label": "Tenerife Norte Airport (Spain) (GCXO / TFN)"
+  },
+  {
+    "id": "MLN",
+    "british": false,
+    "label": "Melilla Airport (Spain) (GEML / MLN)"
+  },
+  {
+    "id": "FNA",
+    "british": false,
+    "label": "Lungi International Airport (Sierra Leone) (GFLL / FNA)"
+  },
+  {
+    "id": "GGCF",
+    "british": false,
+    "label": "Cufar Airport (Guinea-Bissau) (GGCF)"
+  },
+  {
+    "id": "MLW",
+    "british": false,
+    "label": "Spriggs Payne Airport (Liberia) (GLMR / MLW)"
+  },
+  {
+    "id": "ROB",
+    "british": false,
+    "label": "Roberts International Airport (Liberia) (GLRB / ROB)"
+  },
+  {
+    "id": "AGA",
+    "british": false,
+    "label": "Al Massira Airport (Morocco) (GMAD / AGA)"
+  },
+  {
+    "id": "TTA",
+    "british": false,
+    "label": "Tan Tan Airport (Morocco) (GMAT / TTA)"
+  },
+  {
+    "id": "FEZ",
+    "british": false,
+    "label": "Saïss Airport (Morocco) (GMFF / FEZ)"
+  },
+  {
+    "id": "GMFI",
+    "british": false,
+    "label": "Ifrane Airport (Morocco) (GMFI)"
+  },
+  {
+    "id": "ERH",
+    "british": false,
+    "label": "Moulay Ali Cherif Airport (Morocco) (GMFK / ERH)"
+  },
+  {
+    "id": "MEK",
+    "british": false,
+    "label": "Bassatine Airport (Morocco) (GMFM / MEK)"
+  },
+  {
+    "id": "OUD",
+    "british": false,
+    "label": "Angads Airport (Morocco) (GMFO / OUD)"
+  },
+  {
+    "id": "GMD",
+    "british": false,
+    "label": "Ben Slimane Airport (Morocco) (GMMB / GMD)"
+  },
+  {
+    "id": "RBA",
+    "british": false,
+    "label": "Rabat-Salé Airport (Morocco) (GMME / RBA)"
+  },
+  {
+    "id": "CMN",
+    "british": false,
+    "label": "Mohammed V International Airport (Morocco) (GMMN / CMN)"
+  },
+  {
+    "id": "RAK",
+    "british": false,
+    "label": "Menara Airport (Morocco) (GMMX / RAK)"
+  },
+  {
+    "id": "NNA",
+    "british": false,
+    "label": "Kenitra Airport (Morocco) (GMMY / NNA)"
+  },
+  {
+    "id": "OZZ",
+    "british": false,
+    "label": "Ouarzazate Airport (Morocco) (GMMZ / OZZ)"
+  },
+  {
+    "id": "AHU",
+    "british": false,
+    "label": "Cherif Al Idrissi Airport (Morocco) (GMTA / AHU)"
+  },
+  {
+    "id": "TTU",
+    "british": false,
+    "label": "Saniat R'mel Airport (Morocco) (GMTN / TTU)"
+  },
+  {
+    "id": "TNG",
+    "british": false,
+    "label": "Ibn Batouta Airport (Morocco) (GMTT / TNG)"
+  },
+  {
+    "id": "ZIG",
+    "british": false,
+    "label": "Ziguinchor Airport (Senegal) (GOGG / ZIG)"
+  },
+  {
+    "id": "CSK",
+    "british": false,
+    "label": "Cap Skirring Airport (Senegal) (GOGS / CSK)"
+  },
+  {
+    "id": "KLC",
+    "british": false,
+    "label": "Kaolack Airport (Senegal) (GOOK / KLC)"
+  },
+  {
+    "id": "DKR",
+    "british": false,
+    "label": "Léopold Sédar Senghor International Airport (Senegal) (GOOY / DKR)"
+  },
+  {
+    "id": "XLS",
+    "british": false,
+    "label": "Saint Louis Airport (Senegal) (GOSS / XLS)"
+  },
+  {
+    "id": "BXE",
+    "british": false,
+    "label": "Bakel Airport (Senegal) (GOTB / BXE)"
+  },
+  {
+    "id": "KGG",
+    "british": false,
+    "label": "Kédougou Airport (Senegal) (GOTK / KGG)"
+  },
+  {
+    "id": "TUD",
+    "british": false,
+    "label": "Tambacounda Airport (Senegal) (GOTT / TUD)"
+  },
+  {
+    "id": "AEO",
+    "british": false,
+    "label": "Aioun el Atrouss Airport (Mauritania) (GQNA / AEO)"
+  },
+  {
+    "id": "TIY",
+    "british": false,
+    "label": "Tidjikja Airport (Mauritania) (GQND / TIY)"
+  },
+  {
+    "id": "KFA",
+    "british": false,
+    "label": "Kiffa Airport (Mauritania) (GQNF / KFA)"
+  },
+  {
+    "id": "EMN",
+    "british": false,
+    "label": "Néma Airport (Mauritania) (GQNI / EMN)"
+  },
+  {
+    "id": "KED",
+    "british": false,
+    "label": "Kaédi Airport (Mauritania) (GQNK / KED)"
+  },
+  {
+    "id": "NKC",
+    "british": false,
+    "label": "Nouakchott–Oumtounsy International Airport (Mauritania) (GQNO / NKC)"
+  },
+  {
+    "id": "SEY",
+    "british": false,
+    "label": "Sélibaby Airport (Mauritania) (GQNS / SEY)"
+  },
+  {
+    "id": "ATR",
+    "british": false,
+    "label": "Atar International Airport (Mauritania) (GQPA / ATR)"
+  },
+  {
+    "id": "NDB",
+    "british": false,
+    "label": "Nouadhibou International Airport (Mauritania) (GQPP / NDB)"
+  },
+  {
+    "id": "GQPT",
+    "british": false,
+    "label": "Bir Moghrein Airport (Mauritania) (GQPT)"
+  },
+  {
+    "id": "FIG",
+    "british": false,
+    "label": "Fria Airport (Guinea) (GUFA / FIG)"
+  },
+  {
+    "id": "FAA",
+    "british": false,
+    "label": "Faranah Airport (Guinea) (GUFH / FAA)"
+  },
+  {
+    "id": "LEK",
+    "british": false,
+    "label": "Tata Airport (Guinea) (GULB / LEK)"
+  },
+  {
+    "id": "SID",
+    "british": false,
+    "label": "Amílcar Cabral International Airport (Cape Verde) (GVAC / SID)"
+  },
+  {
+    "id": "BVC",
+    "british": false,
+    "label": "Rabil Airport (Cape Verde) (GVBA / BVC)"
+  },
+  {
+    "id": "MMO",
+    "british": false,
+    "label": "Maio Airport (Cape Verde) (GVMA / MMO)"
+  },
+  {
+    "id": "SNE",
+    "british": false,
+    "label": "Preguiça Airport (Cape Verde) (GVSN / SNE)"
+  },
+  {
+    "id": "VXE",
+    "british": false,
+    "label": "São Pedro Airport (Cape Verde) (GVSV / VXE)"
+  },
+  {
+    "id": "ADD",
+    "british": false,
+    "label": "Addis Ababa Bole International Airport (Ethiopia) (HAAB / ADD)"
+  },
+  {
+    "id": "HAAL",
+    "british": false,
+    "label": "Lideta Army Airport (Ethiopia) (HAAL)"
+  },
+  {
+    "id": "AMH",
+    "british": false,
+    "label": "Arba Minch Airport (Ethiopia) (HAAM / AMH)"
+  },
+  {
+    "id": "AXU",
+    "british": false,
+    "label": "Axum Airport (Ethiopia) (HAAX / AXU)"
+  },
+  {
+    "id": "BJR",
+    "british": false,
+    "label": "Bahir Dar Airport (Ethiopia) (HABD / BJR)"
+  },
+  {
+    "id": "DIR",
+    "british": false,
+    "label": "Aba Tenna Dejazmach Yilma International Airport (Ethiopia) (HADR / DIR)"
+  },
+  {
+    "id": "GMB",
+    "british": false,
+    "label": "Gambella Airport (Ethiopia) (HAGM / GMB)"
+  },
+  {
+    "id": "GDQ",
+    "british": false,
+    "label": "Gonder Airport (Ethiopia) (HAGN / GDQ)"
+  },
+  {
+    "id": "JIM",
+    "british": false,
+    "label": "Jimma Airport (Ethiopia) (HAJM / JIM)"
+  },
+  {
+    "id": "LLI",
+    "british": false,
+    "label": "Lalibella Airport (Ethiopia) (HALL / LLI)"
+  },
+  {
+    "id": "MQX",
+    "british": false,
+    "label": "Mekele Airport (Ethiopia) (HAMK / MQX)"
+  },
+  {
+    "id": "ASO",
+    "british": false,
+    "label": "Asosa Airport (Ethiopia) (HASO / ASO)"
+  },
+  {
+    "id": "BJM",
+    "british": false,
+    "label": "Bujumbura International Airport (Burundi) (HBBA / BJM)"
+  },
+  {
+    "id": "HGA",
+    "british": false,
+    "label": "Egal International Airport (Somalia) (HCMH / HGA)"
+  },
+  {
+    "id": "BBO",
+    "british": false,
+    "label": "Berbera Airport (Somalia) (HCMI / BBO)"
+  },
+  {
+    "id": "KMU",
+    "british": false,
+    "label": "Kisimayu Airport (Somalia) (HCMK / KMU)"
+  },
+  {
+    "id": "ALY",
+    "british": false,
+    "label": "El Nouzha Airport (Egypt) (HEAX / ALY)"
+  },
+  {
+    "id": "ABS",
+    "british": false,
+    "label": "Abu Simbel Airport (Egypt) (HEBL / ABS)"
+  },
+  {
+    "id": "CAI",
+    "british": false,
+    "label": "Cairo International Airport (Egypt) (HECA / CAI)"
+  },
+  {
+    "id": "CWE",
+    "british": false,
+    "label": "Cairo West Airport (Egypt) (HECW / CWE)"
+  },
+  {
+    "id": "HRG",
+    "british": false,
+    "label": "Hurghada International Airport (Egypt) (HEGN / HRG)"
+  },
+  {
+    "id": "EGH",
+    "british": false,
+    "label": "El Gora Airport (Egypt) (HEGR / EGH)"
+  },
+  {
+    "id": "LXR",
+    "british": false,
+    "label": "Luxor International Airport (Egypt) (HELX / LXR)"
+  },
+  {
+    "id": "MUH",
+    "british": false,
+    "label": "Mersa Matruh Airport (Egypt) (HEMM / MUH)"
+  },
+  {
+    "id": "PSD",
+    "british": false,
+    "label": "Port Said Airport (Egypt) (HEPS / PSD)"
+  },
+  {
+    "id": "SKV",
+    "british": false,
+    "label": "St Catherine International Airport (Egypt) (HESC / SKV)"
+  },
+  {
+    "id": "ASW",
+    "british": false,
+    "label": "Aswan International Airport (Egypt) (HESN / ASW)"
+  },
+  {
+    "id": "ELT",
+    "british": false,
+    "label": "El Tor Airport (Egypt) (HETR / ELT)"
+  },
+  {
+    "id": "EDL",
+    "british": false,
+    "label": "Eldoret International Airport (Kenya) (HKEL / EDL)"
+  },
+  {
+    "id": "GGM",
+    "british": false,
+    "label": "Kakamega Airport (Kenya) (HKKG / GGM)"
+  },
+  {
+    "id": "KIS",
+    "british": false,
+    "label": "Kisumu Airport (Kenya) (HKKI / KIS)"
+  },
+  {
+    "id": "KTL",
+    "british": false,
+    "label": "Kitale Airport (Kenya) (HKKT / KTL)"
+  },
+  {
+    "id": "LOK",
+    "british": false,
+    "label": "Lodwar Airport (Kenya) (HKLO / LOK)"
+  },
+  {
+    "id": "LAU",
+    "british": false,
+    "label": "Manda Airstrip (Kenya) (HKLU / LAU)"
+  },
+  {
+    "id": "MBA",
+    "british": false,
+    "label": "Mombasa Moi International Airport (Kenya) (HKMO / MBA)"
+  },
+  {
+    "id": "HKNV",
+    "british": false,
+    "label": "Naivasha Airport (Kenya) (HKNV)"
+  },
+  {
+    "id": "WIL",
+    "british": false,
+    "label": "Nairobi Wilson Airport (Kenya) (HKNW / WIL)"
+  },
+  {
+    "id": "HKRE",
+    "british": false,
+    "label": "Moi Air Base (Kenya) (HKRE)"
+  },
+  {
+    "id": "WJR",
+    "british": false,
+    "label": "Wajir Airport (Kenya) (HKWJ / WJR)"
+  },
+  {
+    "id": "HLFL",
+    "british": false,
+    "label": "Bu Attifel Airport (Libya) (HLFL)"
+  },
+  {
+    "id": "HLGL",
+    "british": false,
+    "label": "Warehouse 59e Airport (Libya) (HLGL)"
+  },
+  {
+    "id": "GHT",
+    "british": false,
+    "label": "Ghat Airport (Libya) (HLGT / GHT)"
+  },
+  {
+    "id": "AKF",
+    "british": false,
+    "label": "Kufra Airport (Libya) (HLKF / AKF)"
+  },
+  {
+    "id": "BEN",
+    "british": false,
+    "label": "Benina International Airport (Libya) (HLLB / BEN)"
+  },
+  {
+    "id": "SEB",
+    "british": false,
+    "label": "Sabha Airport (Libya) (HLLS / SEB)"
+  },
+  {
+    "id": "TIP",
+    "british": false,
+    "label": "Tripoli International Airport (Libya) (HLLT / TIP)"
+  },
+  {
+    "id": "LMQ",
+    "british": false,
+    "label": "Marsa Brega Airport (Libya) (HLMB / LMQ)"
+  },
+  {
+    "id": "HLNF",
+    "british": false,
+    "label": "Ras Lanuf Oil Airport (Libya) (HLNF)"
+  },
+  {
+    "id": "HUQ",
+    "british": false,
+    "label": "Hon Airport (Libya) (HLON / HUQ)"
+  },
+  {
+    "id": "HLRA",
+    "british": false,
+    "label": "Dahra Airport (Libya) (HLRA)"
+  },
+  {
+    "id": "LTD",
+    "british": false,
+    "label": "Ghadames East Airport (Libya) (HLTD / LTD)"
+  },
+  {
+    "id": "HLZA",
+    "british": false,
+    "label": "Zella 74 Airport (Libya) (HLZA)"
+  },
+  {
+    "id": "GYI",
+    "british": false,
+    "label": "Gisenyi Airport (Rwanda) (HRYG / GYI)"
+  },
+  {
+    "id": "KGL",
+    "british": false,
+    "label": "Kigali International Airport (Rwanda) (HRYR / KGL)"
+  },
+  {
+    "id": "KME",
+    "british": false,
+    "label": "Kamembe Airport (Rwanda) (HRZA / KME)"
+  },
+  {
+    "id": "DOG",
+    "british": false,
+    "label": "Dongola Airport (Sudan) (HSDN / DOG)"
+  },
+  {
+    "id": "RSS",
+    "british": false,
+    "label": "Damazin Airport (Sudan) (HSDZ / RSS)"
+  },
+  {
+    "id": "ELF",
+    "british": false,
+    "label": "El Fasher Airport (Sudan) (HSFS / ELF)"
+  },
+  {
+    "id": "KSL",
+    "british": false,
+    "label": "Kassala Airport (Sudan) (HSKA / KSL)"
+  },
+  {
+    "id": "KDX",
+    "british": false,
+    "label": "Kadugli Airport (Sudan) (HSLI / KDX)"
+  },
+  {
+    "id": "EBD",
+    "british": false,
+    "label": "El Obeid Airport (Sudan) (HSOB / EBD)"
+  },
+  {
+    "id": "JUB",
+    "british": false,
+    "label": "Juba International Airport (South Sudan) (HSSJ / JUB)"
+  },
+  {
+    "id": "MAK",
+    "british": false,
+    "label": "Malakal Airport (Sudan) (HSSM / MAK)"
+  },
+  {
+    "id": "KRT",
+    "british": false,
+    "label": "Khartoum International Airport (Sudan) (HSSS / KRT)"
+  },
+  {
+    "id": "ARK",
+    "british": false,
+    "label": "Arusha Airport (Tanzania) (HTAR / ARK)"
+  },
+  {
+    "id": "DAR",
+    "british": false,
+    "label": "Julius Nyerere International Airport (Tanzania) (HTDA / DAR)"
+  },
+  {
+    "id": "DOD",
+    "british": false,
+    "label": "Dodoma Airport (Tanzania) (HTDO / DOD)"
+  },
+  {
+    "id": "IRI",
+    "british": false,
+    "label": "Iringa Airport (Tanzania) (HTIR / IRI)"
+  },
+  {
+    "id": "JRO",
+    "british": false,
+    "label": "Kilimanjaro International Airport (Tanzania) (HTKJ / JRO)"
+  },
+  {
+    "id": "LKY",
+    "british": false,
+    "label": "Lake Manyara Airport (Tanzania) (HTLM / LKY)"
+  },
+  {
+    "id": "MYW",
+    "british": false,
+    "label": "Mtwara Airport (Tanzania) (HTMT / MYW)"
+  },
+  {
+    "id": "MWZ",
+    "british": false,
+    "label": "Mwanza Airport (Tanzania) (HTMW / MWZ)"
+  },
+  {
+    "id": "PMA",
+    "british": false,
+    "label": "Pemba Airport (Tanzania) (HTPE / PMA)"
+  },
+  {
+    "id": "TGT",
+    "british": false,
+    "label": "Tanga Airport (Tanzania) (HTTG / TGT)"
+  },
+  {
+    "id": "ZNZ",
+    "british": false,
+    "label": "Abeid Amani Karume International Airport (Tanzania) (HTZA / ZNZ)"
+  },
+  {
+    "id": "EBB",
+    "british": false,
+    "label": "Entebbe International Airport (Uganda) (HUEN / EBB)"
+  },
+  {
+    "id": "SRT",
+    "british": false,
+    "label": "Soroti Airport (Uganda) (HUSO / SRT)"
+  },
+  {
+    "id": "TIA",
+    "british": false,
+    "label": "Tirana International Airport Mother Teresa (Albania) (LATI / TIA)"
+  },
+  {
+    "id": "BOJ",
+    "british": false,
+    "label": "Burgas Airport (Bulgaria) (LBBG / BOJ)"
+  },
+  {
+    "id": "GOZ",
+    "british": false,
+    "label": "Gorna Oryahovitsa Airport (Bulgaria) (LBGO / GOZ)"
+  },
+  {
+    "id": "PDV",
+    "british": false,
+    "label": "Plovdiv International Airport (Bulgaria) (LBPD / PDV)"
+  },
+  {
+    "id": "SOF",
+    "british": false,
+    "label": "Sofia Airport (Bulgaria) (LBSF / SOF)"
+  },
+  {
+    "id": "SZR",
+    "british": false,
+    "label": "Stara Zagora Airport (Bulgaria) (LBSZ / SZR)"
+  },
+  {
+    "id": "VAR",
+    "british": false,
+    "label": "Varna Airport (Bulgaria) (LBWN / VAR)"
+  },
+  {
+    "id": "LCA",
+    "british": false,
+    "label": "Larnaca International Airport (Cyprus) (LCLK / LCA)"
+  },
+  {
+    "id": "PFO",
+    "british": false,
+    "label": "Paphos International Airport (Cyprus) (LCPH / PFO)"
+  },
+  {
+    "id": "AKT",
+    "british": false,
+    "label": "RAF Akrotiri (Cyprus) (LCRA / AKT)"
+  },
+  {
+    "id": "DBV",
+    "british": false,
+    "label": "Dubrovnik Airport (Croatia) (LDDU / DBV)"
+  },
+  {
+    "id": "LDOC",
+    "british": false,
+    "label": "Osijek-Čepin Airfield (Croatia) (LDOC)"
+  },
+  {
+    "id": "OSI",
+    "british": false,
+    "label": "Osijek Airport (Croatia) (LDOS / OSI)"
+  },
+  {
+    "id": "PUY",
+    "british": false,
+    "label": "Pula Airport (Croatia) (LDPL / PUY)"
+  },
+  {
+    "id": "LDRG",
+    "british": false,
+    "label": "Grobnicko Polje Airport (Croatia) (LDRG)"
+  },
+  {
+    "id": "RJK",
+    "british": false,
+    "label": "Rijeka Airport (Croatia) (LDRI / RJK)"
+  },
+  {
+    "id": "SPU",
+    "british": false,
+    "label": "Split Airport (Croatia) (LDSP / SPU)"
+  },
+  {
+    "id": "LDVA",
+    "british": false,
+    "label": "Varaždin Airport (Croatia) (LDVA)"
+  },
+  {
+    "id": "ZAG",
+    "british": false,
+    "label": "Zagreb Airport (Croatia) (LDZA / ZAG)"
+  },
+  {
+    "id": "ZAD",
+    "british": false,
+    "label": "Zadar Airport (Croatia) (LDZD / ZAD)"
+  },
+  {
+    "id": "LDZU",
+    "british": false,
+    "label": "Udbina Air Base (Croatia) (LDZU)"
+  },
+  {
+    "id": "ABC",
+    "british": false,
+    "label": "Albacete-Los Llanos Airport (Spain) (LEAB / ABC)"
+  },
+  {
+    "id": "ALC",
+    "british": false,
+    "label": "Alicante International Airport (Spain) (LEAL / ALC)"
+  },
+  {
+    "id": "LEI",
+    "british": false,
+    "label": "Almería International Airport (Spain) (LEAM / LEI)"
+  },
+  {
+    "id": "OVD",
+    "british": false,
+    "label": "Asturias Airport (Spain) (LEAS / OVD)"
+  },
+  {
+    "id": "ODB",
+    "british": false,
+    "label": "Córdoba Airport (Spain) (LEBA / ODB)"
+  },
+  {
+    "id": "BIO",
+    "british": false,
+    "label": "Bilbao Airport (Spain) (LEBB / BIO)"
+  },
+  {
+    "id": "BCN",
+    "british": false,
+    "label": "Barcelona International Airport (Spain) (LEBL / BCN)"
+  },
+  {
+    "id": "BJZ",
+    "british": false,
+    "label": "Badajoz Airport (Spain) (LEBZ / BJZ)"
+  },
+  {
+    "id": "LCG",
+    "british": false,
+    "label": "A Coruña Airport (Spain) (LECO / LCG)"
+  },
+  {
+    "id": "LEGA",
+    "british": false,
+    "label": "Armilla Air Base (Spain) (LEGA)"
+  },
+  {
+    "id": "GRO",
+    "british": false,
+    "label": "Girona Airport (Spain) (LEGE / GRO)"
+  },
+  {
+    "id": "GRX",
+    "british": false,
+    "label": "Federico Garcia Lorca Airport (Spain) (LEGR / GRX)"
+  },
+  {
+    "id": "LEGT",
+    "british": false,
+    "label": "Getafe Air Base (Spain) (LEGT)"
+  },
+  {
+    "id": "IBZ",
+    "british": false,
+    "label": "Ibiza Airport (Spain) (LEIB / IBZ)"
+  },
+  {
+    "id": "XRY",
+    "british": false,
+    "label": "Jerez Airport (Spain) (LEJR / XRY)"
+  },
+  {
+    "id": "MJV",
+    "british": false,
+    "label": "San Javier Airport (Spain) (LELC / MJV)"
+  },
+  {
+    "id": "MAD",
+    "british": false,
+    "label": "Adolfo Suárez Madrid–Barajas Airport (Spain) (LEMD / MAD)"
+  },
+  {
+    "id": "AGP",
+    "british": false,
+    "label": "Málaga Airport (Spain) (LEMG / AGP)"
+  },
+  {
+    "id": "MAH",
+    "british": false,
+    "label": "Menorca Airport (Spain) (LEMH / MAH)"
+  },
+  {
+    "id": "OZP",
+    "british": false,
+    "label": "Moron Air Base (Spain) (LEMO / OZP)"
+  },
+  {
+    "id": "LEOC",
+    "british": false,
+    "label": "Ocaña Airport (Spain) (LEOC)"
+  },
+  {
+    "id": "PNA",
+    "british": false,
+    "label": "Pamplona Airport (Spain) (LEPP / PNA)"
+  },
+  {
+    "id": "LERI",
+    "british": false,
+    "label": "Alcantarilla Air Base (Spain) (LERI)"
+  },
+  {
+    "id": "REU",
+    "british": false,
+    "label": "Reus Air Base (Spain) (LERS / REU)"
+  },
+  {
+    "id": "ROZ",
+    "british": false,
+    "label": "Rota Naval Station Airport (Spain) (LERT / ROZ)"
+  },
+  {
+    "id": "SLM",
+    "british": false,
+    "label": "Salamanca Airport (Spain) (LESA / SLM)"
+  },
+  {
+    "id": "LESB",
+    "british": false,
+    "label": "Son Bonet Airport (Spain) (LESB)"
+  },
+  {
+    "id": "LESL",
+    "british": false,
+    "label": "San Luis Airport (Spain) (LESL)"
+  },
+  {
+    "id": "EAS",
+    "british": false,
+    "label": "San Sebastian Airport (Spain) (LESO / EAS)"
+  },
+  {
+    "id": "SCQ",
+    "british": false,
+    "label": "Santiago de Compostela Airport (Spain) (LEST / SCQ)"
+  },
+  {
+    "id": "LEU",
+    "british": false,
+    "label": "Pirineus - la Seu d'Urgel Airport (Spain) (LESU / LEU)"
+  },
+  {
+    "id": "TOJ",
+    "british": false,
+    "label": "Torrejón Airport (Spain) (LETO / TOJ)"
+  },
+  {
+    "id": "VLC",
+    "british": false,
+    "label": "Valencia Airport (Spain) (LEVC / VLC)"
+  },
+  {
+    "id": "VLL",
+    "british": false,
+    "label": "Valladolid Airport (Spain) (LEVD / VLL)"
+  },
+  {
+    "id": "VIT",
+    "british": false,
+    "label": "Vitoria/Foronda Airport (Spain) (LEVT / VIT)"
+  },
+  {
+    "id": "VGO",
+    "british": false,
+    "label": "Vigo Airport (Spain) (LEVX / VGO)"
+  },
+  {
+    "id": "SDR",
+    "british": false,
+    "label": "Santander Airport (Spain) (LEXJ / SDR)"
+  },
+  {
+    "id": "ZAZ",
+    "british": false,
+    "label": "Zaragoza Air Base (Spain) (LEZG / ZAZ)"
+  },
+  {
+    "id": "SVQ",
+    "british": false,
+    "label": "Sevilla Airport (Spain) (LEZL / SVQ)"
+  },
+  {
+    "id": "CQF",
+    "british": false,
+    "label": "Calais-Dunkerque Airport (France) (LFAC / CQF)"
+  },
+  {
+    "id": "LFAG",
+    "british": false,
+    "label": "Péronne-Saint-Quentin Airport (France) (LFAG)"
+  },
+  {
+    "id": "LFAI",
+    "british": false,
+    "label": "Nangis-Les Loges Airport (France) (LFAI)"
+  },
+  {
+    "id": "LFAO",
+    "british": false,
+    "label": "Bagnoles-de-l'Orne-Couterne Airport (France) (LFAO)"
+  },
+  {
+    "id": "BYF",
+    "british": false,
+    "label": "Albert-Bray Airport (France) (LFAQ / BYF)"
+  },
+  {
+    "id": "LTQ",
+    "british": false,
+    "label": "Le Touquet-Côte d'Opale Airport (France) (LFAT / LTQ)"
+  },
+  {
+    "id": "XVS",
+    "british": false,
+    "label": "Valenciennes-Denain Airport (France) (LFAV / XVS)"
+  },
+  {
+    "id": "LFAY",
+    "british": false,
+    "label": "Amiens-Glisy Airport (France) (LFAY)"
+  },
+  {
+    "id": "AGF",
+    "british": false,
+    "label": "Agen-La Garenne Airport (France) (LFBA / AGF)"
+  },
+  {
+    "id": "LFBC",
+    "british": false,
+    "label": "Cazaux (BA 120) Air Base (France) (LFBC)"
+  },
+  {
+    "id": "BOD",
+    "british": false,
+    "label": "Bordeaux-Mérignac Airport (France) (LFBD / BOD)"
+  },
+  {
+    "id": "EGC",
+    "british": false,
+    "label": "Bergerac-Roumanière Airport (France) (LFBE / EGC)"
+  },
+  {
+    "id": "LFBF",
+    "british": false,
+    "label": "Toulouse-Francazal (BA 101) Air Base (France) (LFBF)"
+  },
+  {
+    "id": "CNG",
+    "british": false,
+    "label": "Cognac-Châteaubernard (BA 709) Air Base (France) (LFBG / CNG)"
+  },
+  {
+    "id": "PIS",
+    "british": false,
+    "label": "Poitiers-Biard Airport (France) (LFBI / PIS)"
+  },
+  {
+    "id": "MCU",
+    "british": false,
+    "label": "Montluçon-Guéret Airport (France) (LFBK / MCU)"
+  },
+  {
+    "id": "LIG",
+    "british": false,
+    "label": "Limoges Airport (France) (LFBL / LIG)"
+  },
+  {
+    "id": "LFBM",
+    "british": false,
+    "label": "Mont-de-Marsan (BA 118) Air Base (France) (LFBM)"
+  },
+  {
+    "id": "NIT",
+    "british": false,
+    "label": "Niort-Souché Airport (France) (LFBN / NIT)"
+  },
+  {
+    "id": "TLS",
+    "british": false,
+    "label": "Toulouse-Blagnac Airport (France) (LFBO / TLS)"
+  },
+  {
+    "id": "PUF",
+    "british": false,
+    "label": "Pau Pyrénées Airport (France) (LFBP / PUF)"
+  },
+  {
+    "id": "LFBR",
+    "british": false,
+    "label": "Muret-Lherm Airport (France) (LFBR)"
+  },
+  {
+    "id": "LDE",
+    "british": false,
+    "label": "Tarbes-Lourdes-Pyrénées Airport (France) (LFBT / LDE)"
+  },
+  {
+    "id": "ANG",
+    "british": false,
+    "label": "Angoulême-Brie-Champniers Airport (France) (LFBU / ANG)"
+  },
+  {
+    "id": "BVE",
+    "british": false,
+    "label": "Brive Souillac Airport (France) (LFSL / BVE)"
+  },
+  {
+    "id": "PGX",
+    "british": false,
+    "label": "Périgueux-Bassillac Airport (France) (LFBX / PGX)"
+  },
+  {
+    "id": "BIQ",
+    "british": false,
+    "label": "Biarritz-Anglet-Bayonne Airport (France) (LFBZ / BIQ)"
+  },
+  {
+    "id": "ZAO",
+    "british": false,
+    "label": "Cahors-Lalbenque Airport (France) (LFCC / ZAO)"
+  },
+  {
+    "id": "LFCG",
+    "british": false,
+    "label": "Saint-Girons-Antichan Airport (France) (LFCG)"
+  },
+  {
+    "id": "LFCH",
+    "british": false,
+    "label": "Arcachon-La Teste-de-Buch Airport (France) (LFCH)"
+  },
+  {
+    "id": "LBI",
+    "british": false,
+    "label": "Albi-Le Séquestre Airport (France) (LFCI / LBI)"
+  },
+  {
+    "id": "DCM",
+    "british": false,
+    "label": "Castres-Mazamet Airport (France) (LFCK / DCM)"
+  },
+  {
+    "id": "LFCL",
+    "british": false,
+    "label": "Toulouse-Lasbordes Airport (France) (LFCL)"
+  },
+  {
+    "id": "LFCM",
+    "british": false,
+    "label": "Millau-Larzac Airfield (France) (LFCM)"
+  },
+  {
+    "id": "LFCQ",
+    "british": false,
+    "label": "Graulhet-Montdragon Airport (France) (LFCQ)"
+  },
+  {
+    "id": "RDZ",
+    "british": false,
+    "label": "Rodez-Marcillac Airport (France) (LFCR / RDZ)"
+  },
+  {
+    "id": "LFCU",
+    "british": false,
+    "label": "Ussel-Thalamy Airport (France) (LFCU)"
+  },
+  {
+    "id": "LFCW",
+    "british": false,
+    "label": "Villeneuve-sur-Lot Airport (France) (LFCW)"
+  },
+  {
+    "id": "RYN",
+    "british": false,
+    "label": "Royan-Médis Airport (France) (LFCY / RYN)"
+  },
+  {
+    "id": "LFCZ",
+    "british": false,
+    "label": "Mimizan Airport (France) (LFCZ)"
+  },
+  {
+    "id": "LFDA",
+    "british": false,
+    "label": "Aire-sur-l'Adour Airport (France) (LFDA)"
+  },
+  {
+    "id": "XMW",
+    "british": false,
+    "label": "Montauban Airport (France) (LFDB / XMW)"
+  },
+  {
+    "id": "LFDH",
+    "british": false,
+    "label": "Auch-Lamothe Airport (France) (LFDH)"
+  },
+  {
+    "id": "LFDI",
+    "british": false,
+    "label": "Libourne-Artigues-de-Lussac Airport (France) (LFDI)"
+  },
+  {
+    "id": "LFDJ",
+    "british": false,
+    "label": "Pamiers-Les Pujols Airport (France) (LFDJ)"
+  },
+  {
+    "id": "LFDM",
+    "british": false,
+    "label": "Marmande-Virazeil Airport (France) (LFDM)"
+  },
+  {
+    "id": "RCO",
+    "british": false,
+    "label": "Rochefort-Saint-Agnant (BA 721) Airport (France) (LFDN / RCO)"
+  },
+  {
+    "id": "LFED",
+    "british": false,
+    "label": "Pontivy Airport (France) (LFED)"
+  },
+  {
+    "id": "LFEH",
+    "british": false,
+    "label": "Aubigny-sur-Nère Airport (France) (LFEH)"
+  },
+  {
+    "id": "LFES",
+    "british": false,
+    "label": "Guiscriff Scaer Airport (France) (LFES)"
+  },
+  {
+    "id": "LFFI",
+    "british": false,
+    "label": "Ancenis Airport (France) (LFFI)"
+  },
+  {
+    "id": "LFFN",
+    "british": false,
+    "label": "Brienne-le-Château Airport (France) (LFFN)"
+  },
+  {
+    "id": "CMR",
+    "british": false,
+    "label": "Colmar-Houssen Airport (France) (LFGA / CMR)"
+  },
+  {
+    "id": "LFGF",
+    "british": false,
+    "label": "Beaune-Challanges Airport (France) (LFGF)"
+  },
+  {
+    "id": "DLE",
+    "british": false,
+    "label": "Dole-Tavaux Airport (France) (LFGJ / DLE)"
+  },
+  {
+    "id": "LFGK",
+    "british": false,
+    "label": "Joigny Airport (France) (LFGK)"
+  },
+  {
+    "id": "LFGW",
+    "british": false,
+    "label": "Verdun-Le Rozelier Airfield (France) (LFGW)"
+  },
+  {
+    "id": "OBS",
+    "british": false,
+    "label": "Aubenas-Ardèche Méridional Airport (France) (LFHO / OBS)"
+  },
+  {
+    "id": "LPY",
+    "british": false,
+    "label": "Le Puy-Loudes Airport (France) (LFHP / LPY)"
+  },
+  {
+    "id": "LFHQ",
+    "british": false,
+    "label": "Saint-Flour-Coltines Airport (France) (LFHQ)"
+  },
+  {
+    "id": "LFHS",
+    "british": false,
+    "label": "Bourg-Ceyzériat Airport (France) (LFHS)"
+  },
+  {
+    "id": "LFHV",
+    "british": false,
+    "label": "Villefranche-Tarare Airport (France) (LFHV)"
+  },
+  {
+    "id": "LFHY",
+    "british": false,
+    "label": "Moulins-Montbeugny Airport (France) (LFHY)"
+  },
+  {
+    "id": "LFIF",
+    "british": false,
+    "label": "Saint-Affrique-Belmont Airport (France) (LFIF)"
+  },
+  {
+    "id": "LFIG",
+    "british": false,
+    "label": "Cassagnes-Bégonhès Airport (France) (LFIG)"
+  },
+  {
+    "id": "ETZ",
+    "british": false,
+    "label": "Metz-Nancy-Lorraine Airport (France) (LFJL / ETZ)"
+  },
+  {
+    "id": "BIA",
+    "british": false,
+    "label": "Bastia-Poretta Airport (France) (LFKB / BIA)"
+  },
+  {
+    "id": "CLY",
+    "british": false,
+    "label": "Calvi-Sainte-Catherine Airport (France) (LFKC / CLY)"
+  },
+  {
+    "id": "FSC",
+    "british": false,
+    "label": "Figari Sud-Corse Airport (France) (LFKF / FSC)"
+  },
+  {
+    "id": "AJA",
+    "british": false,
+    "label": "Ajaccio-Napoléon Bonaparte Airport (France) (LFKJ / AJA)"
+  },
+  {
+    "id": "PRP",
+    "british": false,
+    "label": "Propriano Airport (France) (LFKO / PRP)"
+  },
+  {
+    "id": "SOZ",
+    "british": false,
+    "label": "Solenzara (BA 126) Air Base (France) (LFKS / SOZ)"
+  },
+  {
+    "id": "LFKT",
+    "british": false,
+    "label": "Corte Airport (France) (LFKT)"
+  },
+  {
+    "id": "AUF",
+    "british": false,
+    "label": "Auxerre-Branches Airport (France) (LFLA / AUF)"
+  },
+  {
+    "id": "CMF",
+    "british": false,
+    "label": "Chambéry-Savoie Airport (France) (LFLB / CMF)"
+  },
+  {
+    "id": "CFE",
+    "british": false,
+    "label": "Clermont-Ferrand Auvergne Airport (France) (LFLC / CFE)"
+  },
+  {
+    "id": "BOU",
+    "british": false,
+    "label": "Bourges Airport (France) (LFLD / BOU)"
+  },
+  {
+    "id": "LFLE",
+    "british": false,
+    "label": "Chambéry-Challes-les-Eaux Airport (France) (LFLE)"
+  },
+  {
+    "id": "LFLH",
+    "british": false,
+    "label": "Chalon-Champforgeuil Airport (France) (LFLH)"
+  },
+  {
+    "id": "QNJ",
+    "british": false,
+    "label": "Annemasse Airport (France) (LFLI / QNJ)"
+  },
+  {
+    "id": "LYS",
+    "british": false,
+    "label": "Lyon Saint-Exupéry Airport (France) (LFLL / LYS)"
+  },
+  {
+    "id": "LFLM",
+    "british": false,
+    "label": "Mâcon-Charnay Airport (France) (LFLM)"
+  },
+  {
+    "id": "SYT",
+    "british": false,
+    "label": "Saint-Yan Airport (France) (LFLN / SYT)"
+  },
+  {
+    "id": "RNE",
+    "british": false,
+    "label": "Roanne-Renaison Airport (France) (LFLO / RNE)"
+  },
+  {
+    "id": "NCY",
+    "british": false,
+    "label": "Annecy-Haute-Savoie-Mont Blanc Airport (France) (LFLP / NCY)"
+  },
+  {
+    "id": "GNB",
+    "british": false,
+    "label": "Grenoble-Isère Airport (France) (LFLS / GNB)"
+  },
+  {
+    "id": "LFLT",
+    "british": false,
+    "label": "Montluçon-Domérat Airport (France) (LFLT)"
+  },
+  {
+    "id": "VAF",
+    "british": false,
+    "label": "Valence-Chabeuil Airport (France) (LFLU / VAF)"
+  },
+  {
+    "id": "VHY",
+    "british": false,
+    "label": "Vichy-Charmeil Airport (France) (LFLV / VHY)"
+  },
+  {
+    "id": "AUR",
+    "british": false,
+    "label": "Aurillac Airport (France) (LFLW / AUR)"
+  },
+  {
+    "id": "CHR",
+    "british": false,
+    "label": "Châteauroux-Déols \"Marcel Dassault\" Airport (France) (LFLX / CHR)"
+  },
+  {
+    "id": "LYN",
+    "british": false,
+    "label": "Lyon-Bron Airport (France) (LFLY / LYN)"
+  },
+  {
+    "id": "LFMA",
+    "british": false,
+    "label": "Aix-en-Provence (BA 114) Airport (France) (LFMA)"
+  },
+  {
+    "id": "LFMC",
+    "british": false,
+    "label": "Le Luc-Le Cannet Airport (France) (LFMC)"
+  },
+  {
+    "id": "CEQ",
+    "british": false,
+    "label": "Cannes-Mandelieu Airport (France) (LFMD / CEQ)"
+  },
+  {
+    "id": "EBU",
+    "british": false,
+    "label": "Saint-Étienne-Bouthéon Airport (France) (LFMH / EBU)"
+  },
+  {
+    "id": "LFMI",
+    "british": false,
+    "label": "Istres Le Tubé/Istres Air Base (BA 125) Airport (France) (LFMI)"
+  },
+  {
+    "id": "CCF",
+    "british": false,
+    "label": "Carcassonne Airport (France) (LFMK / CCF)"
+  },
+  {
+    "id": "MRS",
+    "british": false,
+    "label": "Marseille Provence Airport (France) (LFML / MRS)"
+  },
+  {
+    "id": "NCE",
+    "british": false,
+    "label": "Nice-Côte d'Azur Airport (France) (LFMN / NCE)"
+  },
+  {
+    "id": "XOG",
+    "british": false,
+    "label": "Orange-Caritat (BA 115) Air Base (France) (LFMO / XOG)"
+  },
+  {
+    "id": "PGF",
+    "british": false,
+    "label": "Perpignan-Rivesaltes (Llabanère) Airport (France) (LFMP / PGF)"
+  },
+  {
+    "id": "CTT",
+    "british": false,
+    "label": "Le Castellet Airport (France) (LFMQ / CTT)"
+  },
+  {
+    "id": "LFMS",
+    "british": false,
+    "label": "Alès-Deaux Airport (France) (LFMS)"
+  },
+  {
+    "id": "MPL",
+    "british": false,
+    "label": "Montpellier-Méditerranée Airport (France) (LFMT / MPL)"
+  },
+  {
+    "id": "BZR",
+    "british": false,
+    "label": "Béziers-Vias Airport (France) (LFMU / BZR)"
+  },
+  {
+    "id": "AVN",
+    "british": false,
+    "label": "Avignon-Caumont Airport (France) (LFMV / AVN)"
+  },
+  {
+    "id": "LFMY",
+    "british": false,
+    "label": "Salon-de-Provence (BA 701) Air Base (France) (LFMY)"
+  },
+  {
+    "id": "LFMZ",
+    "british": false,
+    "label": "Lézignan-Corbières Airfield (France) (LFMZ)"
+  },
+  {
+    "id": "MEN",
+    "british": false,
+    "label": "Mende-Brenoux Airfield (France) (LFNB / MEN)"
+  },
+  {
+    "id": "LFNH",
+    "british": false,
+    "label": "Carpentras Airport (France) (LFNH)"
+  },
+  {
+    "id": "LFOA",
+    "british": false,
+    "label": "Avord (BA 702) Air Base (France) (LFOA)"
+  },
+  {
+    "id": "BVA",
+    "british": false,
+    "label": "Paris Beauvais Tillé Airport (France) (LFOB / BVA)"
+  },
+  {
+    "id": "LFOC",
+    "british": false,
+    "label": "Châteaudun (BA 279) Air Base (France) (LFOC)"
+  },
+  {
+    "id": "LFOD",
+    "british": false,
+    "label": "Saumur-Saint-Florent Airport (France) (LFOD)"
+  },
+  {
+    "id": "EVX",
+    "british": false,
+    "label": "Évreux-Fauville (BA 105) Air Base (France) (LFOE / EVX)"
+  },
+  {
+    "id": "LEH",
+    "british": false,
+    "label": "Le Havre Octeville Airport (France) (LFOH / LEH)"
+  },
+  {
+    "id": "XAB",
+    "british": false,
+    "label": "Abbeville (France) (LFOI / XAB)"
+  },
+  {
+    "id": "ORE",
+    "british": false,
+    "label": "Orléans-Bricy (BA 123) Air Base (France) (LFOJ / ORE)"
+  },
+  {
+    "id": "XCR",
+    "british": false,
+    "label": "Châlons-Vatry Airport (France) (LFOK / XCR)"
+  },
+  {
+    "id": "URO",
+    "british": false,
+    "label": "Rouen Airport (France) (LFOP / URO)"
+  },
+  {
+    "id": "TUF",
+    "british": false,
+    "label": "Tours-Val-de-Loire Airport (France) (LFOT / TUF)"
+  },
+  {
+    "id": "CET",
+    "british": false,
+    "label": "Cholet Le Pontreau Airport (France) (LFOU / CET)"
+  },
+  {
+    "id": "LVA",
+    "british": false,
+    "label": "Laval-Entrammes Airport (France) (LFOV / LVA)"
+  },
+  {
+    "id": "LFOZ",
+    "british": false,
+    "label": "Orléans-Saint-Denis-de-l'Hôtel Airport (France) (LFOZ)"
+  },
+  {
+    "id": "LBG",
+    "british": false,
+    "label": "Paris-Le Bourget Airport (France) (LFPB / LBG)"
+  },
+  {
+    "id": "CSF",
+    "british": false,
+    "label": "Creil Air Base (France) (LFPC / CSF)"
+  },
+  {
+    "id": "CDG",
+    "british": false,
+    "label": "Charles de Gaulle International Airport (France) (LFPG / CDG)"
+  },
+  {
+    "id": "LFPK",
+    "british": false,
+    "label": "Coulommiers-Voisins Airport (France) (LFPK)"
+  },
+  {
+    "id": "LFPM",
+    "british": false,
+    "label": "Melun-Villaroche Air Base (France) (LFPM)"
+  },
+  {
+    "id": "TNF",
+    "british": false,
+    "label": "Toussus-le-Noble Airport (France) (LFPN / TNF)"
+  },
+  {
+    "id": "ORY",
+    "british": false,
+    "label": "Paris-Orly Airport (France) (LFPO / ORY)"
+  },
+  {
+    "id": "POX",
+    "british": false,
+    "label": "Pontoise - Cormeilles-en-Vexin Airport (France) (LFPT / POX)"
+  },
+  {
+    "id": "VIY",
+    "british": false,
+    "label": "Villacoublay-Vélizy (BA 107) Air Base (France) (LFPV / VIY)"
+  },
+  {
+    "id": "LFQA",
+    "british": false,
+    "label": "Reims-Prunay Airport (France) (LFQA)"
+  },
+  {
+    "id": "LFQB",
+    "british": false,
+    "label": "Troyes-Barberey Airport (France) (LFQB)"
+  },
+  {
+    "id": "LFQC",
+    "british": false,
+    "label": "Lunéville-Croismare Airport (France) (LFQC)"
+  },
+  {
+    "id": "LFQE",
+    "british": false,
+    "label": "Étain-Rouvres Air Base (France) (LFQE)"
+  },
+  {
+    "id": "LFQF",
+    "british": false,
+    "label": "Autun-Bellevue Airport (France) (LFQF)"
+  },
+  {
+    "id": "NVS",
+    "british": false,
+    "label": "Nevers-Fourchambault Airport (France) (LFQG / NVS)"
+  },
+  {
+    "id": "LFQI",
+    "british": false,
+    "label": "Cambrai-Épinoy (BA 103) Air Base (France) (LFQI)"
+  },
+  {
+    "id": "XME",
+    "british": false,
+    "label": "Maubeuge-Élesmes Airport (France) (LFQJ / XME)"
+  },
+  {
+    "id": "LFQM",
+    "british": false,
+    "label": "Besançon-La Vèze Airport (France) (LFQM)"
+  },
+  {
+    "id": "LFQP",
+    "british": false,
+    "label": "Phalsbourg-Bourscheid Air Base (France) (LFQP)"
+  },
+  {
+    "id": "LIL",
+    "british": false,
+    "label": "Lille-Lesquin Airport (France) (LFQQ / LIL)"
+  },
+  {
+    "id": "HZB",
+    "british": false,
+    "label": "Merville-Calonne Airport (France) (LFQT / HZB)"
+  },
+  {
+    "id": "XCZ",
+    "british": false,
+    "label": "Charleville-Mézières Airport (France) (LFQV / XCZ)"
+  },
+  {
+    "id": "LFQW",
+    "british": false,
+    "label": "Vesoul-Frotey Airport (France) (LFQW)"
+  },
+  {
+    "id": "BES",
+    "british": false,
+    "label": "Brest Bretagne Airport (France) (LFRB / BES)"
+  },
+  {
+    "id": "CER",
+    "british": false,
+    "label": "Cherbourg-Maupertus Airport (France) (LFRC / CER)"
+  },
+  {
+    "id": "DNR",
+    "british": false,
+    "label": "Dinard-Pleurtuit-Saint-Malo Airport (France) (LFRD / DNR)"
+  },
+  {
+    "id": "LBY",
+    "british": false,
+    "label": "La Baule-Escoublac Airport (France) (LFRE / LBY)"
+  },
+  {
+    "id": "GFR",
+    "british": false,
+    "label": "Granville Airport (France) (LFRF / GFR)"
+  },
+  {
+    "id": "DOL",
+    "british": false,
+    "label": "Deauville-Saint-Gatien Airport (France) (LFRG / DOL)"
+  },
+  {
+    "id": "LRT",
+    "british": false,
+    "label": "Lorient South Brittany (Bretagne Sud) Airport (France) (LFRH / LRT)"
+  },
+  {
+    "id": "EDM",
+    "british": false,
+    "label": "La Roche-sur-Yon Airport (France) (LFRI / EDM)"
+  },
+  {
+    "id": "LDV",
+    "british": false,
+    "label": "Landivisiau Air Base (France) (LFRJ / LDV)"
+  },
+  {
+    "id": "CFR",
+    "british": false,
+    "label": "Caen-Carpiquet Airport (France) (LFRK / CFR)"
+  },
+  {
+    "id": "LFRL",
+    "british": false,
+    "label": "Lanvéoc-Poulmic Air Base (France) (LFRL)"
+  },
+  {
+    "id": "LME",
+    "british": false,
+    "label": "Le Mans-Arnage Airport (France) (LFRM / LME)"
+  },
+  {
+    "id": "RNS",
+    "british": false,
+    "label": "Rennes-Saint-Jacques Airport (France) (LFRN / RNS)"
+  },
+  {
+    "id": "LAI",
+    "british": false,
+    "label": "Lannion-Côte de Granit Airport (France) (LFRO / LAI)"
+  },
+  {
+    "id": "UIP",
+    "british": false,
+    "label": "Quimper-Cornouaille Airport (France) (LFRQ / UIP)"
+  },
+  {
+    "id": "NTE",
+    "british": false,
+    "label": "Nantes Atlantique Airport (France) (LFRS / NTE)"
+  },
+  {
+    "id": "SBK",
+    "british": false,
+    "label": "Saint-Brieuc-Armor Airport (France) (LFRT / SBK)"
+  },
+  {
+    "id": "MXN",
+    "british": false,
+    "label": "Morlaix-Ploujean Airport (France) (LFRU / MXN)"
+  },
+  {
+    "id": "VNE",
+    "british": false,
+    "label": "Vannes-Meucon Airport (France) (LFRV / VNE)"
+  },
+  {
+    "id": "SNR",
+    "british": false,
+    "label": "Saint-Nazaire-Montoir Airport (France) (LFRZ / SNR)"
+  },
+  {
+    "id": "BSL",
+    "british": false,
+    "label": "EuroAirport Basel-Mulhouse-Freiburg Airport (France) (LFSB / BSL)"
+  },
+  {
+    "id": "LFSC",
+    "british": false,
+    "label": "Colmar-Meyenheim Air Base (France) (LFSC)"
+  },
+  {
+    "id": "DIJ",
+    "british": false,
+    "label": "Dijon-Bourgogne Airport (France) (LFSD / DIJ)"
+  },
+  {
+    "id": "MZM",
+    "british": false,
+    "label": "Metz-Frescaty (BA 128) Air Base (France) (LFSF / MZM)"
+  },
+  {
+    "id": "EPL",
+    "british": false,
+    "label": "Épinal-Mirecourt Airport (France) (LFSG / EPL)"
+  },
+  {
+    "id": "LFSH",
+    "british": false,
+    "label": "Haguenau Airport (France) (LFSH)"
+  },
+  {
+    "id": "LFSI",
+    "british": false,
+    "label": "Saint-Dizier-Robinson (BA 113) Air Base (France) (LFSI)"
+  },
+  {
+    "id": "LFSM",
+    "british": false,
+    "label": "Montbéliard-Courcelles Airfield (France) (LFSM)"
+  },
+  {
+    "id": "ENC",
+    "british": false,
+    "label": "Nancy-Essey Airport (France) (LFSN / ENC)"
+  },
+  {
+    "id": "LFSO",
+    "british": false,
+    "label": "Nancy-Ochey (BA 133) Air Base (France) (LFSO)"
+  },
+  {
+    "id": "LFSP",
+    "british": false,
+    "label": "Pontarlier Airport (France) (LFSP)"
+  },
+  {
+    "id": "RHE",
+    "british": false,
+    "label": "Reims-Champagne (BA 112) Air Base (France) (LFSR / RHE)"
+  },
+  {
+    "id": "SXB",
+    "british": false,
+    "label": "Strasbourg Airport (France) (LFST / SXB)"
+  },
+  {
+    "id": "LFSX",
+    "british": false,
+    "label": "Luxeuil-Saint-Sauveur (BA 116) Air Base (France) (LFSX)"
+  },
+  {
+    "id": "LFTF",
+    "british": false,
+    "label": "Cuers-Pierrefeu Airport (France) (LFTF)"
+  },
+  {
+    "id": "TLN",
+    "british": false,
+    "label": "Toulon-Hyères Airport (France) (LFTH / TLN)"
+  },
+  {
+    "id": "FNI",
+    "british": false,
+    "label": "Nîmes-Arles-Camargue Airport (France) (LFTW / FNI)"
+  },
+  {
+    "id": "MQC",
+    "british": false,
+    "label": "Miquelon Airport (Saint Pierre and Miquelon) (LFVM / MQC)"
+  },
+  {
+    "id": "FSP",
+    "british": false,
+    "label": "St Pierre Airport (Saint Pierre and Miquelon) (LFVP / FSP)"
+  },
+  {
+    "id": "LFXA",
+    "british": false,
+    "label": "Ambérieu Air Base (BA 278) (France) (LFXA)"
+  },
+  {
+    "id": "LFYD",
+    "british": false,
+    "label": "Damblain Airport (France) (LFYD)"
+  },
+  {
+    "id": "PYR",
+    "british": false,
+    "label": "Andravida Air Base (Greece) (LGAD / PYR)"
+  },
+  {
+    "id": "AGQ",
+    "british": false,
+    "label": "Agrinion Air Base (Greece) (LGAG / AGQ)"
+  },
+  {
+    "id": "AXD",
+    "british": false,
+    "label": "Dimokritos Airport (Greece) (LGAL / AXD)"
+  },
+  {
+    "id": "LGAX",
+    "british": false,
+    "label": "Alexandria Airport (Greece) (LGAX)"
+  },
+  {
+    "id": "VOL",
+    "british": false,
+    "label": "Nea Anchialos Airport (Greece) (LGBL / VOL)"
+  },
+  {
+    "id": "LGEL",
+    "british": false,
+    "label": "Elefsis Airport (Greece) (LGEL)"
+  },
+  {
+    "id": "JKH",
+    "british": false,
+    "label": "Chios Island National Airport (Greece) (LGHI / JKH)"
+  },
+  {
+    "id": "IOA",
+    "british": false,
+    "label": "Ioannina Airport (Greece) (LGIO / IOA)"
+  },
+  {
+    "id": "HER",
+    "british": false,
+    "label": "Heraklion International Nikos Kazantzakis Airport (Greece) (LGIR / HER)"
+  },
+  {
+    "id": "KSO",
+    "british": false,
+    "label": "Kastoria National Airport (Greece) (LGKA / KSO)"
+  },
+  {
+    "id": "KIT",
+    "british": false,
+    "label": "Kithira Airport (Greece) (LGKC / KIT)"
+  },
+  {
+    "id": "EFL",
+    "british": false,
+    "label": "Kefallinia Airport (Greece) (LGKF / EFL)"
+  },
+  {
+    "id": "KLX",
+    "british": false,
+    "label": "Kalamata Airport (Greece) (LGKL / KLX)"
+  },
+  {
+    "id": "LGKM",
+    "british": false,
+    "label": "Amigdhaleon Airport (Greece) (LGKM)"
+  },
+  {
+    "id": "KGS",
+    "british": false,
+    "label": "Kos Airport (Greece) (LGKO / KGS)"
+  },
+  {
+    "id": "AOK",
+    "british": false,
+    "label": "Karpathos Airport (Greece) (LGKP / AOK)"
+  },
+  {
+    "id": "CFU",
+    "british": false,
+    "label": "Ioannis Kapodistrias International Airport (Greece) (LGKR / CFU)"
+  },
+  {
+    "id": "KSJ",
+    "british": false,
+    "label": "Kasos Airport (Greece) (LGKS / KSJ)"
+  },
+  {
+    "id": "KVA",
+    "british": false,
+    "label": "Alexander the Great International Airport (Greece) (LGKV / KVA)"
+  },
+  {
+    "id": "KZI",
+    "british": false,
+    "label": "Filippos Airport (Greece) (LGKZ / KZI)"
+  },
+  {
+    "id": "LRS",
+    "british": false,
+    "label": "Leros Airport (Greece) (LGLE / LRS)"
+  },
+  {
+    "id": "LXS",
+    "british": false,
+    "label": "Limnos Airport (Greece) (LGLM / LXS)"
+  },
+  {
+    "id": "LRA",
+    "british": false,
+    "label": "Larisa Airport (Greece) (LGLR / LRA)"
+  },
+  {
+    "id": "LGMG",
+    "british": false,
+    "label": "Megara Airport (Greece) (LGMG)"
+  },
+  {
+    "id": "JMK",
+    "british": false,
+    "label": "Mikonos Airport (Greece) (LGMK / JMK)"
+  },
+  {
+    "id": "MJT",
+    "british": false,
+    "label": "Mytilene International Airport (Greece) (LGMT / MJT)"
+  },
+  {
+    "id": "PVK",
+    "british": false,
+    "label": "Aktion National Airport (Greece) (LGPZ / PVK)"
+  },
+  {
+    "id": "LGRD",
+    "british": false,
+    "label": "Maritsa Airport (Greece) (LGRD)"
+  },
+  {
+    "id": "RHO",
+    "british": false,
+    "label": "Diagoras Airport (Greece) (LGRP / RHO)"
+  },
+  {
+    "id": "GPA",
+    "british": false,
+    "label": "Araxos Airport (Greece) (LGRX / GPA)"
+  },
+  {
+    "id": "CHQ",
+    "british": false,
+    "label": "Chania International Airport (Greece) (LGSA / CHQ)"
+  },
+  {
+    "id": "JSI",
+    "british": false,
+    "label": "Skiathos Island National Airport (Greece) (LGSK / JSI)"
+  },
+  {
+    "id": "SMI",
+    "british": false,
+    "label": "Samos Airport (Greece) (LGSM / SMI)"
+  },
+  {
+    "id": "SPJ",
+    "british": false,
+    "label": "Sparti Airport (Greece) (LGSP / SPJ)"
+  },
+  {
+    "id": "JTR",
+    "british": false,
+    "label": "Santorini Airport (Greece) (LGSR / JTR)"
+  },
+  {
+    "id": "JSH",
+    "british": false,
+    "label": "Sitia Airport (Greece) (LGST / JSH)"
+  },
+  {
+    "id": "LGSV",
+    "british": false,
+    "label": "Stefanovikion Air Base (Greece) (LGSV)"
+  },
+  {
+    "id": "SKU",
+    "british": false,
+    "label": "Skiros Airport (Greece) (LGSY / SKU)"
+  },
+  {
+    "id": "LGTG",
+    "british": false,
+    "label": "Tanagra Air Base (Greece) (LGTG)"
+  },
+  {
+    "id": "LGTL",
+    "british": false,
+    "label": "Kasteli Airport (Greece) (LGTL)"
+  },
+  {
+    "id": "LGTP",
+    "british": false,
+    "label": "Tripolis Airport (Greece) (LGTP)"
+  },
+  {
+    "id": "SKG",
+    "british": false,
+    "label": "Thessaloniki Macedonia International Airport (Greece) (LGTS / SKG)"
+  },
+  {
+    "id": "LGTT",
+    "british": false,
+    "label": "Tatoi Airport (Greece) (LGTT)"
+  },
+  {
+    "id": "ZTH",
+    "british": false,
+    "label": "Zakynthos International Airport \"Dionysios Solomos\" (Greece) (LGZA / ZTH)"
+  },
+  {
+    "id": "BUD",
+    "british": false,
+    "label": "Budapest Liszt Ferenc International Airport (Hungary) (LHBP / BUD)"
+  },
+  {
+    "id": "DEB",
+    "british": false,
+    "label": "Debrecen International Airport (Hungary) (LHDC / DEB)"
+  },
+  {
+    "id": "LHKE",
+    "british": false,
+    "label": "Kecskemét Airport (Hungary) (LHKE)"
+  },
+  {
+    "id": "LHNY",
+    "british": false,
+    "label": "Nyíregyháza Airport (Hungary) (LHNY)"
+  },
+  {
+    "id": "LHOY",
+    "british": false,
+    "label": "Őcsény Airport (Hungary) (LHOY)"
+  },
+  {
+    "id": "LHSA",
+    "british": false,
+    "label": "Szentkirályszabadja Airport (Hungary) (LHSA)"
+  },
+  {
+    "id": "LHSN",
+    "british": false,
+    "label": "Szolnok Air Base (Hungary) (LHSN)"
+  },
+  {
+    "id": "LIBA",
+    "british": false,
+    "label": "Amendola Air Base (Italy) (LIBA)"
+  },
+  {
+    "id": "CRV",
+    "british": false,
+    "label": "Crotone Airport (Italy) (LIBC / CRV)"
+  },
+  {
+    "id": "BRI",
+    "british": false,
+    "label": "Bari Karol Wojtyła Airport (Italy) (LIBD / BRI)"
+  },
+  {
+    "id": "FOG",
+    "british": false,
+    "label": "Foggia \"Gino Lisa\" Airport (Italy) (LIBF / FOG)"
+  },
+  {
+    "id": "TAR",
+    "british": false,
+    "label": "Taranto-Grottaglie \"Marcello Arlotta\" Airport (Italy) (LIBG / TAR)"
+  },
+  {
+    "id": "LCC",
+    "british": false,
+    "label": "Lecce Galatina Air Base (Italy) (LIBN / LCC)"
+  },
+  {
+    "id": "PSR",
+    "british": false,
+    "label": "Pescara International Airport (Italy) (LIBP / PSR)"
+  },
+  {
+    "id": "BDS",
+    "british": false,
+    "label": "Brindisi – Salento Airport (Italy) (LIBR / BDS)"
+  },
+  {
+    "id": "LIBV",
+    "british": false,
+    "label": "Gioia Del Colle Air Base (Italy) (LIBV)"
+  },
+  {
+    "id": "SUF",
+    "british": false,
+    "label": "Lamezia Terme Airport (Italy) (LICA / SUF)"
+  },
+  {
+    "id": "CTA",
+    "british": false,
+    "label": "Catania-Fontanarossa Airport (Italy) (LICC / CTA)"
+  },
+  {
+    "id": "LMP",
+    "british": false,
+    "label": "Lampedusa Airport (Italy) (LICD / LMP)"
+  },
+  {
+    "id": "PNL",
+    "british": false,
+    "label": "Pantelleria Airport (Italy) (LICG / PNL)"
+  },
+  {
+    "id": "PMO",
+    "british": false,
+    "label": "Falcone–Borsellino Airport (Italy) (LICJ / PMO)"
+  },
+  {
+    "id": "LICP",
+    "british": false,
+    "label": "Palermo-Boccadifalco Airport (Italy) (LICP)"
+  },
+  {
+    "id": "REG",
+    "british": false,
+    "label": "Reggio Calabria Airport (Italy) (LICR / REG)"
+  },
+  {
+    "id": "TPS",
+    "british": false,
+    "label": "Vincenzo Florio Airport Trapani-Birgi (Italy) (LICT / TPS)"
+  },
+  {
+    "id": "NSY",
+    "british": false,
+    "label": "Sigonella Navy Air Base (Italy) (LICZ / NSY)"
+  },
+  {
+    "id": "AHO",
+    "british": false,
+    "label": "Alghero-Fertilia Airport (Italy) (LIEA / AHO)"
+  },
+  {
+    "id": "DCI",
+    "british": false,
+    "label": "Decimomannu Air Base (Italy) (LIED / DCI)"
+  },
+  {
+    "id": "CAG",
+    "british": false,
+    "label": "Cagliari Elmas Airport (Italy) (LIEE / CAG)"
+  },
+  {
+    "id": "OLB",
+    "british": false,
+    "label": "Olbia Costa Smeralda Airport (Italy) (LIEO / OLB)"
+  },
+  {
+    "id": "TTB",
+    "british": false,
+    "label": "Tortolì Airport (Italy) (LIET / TTB)"
+  },
+  {
+    "id": "LIMA",
+    "british": false,
+    "label": "Torino-Aeritalia Airport (Italy) (LIMA)"
+  },
+  {
+    "id": "LIMB",
+    "british": false,
+    "label": "Milano-Bresso Airfield (Italy) (LIMB)"
+  },
+  {
+    "id": "MXP",
+    "british": false,
+    "label": "Malpensa International Airport (Italy) (LIMC / MXP)"
+  },
+  {
+    "id": "BGY",
+    "british": false,
+    "label": "Il Caravaggio International Airport (Italy) (LIME / BGY)"
+  },
+  {
+    "id": "TRN",
+    "british": false,
+    "label": "Turin Airport (Italy) (LIMF / TRN)"
+  },
+  {
+    "id": "ALL",
+    "british": false,
+    "label": "Villanova D'Albenga International Airport (Italy) (LIMG / ALL)"
+  },
+  {
+    "id": "GOA",
+    "british": false,
+    "label": "Genoa Cristoforo Colombo Airport (Italy) (LIMJ / GOA)"
+  },
+  {
+    "id": "LIN",
+    "british": false,
+    "label": "Milano Linate Airport (Italy) (LIML / LIN)"
+  },
+  {
+    "id": "LIMN",
+    "british": false,
+    "label": "Cameri Air Base [MIL] (Italy) (LIMN)"
+  },
+  {
+    "id": "PMF",
+    "british": false,
+    "label": "Parma Airport (Italy) (LIMP / PMF)"
+  },
+  {
+    "id": "LIMS",
+    "british": false,
+    "label": "Piacenza San Damiano Air Base (Italy) (LIMS)"
+  },
+  {
+    "id": "CUF",
+    "british": false,
+    "label": "Cuneo International Airport (Italy) (LIMZ / CUF)"
+  },
+  {
+    "id": "AVB",
+    "british": false,
+    "label": "Aviano Air Base (Italy) (LIPA / AVB)"
+  },
+  {
+    "id": "BZO",
+    "british": false,
+    "label": "Bolzano Airport (Italy) (LIPB / BZO)"
+  },
+  {
+    "id": "LIPC",
+    "british": false,
+    "label": "Cervia Air Base (Italy) (LIPC)"
+  },
+  {
+    "id": "BLQ",
+    "british": false,
+    "label": "Bologna Guglielmo Marconi Airport (Italy) (LIPE / BLQ)"
+  },
+  {
+    "id": "TSF",
+    "british": false,
+    "label": "Treviso-Sant'Angelo Airport (Italy) (LIPH / TSF)"
+  },
+  {
+    "id": "LIPI",
+    "british": false,
+    "label": "Rivolto Air Base (Italy) (LIPI)"
+  },
+  {
+    "id": "FRL",
+    "british": false,
+    "label": "Forlì Airport (Italy) (LIPK / FRL)"
+  },
+  {
+    "id": "LIPL",
+    "british": false,
+    "label": "Ghedi Air Base (Italy) (LIPL)"
+  },
+  {
+    "id": "LIPN",
+    "british": false,
+    "label": "Verona-Boscomantico Airport (Italy) (LIPN)"
+  },
+  {
+    "id": "VBS",
+    "british": false,
+    "label": "Brescia Airport (Italy) (LIPO / VBS)"
+  },
+  {
+    "id": "TRS",
+    "british": false,
+    "label": "Trieste–Friuli Venezia Giulia Airport (Italy) (LIPQ / TRS)"
+  },
+  {
+    "id": "RMI",
+    "british": false,
+    "label": "Federico Fellini International Airport (Italy) (LIPR / RMI)"
+  },
+  {
+    "id": "LIPS",
+    "british": false,
+    "label": "Istrana Air Base (Italy) (LIPS)"
+  },
+  {
+    "id": "VIC",
+    "british": false,
+    "label": "Vicenza Airport (Italy) (LIPT / VIC)"
+  },
+  {
+    "id": "QPA",
+    "british": false,
+    "label": "Padova Airport (Italy) (LIPU / QPA)"
+  },
+  {
+    "id": "VRN",
+    "british": false,
+    "label": "Verona Villafranca Airport (Italy) (LIPX / VRN)"
+  },
+  {
+    "id": "VCE",
+    "british": false,
+    "label": "Venice Marco Polo Airport (Italy) (LIPZ / VCE)"
+  },
+  {
+    "id": "SAY",
+    "british": false,
+    "label": "Siena-Ampugnano Airport (Italy) (LIQS / SAY)"
+  },
+  {
+    "id": "CIA",
+    "british": false,
+    "label": "Ciampino–G. B. Pastine International Airport (Italy) (LIRA / CIA)"
+  },
+  {
+    "id": "LIRE",
+    "british": false,
+    "label": "Pratica Di Mare Air Base (Italy) (LIRE)"
+  },
+  {
+    "id": "FCO",
+    "british": false,
+    "label": "Leonardo da Vinci–Fiumicino Airport (Italy) (LIRF / FCO)"
+  },
+  {
+    "id": "LIRG",
+    "british": false,
+    "label": "Guidonia Air Base (Italy) (LIRG)"
+  },
+  {
+    "id": "EBA",
+    "british": false,
+    "label": "Marina Di Campo Airport (Italy) (LIRJ / EBA)"
+  },
+  {
+    "id": "QLT",
+    "british": false,
+    "label": "Latina Air Base (Italy) (LIRL / QLT)"
+  },
+  {
+    "id": "LIRM",
+    "british": false,
+    "label": "Grazzanise Air Base (Italy) (LIRM)"
+  },
+  {
+    "id": "NAP",
+    "british": false,
+    "label": "Naples International Airport (Italy) (LIRN / NAP)"
+  },
+  {
+    "id": "PSA",
+    "british": false,
+    "label": "Pisa International Airport (Italy) (LIRP / PSA)"
+  },
+  {
+    "id": "FLR",
+    "british": false,
+    "label": "Peretola Airport (Italy) (LIRQ / FLR)"
+  },
+  {
+    "id": "GRS",
+    "british": false,
+    "label": "Grosseto Air Base (Italy) (LIRS / GRS)"
+  },
+  {
+    "id": "LIRU",
+    "british": false,
+    "label": "Urbe Airport (Italy) (LIRU)"
+  },
+  {
+    "id": "LIRV",
+    "british": false,
+    "label": "Viterbo Airport (Italy) (LIRV)"
+  },
+  {
+    "id": "PEG",
+    "british": false,
+    "label": "Perugia San Francesco d'Assisi – Umbria International Airport (Italy) (LIRZ / PEG)"
+  },
+  {
+    "id": "LJCE",
+    "british": false,
+    "label": "Cerklje Airport (Slovenia) (LJCE)"
+  },
+  {
+    "id": "LJU",
+    "british": false,
+    "label": "Ljubljana Jože Pučnik Airport (Slovenia) (LJLJ / LJU)"
+  },
+  {
+    "id": "MBX",
+    "british": false,
+    "label": "Maribor Airport (Slovenia) (LJMB / MBX)"
+  },
+  {
+    "id": "POW",
+    "british": false,
+    "label": "Portoroz Airport (Slovenia) (LJPZ / POW)"
+  },
+  {
+    "id": "LJSG",
+    "british": false,
+    "label": "Slovenj Gradec Airport (Slovenia) (LJSG)"
+  },
+  {
+    "id": "LKCS",
+    "british": false,
+    "label": "České Budějovice Airport (Czech Republic) (LKCS)"
+  },
+  {
+    "id": "LKCV",
+    "british": false,
+    "label": "Čáslav Air Base (Czech Republic) (LKCV)"
+  },
+  {
+    "id": "LKHK",
+    "british": false,
+    "label": "Hradec Králové Airport (Czech Republic) (LKHK)"
+  },
+  {
+    "id": "LKHV",
+    "british": false,
+    "label": "Hořovice Airport (Czech Republic) (LKHV)"
+  },
+  {
+    "id": "LKKB",
+    "british": false,
+    "label": "Kbely Air Base (Czech Republic) (LKKB)"
+  },
+  {
+    "id": "UHE",
+    "british": false,
+    "label": "Kunovice Airport (Czech Republic) (LKKU / UHE)"
+  },
+  {
+    "id": "KLV",
+    "british": false,
+    "label": "Karlovy Vary International Airport (Czech Republic) (LKKV / KLV)"
+  },
+  {
+    "id": "LKLN",
+    "british": false,
+    "label": "Plzeň-Líně Airport (Czech Republic) (LKLN)"
+  },
+  {
+    "id": "LKMH",
+    "british": false,
+    "label": "Mnichovo Hradiště Airport (Czech Republic) (LKMH)"
+  },
+  {
+    "id": "OSR",
+    "british": false,
+    "label": "Ostrava Leos Janáček Airport (Czech Republic) (LKMT / OSR)"
+  },
+  {
+    "id": "LKNA",
+    "british": false,
+    "label": "Náměšť Air Base (Czech Republic) (LKNA)"
+  },
+  {
+    "id": "PED",
+    "british": false,
+    "label": "Pardubice Airport (Czech Republic) (LKPD / PED)"
+  },
+  {
+    "id": "LKPM",
+    "british": false,
+    "label": "Pribram Airport (Czech Republic) (LKPM)"
+  },
+  {
+    "id": "PRV",
+    "british": false,
+    "label": "Přerov Air Base (Czech Republic) (LKPO / PRV)"
+  },
+  {
+    "id": "PRG",
+    "british": false,
+    "label": "Václav Havel Airport Prague (Czech Republic) (LKPR / PRG)"
+  },
+  {
+    "id": "BRQ",
+    "british": false,
+    "label": "Brno-Tuřany Airport (Czech Republic) (LKTB / BRQ)"
+  },
+  {
+    "id": "VOD",
+    "british": false,
+    "label": "Vodochody Airport (Czech Republic) (LKVO / VOD)"
+  },
+  {
+    "id": "TLV",
+    "british": false,
+    "label": "Ben Gurion International Airport (Israel) (LLBG / TLV)"
+  },
+  {
+    "id": "BEV",
+    "british": false,
+    "label": "Beersheba (Teyman) Airport (Israel) (LLBS / BEV)"
+  },
+  {
+    "id": "LLEK",
+    "british": false,
+    "label": "Tel Nof Air Base (Israel) (LLEK)"
+  },
+  {
+    "id": "LLES",
+    "british": false,
+    "label": "Ein Shemer Airfield (Israel) (LLES)"
+  },
+  {
+    "id": "ETH",
+    "british": false,
+    "label": "Eilat Airport (Israel) (LLET / ETH)"
+  },
+  {
+    "id": "EIY",
+    "british": false,
+    "label": "Ein Yahav Airfield (Israel) (LLEY / EIY)"
+  },
+  {
+    "id": "HFA",
+    "british": false,
+    "label": "Haifa International Airport (Israel) (LLHA / HFA)"
+  },
+  {
+    "id": "LLHS",
+    "british": false,
+    "label": "Hatzor Air Base (Israel) (LLHS)"
+  },
+  {
+    "id": "RPN",
+    "british": false,
+    "label": "Ben Ya'akov Airport (Israel) (LLIB / RPN)"
+  },
+  {
+    "id": "LLMG",
+    "british": false,
+    "label": "Megiddo Airport (Israel) (LLMG)"
+  },
+  {
+    "id": "MTZ",
+    "british": false,
+    "label": "Bar Yehuda Airfield (Israel) (LLMZ / MTZ)"
+  },
+  {
+    "id": "VTM",
+    "british": false,
+    "label": "Nevatim Air Base (Israel) (LLNV / VTM)"
+  },
+  {
+    "id": "VDA",
+    "british": false,
+    "label": "Ovda International Airport (Israel) (LLOV / VDA)"
+  },
+  {
+    "id": "LLRD",
+    "british": false,
+    "label": "Ramat David Air Base (Israel) (LLRD)"
+  },
+  {
+    "id": "MIP",
+    "british": false,
+    "label": "Ramon Air Base (Israel) (LLRM / MIP)"
+  },
+  {
+    "id": "SDV",
+    "british": false,
+    "label": "Sde Dov Airport (Israel) (LLSD / SDV)"
+  },
+  {
+    "id": "MLA",
+    "british": false,
+    "label": "Malta International Airport (Malta) (LMML / MLA)"
+  },
+  {
+    "id": "LOAN",
+    "british": false,
+    "label": "Wiener Neustadt East Airport (Austria) (LOAN)"
+  },
+  {
+    "id": "LOLW",
+    "british": false,
+    "label": "Wels Airport (Austria) (LOLW)"
+  },
+  {
+    "id": "GRZ",
+    "british": false,
+    "label": "Graz Airport (Austria) (LOWG / GRZ)"
+  },
+  {
+    "id": "INN",
+    "british": false,
+    "label": "Innsbruck Airport (Austria) (LOWI / INN)"
+  },
+  {
+    "id": "LNZ",
+    "british": false,
+    "label": "Linz Hörsching Airport (Austria) (LOWL / LNZ)"
+  },
+  {
+    "id": "SZG",
+    "british": false,
+    "label": "Salzburg Airport (Austria) (LOWS / SZG)"
+  },
+  {
+    "id": "VIE",
+    "british": false,
+    "label": "Vienna International Airport (Austria) (LOWW / VIE)"
+  },
+  {
+    "id": "LOXZ",
+    "british": false,
+    "label": "Hinterstoisser Air Base (Austria) (LOXZ)"
+  },
+  {
+    "id": "AVR",
+    "british": false,
+    "label": "Alverca Air Base (Portugal) (LPAR / AVR)"
+  },
+  {
+    "id": "SMA",
+    "british": false,
+    "label": "Santa Maria Airport (Portugal) (LPAZ / SMA)"
+  },
+  {
+    "id": "BGC",
+    "british": false,
+    "label": "Bragança Airport (Portugal) (LPBG / BGC)"
+  },
+  {
+    "id": "BYJ",
+    "british": false,
+    "label": "Beja Airport / Airbase (Portugal) (LPBJ / BYJ)"
+  },
+  {
+    "id": "BGZ",
+    "british": false,
+    "label": "Braga Municipal Aerodrome (Portugal) (LPBR / BGZ)"
+  },
+  {
+    "id": "LPCO",
+    "british": false,
+    "label": "Aerodromo Municipal de Coimbra (Portugal) (LPCO)"
+  },
+  {
+    "id": "CAT",
+    "british": false,
+    "label": "Cascais Airport (Portugal) (LPCS / CAT)"
+  },
+  {
+    "id": "LPCV",
+    "british": false,
+    "label": "Coimbra Hospital Covões Heliport (Portugal) (LPCV)"
+  },
+  {
+    "id": "LPEV",
+    "british": false,
+    "label": "Évora Airport (Portugal) (LPEV)"
+  },
+  {
+    "id": "FLW",
+    "british": false,
+    "label": "Flores Airport (Portugal) (LPFL / FLW)"
+  },
+  {
+    "id": "FAO",
+    "british": false,
+    "label": "Faro Airport (Portugal) (LPFR / FAO)"
+  },
+  {
+    "id": "GRW",
+    "british": false,
+    "label": "Graciosa Airport (Portugal) (LPGR / GRW)"
+  },
+  {
+    "id": "HOR",
+    "british": false,
+    "label": "Horta Airport (Portugal) (LPHR / HOR)"
+  },
+  {
+    "id": "TER",
+    "british": false,
+    "label": "Lajes Airport (Portugal) (LPLA / TER)"
+  },
+  {
+    "id": "QLR",
+    "british": false,
+    "label": "Monte Real Air Base (Portugal) (LPMR / QLR)"
+  },
+  {
+    "id": "LPMT",
+    "british": false,
+    "label": "Montijo Air Base (Portugal) (LPMT)"
+  },
+  {
+    "id": "LPOV",
+    "british": false,
+    "label": "Ovar Air Base (Portugal) (LPOV)"
+  },
+  {
+    "id": "PDL",
+    "british": false,
+    "label": "João Paulo II Airport (Portugal) (LPPD / PDL)"
+  },
+  {
+    "id": "PIX",
+    "british": false,
+    "label": "Pico Airport (Portugal) (LPPI / PIX)"
+  },
+  {
+    "id": "PRM",
+    "british": false,
+    "label": "Portimão Airport (Portugal) (LPPM / PRM)"
+  },
+  {
+    "id": "OPO",
+    "british": false,
+    "label": "Francisco de Sá Carneiro Airport (Portugal) (LPPR / OPO)"
+  },
+  {
+    "id": "PXO",
+    "british": false,
+    "label": "Porto Santo Airport (Portugal) (LPPS / PXO)"
+  },
+  {
+    "id": "LIS",
+    "british": false,
+    "label": "Humberto Delgado Airport (Lisbon Portela Airport) (Portugal) (LPPT / LIS)"
+  },
+  {
+    "id": "SJZ",
+    "british": false,
+    "label": "São Jorge Airport (Portugal) (LPSJ / SJZ)"
+  },
+  {
+    "id": "LPST",
+    "british": false,
+    "label": "Sintra Air Base (Portugal) (LPST)"
+  },
+  {
+    "id": "LPTN",
+    "british": false,
+    "label": "Tancos Airbase (Portugal) (LPTN)"
+  },
+  {
+    "id": "VRL",
+    "british": false,
+    "label": "Vila Real Airport (Portugal) (LPVR / VRL)"
+  },
+  {
+    "id": "VSE",
+    "british": false,
+    "label": "Aerodromo Goncalves Lobato (Viseu Airport) (Portugal) (LPVZ / VSE)"
+  },
+  {
+    "id": "OMO",
+    "british": false,
+    "label": "Mostar International Airport (Bosnia and Herzegovina) (LQMO / OMO)"
+  },
+  {
+    "id": "SJJ",
+    "british": false,
+    "label": "Sarajevo International Airport (Bosnia and Herzegovina) (LQSA / SJJ)"
+  },
+  {
+    "id": "ARW",
+    "british": false,
+    "label": "Arad International Airport (Romania) (LRAR / ARW)"
+  },
+  {
+    "id": "BCM",
+    "british": false,
+    "label": "Bacău Airport (Romania) (LRBC / BCM)"
+  },
+  {
+    "id": "BAY",
+    "british": false,
+    "label": "Tautii Magheraus Airport (Romania) (LRBM / BAY)"
+  },
+  {
+    "id": "BBU",
+    "british": false,
+    "label": "Băneasa International Airport (Romania) (LRBS / BBU)"
+  },
+  {
+    "id": "CND",
+    "british": false,
+    "label": "Mihail Kogălniceanu International Airport (Romania) (LRCK / CND)"
+  },
+  {
+    "id": "CLJ",
+    "british": false,
+    "label": "Cluj-Napoca International Airport (Romania) (LRCL / CLJ)"
+  },
+  {
+    "id": "CSB",
+    "british": false,
+    "label": "Caransebeş Airport (Romania) (LRCS / CSB)"
+  },
+  {
+    "id": "CRA",
+    "british": false,
+    "label": "Craiova Airport (Romania) (LRCV / CRA)"
+  },
+  {
+    "id": "IAS",
+    "british": false,
+    "label": "Iaşi Airport (Romania) (LRIA / IAS)"
+  },
+  {
+    "id": "OMR",
+    "british": false,
+    "label": "Oradea International Airport (Romania) (LROD / OMR)"
+  },
+  {
+    "id": "OTP",
+    "british": false,
+    "label": "Henri Coandă International Airport (Romania) (LROP / OTP)"
+  },
+  {
+    "id": "SBZ",
+    "british": false,
+    "label": "Sibiu International Airport (Romania) (LRSB / SBZ)"
+  },
+  {
+    "id": "SUJ",
+    "british": false,
+    "label": "Satu Mare Airport (Romania) (LRSM / SUJ)"
+  },
+  {
+    "id": "SCV",
+    "british": false,
+    "label": "Suceava Stefan cel Mare Airport (Romania) (LRSV / SCV)"
+  },
+  {
+    "id": "TCE",
+    "british": false,
+    "label": "Tulcea Airport (Romania) (LRTC / TCE)"
+  },
+  {
+    "id": "TGM",
+    "british": false,
+    "label": "Transilvania Târgu Mureş International Airport (Romania) (LRTM / TGM)"
+  },
+  {
+    "id": "TSR",
+    "british": false,
+    "label": "Timişoara Traian Vuia Airport (Romania) (LRTR / TSR)"
+  },
+  {
+    "id": "LSGC",
+    "british": false,
+    "label": "Les Eplatures Airport (Switzerland) (LSGC)"
+  },
+  {
+    "id": "GVA",
+    "british": false,
+    "label": "Geneva Cointrin International Airport (Switzerland) (LSGG / GVA)"
+  },
+  {
+    "id": "LSGK",
+    "british": false,
+    "label": "Saanen Airport (Switzerland) (LSGK)"
+  },
+  {
+    "id": "SIR",
+    "british": false,
+    "label": "Sion Airport (Switzerland) (LSGS / SIR)"
+  },
+  {
+    "id": "LSMA",
+    "british": false,
+    "label": "Alpnach Air Base (Switzerland) (LSMA)"
+  },
+  {
+    "id": "LSMD",
+    "british": false,
+    "label": "Dübendorf Air Base (Switzerland) (LSMD)"
+  },
+  {
+    "id": "EML",
+    "british": false,
+    "label": "Emmen Air Base (Switzerland) (LSME / EML)"
+  },
+  {
+    "id": "LSMF",
+    "british": false,
+    "label": "Mollis Airport (Switzerland) (LSMF)"
+  },
+  {
+    "id": "LSMM",
+    "british": false,
+    "label": "Meiringen Airport (Switzerland) (LSMM)"
+  },
+  {
+    "id": "LSMP",
+    "british": false,
+    "label": "Payerne Air Base (Switzerland) (LSMP)"
+  },
+  {
+    "id": "LUG",
+    "british": false,
+    "label": "Lugano Airport (Switzerland) (LSZA / LUG)"
+  },
+  {
+    "id": "BRN",
+    "british": false,
+    "label": "Bern Belp Airport (Switzerland) (LSZB / BRN)"
+  },
+  {
+    "id": "ZHI",
+    "british": false,
+    "label": "Grenchen Airport (Switzerland) (LSZG / ZHI)"
+  },
+  {
+    "id": "ZRH",
+    "british": false,
+    "label": "Zürich Airport (Switzerland) (LSZH / ZRH)"
+  },
+  {
+    "id": "ACH",
+    "british": false,
+    "label": "St Gallen Altenrhein Airport (Switzerland) (LSZR / ACH)"
+  },
+  {
+    "id": "SMV",
+    "british": false,
+    "label": "Samedan Airport (Switzerland) (LSZS / SMV)"
+  },
+  {
+    "id": "LTAB",
+    "british": false,
+    "label": "Güvercinlik Airport (Turkey) (LTAB)"
+  },
+  {
+    "id": "ESB",
+    "british": false,
+    "label": "Esenboğa International Airport (Turkey) (LTAC / ESB)"
+  },
+  {
+    "id": "ANK",
+    "british": false,
+    "label": "Etimesgut Air Base (Turkey) (LTAD / ANK)"
+  },
+  {
+    "id": "LTAE",
+    "british": false,
+    "label": "Akıncı Air Base (Turkey) (LTAE)"
+  },
+  {
+    "id": "ADA",
+    "british": false,
+    "label": "Adana Airport (Turkey) (LTAF / ADA)"
+  },
+  {
+    "id": "UAB",
+    "british": false,
+    "label": "İncirlik Air Base (Turkey) (LTAG / UAB)"
+  },
+  {
+    "id": "AFY",
+    "british": false,
+    "label": "Afyon Airport (Turkey) (LTAH / AFY)"
+  },
+  {
+    "id": "AYT",
+    "british": false,
+    "label": "Antalya International Airport (Turkey) (LTAI / AYT)"
+  },
+  {
+    "id": "GZT",
+    "british": false,
+    "label": "Gaziantep International Airport (Turkey) (LTAJ / GZT)"
+  },
+  {
+    "id": "LTAK",
+    "british": false,
+    "label": "İskenderun Airport (Turkey) (LTAK)"
+  },
+  {
+    "id": "KYA",
+    "british": false,
+    "label": "Konya Airport (Turkey) (LTAN / KYA)"
+  },
+  {
+    "id": "LTAO",
+    "british": false,
+    "label": "Malatya Tulga Airport (Turkey) (LTAO)"
+  },
+  {
+    "id": "MZH",
+    "british": false,
+    "label": "Amasya Merzifon Airport (Turkey) (LTAP / MZH)"
+  },
+  {
+    "id": "VAS",
+    "british": false,
+    "label": "Sivas Nuri Demirağ Airport (Turkey) (LTAR / VAS)"
+  },
+  {
+    "id": "MLX",
+    "british": false,
+    "label": "Malatya Erhaç Airport (Turkey) (LTAT / MLX)"
+  },
+  {
+    "id": "ASR",
+    "british": false,
+    "label": "Kayseri Erkilet Airport (Turkey) (LTAU / ASR)"
+  },
+  {
+    "id": "LTAV",
+    "british": false,
+    "label": "Sivrihisar Airport (Turkey) (LTAV)"
+  },
+  {
+    "id": "TJK",
+    "british": false,
+    "label": "Tokat Airport (Turkey) (LTAW / TJK)"
+  },
+  {
+    "id": "DNZ",
+    "british": false,
+    "label": "Çardak Airport (Turkey) (LTAY / DNZ)"
+  },
+  {
+    "id": "ISL",
+    "british": false,
+    "label": "Atatürk International Airport (Turkey) (LTBA / ISL)"
+  },
+  {
+    "id": "BZI",
+    "british": false,
+    "label": "Balıkesir Merkez Airport (Turkey) (LTBF / BZI)"
+  },
+  {
+    "id": "BDM",
+    "british": false,
+    "label": "Bandırma Airport (Turkey) (LTBG / BDM)"
+  },
+  {
+    "id": "ESK",
+    "british": false,
+    "label": "Eskişehir Air Base (Turkey) (LTBI / ESK)"
+  },
+  {
+    "id": "ADB",
+    "british": false,
+    "label": "Adnan Menderes International Airport (Turkey) (LTBJ / ADB)"
+  },
+  {
+    "id": "LTBK",
+    "british": false,
+    "label": "Gaziemir Airport (Turkey) (LTBK)"
+  },
+  {
+    "id": "IGL",
+    "british": false,
+    "label": "Çiğli Airport (Turkey) (LTBL / IGL)"
+  },
+  {
+    "id": "LTBM",
+    "british": false,
+    "label": "Isparta Airport (Turkey) (LTBM)"
+  },
+  {
+    "id": "LTBN",
+    "british": false,
+    "label": "Kütahya Airport (Turkey) (LTBN)"
+  },
+  {
+    "id": "LTBP",
+    "british": false,
+    "label": "Yalova Airport (Turkey) (LTBP)"
+  },
+  {
+    "id": "KCO",
+    "british": false,
+    "label": "Cengiz Topel Airport (Turkey) (LTBQ / KCO)"
+  },
+  {
+    "id": "DLM",
+    "british": false,
+    "label": "Dalaman International Airport (Turkey) (LTBS / DLM)"
+  },
+  {
+    "id": "LTBT",
+    "british": false,
+    "label": "Akhisar Airport (Turkey) (LTBT)"
+  },
+  {
+    "id": "BXN",
+    "british": false,
+    "label": "Imsık Airport (Turkey) (LTBV / BXN)"
+  },
+  {
+    "id": "LTBX",
+    "british": false,
+    "label": "Samandıra Air Base (Turkey) (LTBX)"
+  },
+  {
+    "id": "EZS",
+    "british": false,
+    "label": "Elazığ Airport (Turkey) (LTCA / EZS)"
+  },
+  {
+    "id": "DIY",
+    "british": false,
+    "label": "Diyarbakir Airport (Turkey) (LTCC / DIY)"
+  },
+  {
+    "id": "ERC",
+    "british": false,
+    "label": "Erzincan Airport (Turkey) (LTCD / ERC)"
+  },
+  {
+    "id": "ERZ",
+    "british": false,
+    "label": "Erzurum International Airport (Turkey) (LTCE / ERZ)"
+  },
+  {
+    "id": "TZX",
+    "british": false,
+    "label": "Trabzon International Airport (Turkey) (LTCG / TZX)"
+  },
+  {
+    "id": "VAN",
+    "british": false,
+    "label": "Van Ferit Melen Airport (Turkey) (LTCI / VAN)"
+  },
+  {
+    "id": "BAL",
+    "british": false,
+    "label": "Batman Airport (Turkey) (LTCJ / BAL)"
+  },
+  {
+    "id": "SXZ",
+    "british": false,
+    "label": "Siirt Airport (Turkey) (LTCL / SXZ)"
+  },
+  {
+    "id": "LTFA",
+    "british": false,
+    "label": "Kaklıç Airport (Turkey) (LTFA)"
+  },
+  {
+    "id": "LTFB",
+    "british": false,
+    "label": "Selçuk Efes Airport (Turkey) (LTFB)"
+  },
+  {
+    "id": "BZY",
+    "british": false,
+    "label": "Bălți International Airport (Moldova) (LUBL / BZY)"
+  },
+  {
+    "id": "KIV",
+    "british": false,
+    "label": "Chişinău International Airport (Moldova) (LUKK / KIV)"
+  },
+  {
+    "id": "OHD",
+    "british": false,
+    "label": "Ohrid St. Paul the Apostle Airport (Macedonia) (LWOH / OHD)"
+  },
+  {
+    "id": "SKP",
+    "british": false,
+    "label": "Skopje Alexander the Great Airport (Macedonia) (LWSK / SKP)"
+  },
+  {
+    "id": "GIB",
+    "british": false,
+    "label": "Gibraltar Airport (Gibraltar) (LXGB / GIB)"
+  },
+  {
+    "id": "BEG",
+    "british": false,
+    "label": "Belgrade Nikola Tesla Airport (Serbia) (LYBE / BEG)"
+  },
+  {
+    "id": "INI",
+    "british": false,
+    "label": "Nis Airport (Serbia) (LYNI / INI)"
+  },
+  {
+    "id": "TGD",
+    "british": false,
+    "label": "Podgorica Airport (Montenegro) (LYPG / TGD)"
+  },
+  {
+    "id": "PRN",
+    "british": false,
+    "label": "Priština International Airport (Serbia) (BKPR / PRN)"
+  },
+  {
+    "id": "TIV",
+    "british": false,
+    "label": "Tivat Airport (Montenegro) (LYTV / TIV)"
+  },
+  {
+    "id": "LYVR",
+    "british": false,
+    "label": "Vršac International Airport (Serbia) (LYVR)"
+  },
+  {
+    "id": "BTS",
+    "british": false,
+    "label": "M. R. Štefánik Airport (Slovakia) (LZIB / BTS)"
+  },
+  {
+    "id": "KSC",
+    "british": false,
+    "label": "Košice Airport (Slovakia) (LZKZ / KSC)"
+  },
+  {
+    "id": "LZMC",
+    "british": false,
+    "label": "Kuchyňa Air Base (Slovakia) (LZMC)"
+  },
+  {
+    "id": "PZY",
+    "british": false,
+    "label": "Piešťany Airport (Slovakia) (LZPP / PZY)"
+  },
+  {
+    "id": "SLD",
+    "british": false,
+    "label": "Sliač Airport (Slovakia) (LZSL / SLD)"
+  },
+  {
+    "id": "LZTN",
+    "british": false,
+    "label": "Trenčín Airport (Slovakia) (LZTN)"
+  },
+  {
+    "id": "TAT",
+    "british": false,
+    "label": "Poprad-Tatry Airport (Slovakia) (LZTT / TAT)"
+  },
+  {
+    "id": "NCA",
+    "british": false,
+    "label": "North Caicos Airport (Turks and Caicos Islands) (MBNC / NCA)"
+  },
+  {
+    "id": "PLS",
+    "british": false,
+    "label": "Providenciales Airport (Turks and Caicos Islands) (MBPV / PLS)"
+  },
+  {
+    "id": "XSC",
+    "british": false,
+    "label": "South Caicos Airport (Turks and Caicos Islands) (MBSC / XSC)"
+  },
+  {
+    "id": "MDAB",
+    "british": false,
+    "label": "Arroyo Barril Airport (Dominican Republic) (MDAB)"
+  },
+  {
+    "id": "BRX",
+    "british": false,
+    "label": "Maria Montez International Airport (Dominican Republic) (MDBH / BRX)"
+  },
+  {
+    "id": "CBJ",
+    "british": false,
+    "label": "Cabo Rojo Airport (Dominican Republic) (MDCR / CBJ)"
+  },
+  {
+    "id": "LRM",
+    "british": false,
+    "label": "Casa De Campo International Airport (Dominican Republic) (MDLR / LRM)"
+  },
+  {
+    "id": "PUJ",
+    "british": false,
+    "label": "Punta Cana International Airport (Dominican Republic) (MDPC / PUJ)"
+  },
+  {
+    "id": "POP",
+    "british": false,
+    "label": "Gregorio Luperon International Airport (Dominican Republic) (MDPP / POP)"
+  },
+  {
+    "id": "SDQ",
+    "british": false,
+    "label": "Las Américas International Airport (Dominican Republic) (MDSD / SDQ)"
+  },
+  {
+    "id": "MDSI",
+    "british": false,
+    "label": "San Isidro Air Base (Dominican Republic) (MDSI)"
+  },
+  {
+    "id": "STI",
+    "british": false,
+    "label": "Cibao International Airport (Dominican Republic) (MDST / STI)"
+  },
+  {
+    "id": "MGBN",
+    "british": false,
+    "label": "Bananera Airport (Guatemala) (MGBN)"
+  },
+  {
+    "id": "CBV",
+    "british": false,
+    "label": "Coban Airport (Guatemala) (MGCB / CBV)"
+  },
+  {
+    "id": "GUA",
+    "british": false,
+    "label": "La Aurora Airport (Guatemala) (MGGT / GUA)"
+  },
+  {
+    "id": "RER",
+    "british": false,
+    "label": "Retalhuleu Airport (Guatemala) (MGRT / RER)"
+  },
+  {
+    "id": "GSJ",
+    "british": false,
+    "label": "San José Airport (Guatemala) (MGSJ / GSJ)"
+  },
+  {
+    "id": "LCE",
+    "british": false,
+    "label": "Goloson International Airport (Honduras) (MHLC / LCE)"
+  },
+  {
+    "id": "SAP",
+    "british": false,
+    "label": "Ramón Villeda Morales International Airport (Honduras) (MHLM / SAP)"
+  },
+  {
+    "id": "GJA",
+    "british": false,
+    "label": "La Laguna Airport (Honduras) (MHNJ / GJA)"
+  },
+  {
+    "id": "RTB",
+    "british": false,
+    "label": "Juan Manuel Galvez International Airport (Honduras) (MHRO / RTB)"
+  },
+  {
+    "id": "TEA",
+    "british": false,
+    "label": "Tela Airport (Honduras) (MHTE / TEA)"
+  },
+  {
+    "id": "TGU",
+    "british": false,
+    "label": "Toncontín International Airport (Honduras) (MHTG / TGU)"
+  },
+  {
+    "id": "TJI",
+    "british": false,
+    "label": "Trujillo Airport (Honduras) (MHTJ / TJI)"
+  },
+  {
+    "id": "OCJ",
+    "british": false,
+    "label": "Boscobel Aerodrome (Jamaica) (MKBS / OCJ)"
+  },
+  {
+    "id": "KIN",
+    "british": false,
+    "label": "Norman Manley International Airport (Jamaica) (MKJP / KIN)"
+  },
+  {
+    "id": "MBJ",
+    "british": false,
+    "label": "Sangster International Airport (Jamaica) (MKJS / MBJ)"
+  },
+  {
+    "id": "POT",
+    "british": false,
+    "label": "Ken Jones Airport (Jamaica) (MKKJ / POT)"
+  },
+  {
+    "id": "KTP",
+    "british": false,
+    "label": "Tinson Pen Airport (Jamaica) (MKTP / KTP)"
+  },
+  {
+    "id": "ACA",
+    "british": false,
+    "label": "General Juan N Alvarez International Airport (Mexico) (MMAA / ACA)"
+  },
+  {
+    "id": "NTR",
+    "british": false,
+    "label": "Del Norte International Airport (Mexico) (MMAN / NTR)"
+  },
+  {
+    "id": "AGU",
+    "british": false,
+    "label": "Jesús Terán Paredo International Airport (Mexico) (MMAS / AGU)"
+  },
+  {
+    "id": "HUX",
+    "british": false,
+    "label": "Bahías de Huatulco International Airport (Mexico) (MMBT / HUX)"
+  },
+  {
+    "id": "CVJ",
+    "british": false,
+    "label": "General Mariano Matamoros Airport (Mexico) (MMCB / CVJ)"
+  },
+  {
+    "id": "ACN",
+    "british": false,
+    "label": "Ciudad Acuña New International Airport (Mexico) (MMCC / ACN)"
+  },
+  {
+    "id": "CME",
+    "british": false,
+    "label": "Ciudad del Carmen International Airport (Mexico) (MMCE / CME)"
+  },
+  {
+    "id": "NCG",
+    "british": false,
+    "label": "Nuevo Casas Grandes Airport (Mexico) (MMCG / NCG)"
+  },
+  {
+    "id": "MMCH",
+    "british": false,
+    "label": "Chilpancingo Airport (Mexico) (MMCH)"
+  },
+  {
+    "id": "CUL",
+    "british": false,
+    "label": "Bachigualato Federal International Airport (Mexico) (MMCL / CUL)"
+  },
+  {
+    "id": "CTM",
+    "british": false,
+    "label": "Chetumal International Airport (Mexico) (MMCM / CTM)"
+  },
+  {
+    "id": "CEN",
+    "british": false,
+    "label": "Ciudad Obregón International Airport (Mexico) (MMCN / CEN)"
+  },
+  {
+    "id": "CPE",
+    "british": false,
+    "label": "Ingeniero Alberto Acuña Ongay International Airport (Mexico) (MMCP / CPE)"
+  },
+  {
+    "id": "CJS",
+    "british": false,
+    "label": "Abraham González International Airport (Mexico) (MMCS / CJS)"
+  },
+  {
+    "id": "CUU",
+    "british": false,
+    "label": "General Roberto Fierro Villalobos International Airport (Mexico) (MMCU / CUU)"
+  },
+  {
+    "id": "CVM",
+    "british": false,
+    "label": "General Pedro Jose Mendez International Airport (Mexico) (MMCV / CVM)"
+  },
+  {
+    "id": "CZM",
+    "british": false,
+    "label": "Cozumel International Airport (Mexico) (MMCZ / CZM)"
+  },
+  {
+    "id": "DGO",
+    "british": false,
+    "label": "General Guadalupe Victoria International Airport (Mexico) (MMDO / DGO)"
+  },
+  {
+    "id": "TPQ",
+    "british": false,
+    "label": "Amado Nervo National Airport (Mexico) (MMEP / TPQ)"
+  },
+  {
+    "id": "ESE",
+    "british": false,
+    "label": "Ensenada International Airport (Mexico) (MMES / ESE)"
+  },
+  {
+    "id": "GDL",
+    "british": false,
+    "label": "Don Miguel Hidalgo Y Costilla International Airport (Mexico) (MMGL / GDL)"
+  },
+  {
+    "id": "GYM",
+    "british": false,
+    "label": "General José María Yáñez International Airport (Mexico) (MMGM / GYM)"
+  },
+  {
+    "id": "TCN",
+    "british": false,
+    "label": "Tehuacan Airport (Mexico) (MMHC / TCN)"
+  },
+  {
+    "id": "HMO",
+    "british": false,
+    "label": "General Ignacio P. Garcia International Airport (Mexico) (MMHO / HMO)"
+  },
+  {
+    "id": "CLQ",
+    "british": false,
+    "label": "Licenciado Miguel de la Madrid Airport (Mexico) (MMIA / CLQ)"
+  },
+  {
+    "id": "ISJ",
+    "british": false,
+    "label": "Isla Mujeres Airport (Mexico) (MMIM / ISJ)"
+  },
+  {
+    "id": "SLW",
+    "british": false,
+    "label": "Plan De Guadalupe International Airport (Mexico) (MMIO / SLW)"
+  },
+  {
+    "id": "IZT",
+    "british": false,
+    "label": "Ixtepec Airport (Mexico) (MMIT / IZT)"
+  },
+  {
+    "id": "LZC",
+    "british": false,
+    "label": "Lázaro Cárdenas Airport (Mexico) (MMLC / LZC)"
+  },
+  {
+    "id": "LMM",
+    "british": false,
+    "label": "Valle del Fuerte International Airport (Mexico) (MMLM / LMM)"
+  },
+  {
+    "id": "BJX",
+    "british": false,
+    "label": "Del Bajío International Airport (Mexico) (MMLO / BJX)"
+  },
+  {
+    "id": "LAP",
+    "british": false,
+    "label": "Manuel Márquez de León International Airport (Mexico) (MMLP / LAP)"
+  },
+  {
+    "id": "LTO",
+    "british": false,
+    "label": "Loreto International Airport (Mexico) (MMLT / LTO)"
+  },
+  {
+    "id": "MAM",
+    "british": false,
+    "label": "General Servando Canales International Airport (Mexico) (MMMA / MAM)"
+  },
+  {
+    "id": "MID",
+    "british": false,
+    "label": "Licenciado Manuel Crescencio Rejon Int Airport (Mexico) (MMMD / MID)"
+  },
+  {
+    "id": "MXL",
+    "british": false,
+    "label": "General Rodolfo Sánchez Taboada International Airport (Mexico) (MMML / MXL)"
+  },
+  {
+    "id": "MLM",
+    "british": false,
+    "label": "General Francisco J. Mujica International Airport (Mexico) (MMMM / MLM)"
+  },
+  {
+    "id": "MTT",
+    "british": false,
+    "label": "Minatitlán/Coatzacoalcos National Airport (Mexico) (MMMT / MTT)"
+  },
+  {
+    "id": "LOV",
+    "british": false,
+    "label": "Monclova International Airport (Mexico) (MMMV / LOV)"
+  },
+  {
+    "id": "MEX",
+    "british": false,
+    "label": "Licenciado Benito Juarez International Airport (Mexico) (MMMX / MEX)"
+  },
+  {
+    "id": "MTY",
+    "british": false,
+    "label": "General Mariano Escobedo International Airport (Mexico) (MMMY / MTY)"
+  },
+  {
+    "id": "MZT",
+    "british": false,
+    "label": "General Rafael Buelna International Airport (Mexico) (MMMZ / MZT)"
+  },
+  {
+    "id": "NOG",
+    "british": false,
+    "label": "Nogales International Airport (Mexico) (MMNG / NOG)"
+  },
+  {
+    "id": "NLD",
+    "british": false,
+    "label": "Quetzalcóatl International Airport (Mexico) (MMNL / NLD)"
+  },
+  {
+    "id": "OAX",
+    "british": false,
+    "label": "Xoxocotlán International Airport (Mexico) (MMOX / OAX)"
+  },
+  {
+    "id": "PAZ",
+    "british": false,
+    "label": "El Tajín National Airport (Mexico) (MMPA / PAZ)"
+  },
+  {
+    "id": "PBC",
+    "british": false,
+    "label": "Hermanos Serdán International Airport (Mexico) (MMPB / PBC)"
+  },
+  {
+    "id": "MMPC",
+    "british": false,
+    "label": "Ingeniero Juan Guillermo Villasana Airport (Mexico) (MMPC)"
+  },
+  {
+    "id": "PPE",
+    "british": false,
+    "label": "Mar de Cortés International Airport (Mexico) (MMPE / PPE)"
+  },
+  {
+    "id": "PDS",
+    "british": false,
+    "label": "Piedras Negras International Airport (Mexico) (MMPG / PDS)"
+  },
+  {
+    "id": "UPN",
+    "british": false,
+    "label": "Licenciado y General Ignacio Lopez Rayon Airport (Mexico) (MMPN / UPN)"
+  },
+  {
+    "id": "PVR",
+    "british": false,
+    "label": "Licenciado Gustavo Díaz Ordaz International Airport (Mexico) (MMPR / PVR)"
+  },
+  {
+    "id": "PXM",
+    "british": false,
+    "label": "Puerto Escondido International Airport (Mexico) (MMPS / PXM)"
+  },
+  {
+    "id": "QRO",
+    "british": false,
+    "label": "Querétaro Intercontinental Airport (Mexico) (MMQT / QRO)"
+  },
+  {
+    "id": "REX",
+    "british": false,
+    "label": "General Lucio Blanco International Airport (Mexico) (MMRX / REX)"
+  },
+  {
+    "id": "SJD",
+    "british": false,
+    "label": "Los Cabos International Airport (Mexico) (MMSD / SJD)"
+  },
+  {
+    "id": "SFH",
+    "british": false,
+    "label": "San Felipe International Airport (Mexico) (MMSF / SFH)"
+  },
+  {
+    "id": "SLP",
+    "british": false,
+    "label": "Ponciano Arriaga International Airport (Mexico) (MMSP / SLP)"
+  },
+  {
+    "id": "MMTA",
+    "british": false,
+    "label": "Tlaxcala Airport (Mexico) (MMTA)"
+  },
+  {
+    "id": "MMTB",
+    "british": false,
+    "label": "Terán Air Base (Mexico) (MMTB)"
+  },
+  {
+    "id": "TRC",
+    "british": false,
+    "label": "Francisco Sarabia International Airport (Mexico) (MMTC / TRC)"
+  },
+  {
+    "id": "TGZ",
+    "british": false,
+    "label": "Angel Albino Corzo International Airport (Mexico) (MMTG / TGZ)"
+  },
+  {
+    "id": "TIJ",
+    "british": false,
+    "label": "General Abelardo L. Rodríguez International Airport (Mexico) (MMTJ / TIJ)"
+  },
+  {
+    "id": "TAM",
+    "british": false,
+    "label": "General Francisco Javier Mina International Airport (Mexico) (MMTM / TAM)"
+  },
+  {
+    "id": "TSL",
+    "british": false,
+    "label": "Tamuin Airport (Mexico) (MMTN / TSL)"
+  },
+  {
+    "id": "TLC",
+    "british": false,
+    "label": "Licenciado Adolfo Lopez Mateos International Airport (Mexico) (MMTO / TLC)"
+  },
+  {
+    "id": "TAP",
+    "british": false,
+    "label": "Tapachula International Airport (Mexico) (MMTP / TAP)"
+  },
+  {
+    "id": "CUN",
+    "british": false,
+    "label": "Cancún International Airport (Mexico) (MMUN / CUN)"
+  },
+  {
+    "id": "VSA",
+    "british": false,
+    "label": "Carlos Rovirosa Pérez International Airport (Mexico) (MMVA / VSA)"
+  },
+  {
+    "id": "VER",
+    "british": false,
+    "label": "General Heriberto Jara International Airport (Mexico) (MMVR / VER)"
+  },
+  {
+    "id": "ZCL",
+    "british": false,
+    "label": "General Leobardo C. Ruiz International Airport (Mexico) (MMZC / ZCL)"
+  },
+  {
+    "id": "ZIH",
+    "british": false,
+    "label": "Ixtapa Zihuatanejo International Airport (Mexico) (MMZH / ZIH)"
+  },
+  {
+    "id": "ZMM",
+    "british": false,
+    "label": "Zamora Airport (Mexico) (MMZM / ZMM)"
+  },
+  {
+    "id": "ZLO",
+    "british": false,
+    "label": "Playa De Oro International Airport (Mexico) (MMZO / ZLO)"
+  },
+  {
+    "id": "MMZP",
+    "british": false,
+    "label": "Zapopan Airport (Mexico) (MMZP)"
+  },
+  {
+    "id": "BEF",
+    "british": false,
+    "label": "Bluefields Airport (Nicaragua) (MNBL / BEF)"
+  },
+  {
+    "id": "MNBR",
+    "british": false,
+    "label": "Los Brasiles Airport (Nicaragua) (MNBR)"
+  },
+  {
+    "id": "MNLN",
+    "british": false,
+    "label": "Leon (Fanor Urroz) Airport (Nicaragua) (MNLN)"
+  },
+  {
+    "id": "MGA",
+    "british": false,
+    "label": "Augusto C. Sandino (Managua) International Airport (Nicaragua) (MNMG / MGA)"
+  },
+  {
+    "id": "PUZ",
+    "british": false,
+    "label": "Puerto Cabezas Airport (Nicaragua) (MNPC / PUZ)"
+  },
+  {
+    "id": "BOC",
+    "british": false,
+    "label": "Bocas Del Toro International Airport (Panama) (MPBO / BOC)"
+  },
+  {
+    "id": "CHX",
+    "british": false,
+    "label": "Cap Manuel Niño International Airport (Panama) (MPCH / CHX)"
+  },
+  {
+    "id": "DAV",
+    "british": false,
+    "label": "Enrique Malek International Airport (Panama) (MPDA / DAV)"
+  },
+  {
+    "id": "BLB",
+    "british": false,
+    "label": "Panama Pacific International Airport (Panama) (MPHO / BLB)"
+  },
+  {
+    "id": "PAC",
+    "british": false,
+    "label": "Marcos A. Gelabert International Airport (Panama) (MPMG / PAC)"
+  },
+  {
+    "id": "SYP",
+    "british": false,
+    "label": "Ruben Cantu Airport (Panama) (MPSA / SYP)"
+  },
+  {
+    "id": "PTY",
+    "british": false,
+    "label": "Tocumen International Airport (Panama) (MPTO / PTY)"
+  },
+  {
+    "id": "BAI",
+    "british": false,
+    "label": "Buenos Aires Airport (Costa Rica) (MRBA / BAI)"
+  },
+  {
+    "id": "OTR",
+    "british": false,
+    "label": "Coto 47 Airport (Costa Rica) (MRCC / OTR)"
+  },
+  {
+    "id": "JAP",
+    "british": false,
+    "label": "Chacarita Airport (Costa Rica) (MRCH / JAP)"
+  },
+  {
+    "id": "MREC",
+    "british": false,
+    "label": "El Carmen de Siquirres Airport (Costa Rica) (MREC)"
+  },
+  {
+    "id": "MRFI",
+    "british": false,
+    "label": "Finca 10 / Nuevo Palmar Sur Airport (Costa Rica) (MRFI)"
+  },
+  {
+    "id": "GLF",
+    "british": false,
+    "label": "Golfito Airport (Costa Rica) (MRGF / GLF)"
+  },
+  {
+    "id": "GPL",
+    "british": false,
+    "label": "Guapiles Airport (Costa Rica) (MRGP / GPL)"
+  },
+  {
+    "id": "LIR",
+    "british": false,
+    "label": "Daniel Oduber Quiros International Airport (Costa Rica) (MRLB / LIR)"
+  },
+  {
+    "id": "LSL",
+    "british": false,
+    "label": "Los Chiles Airport (Costa Rica) (MRLC / LSL)"
+  },
+  {
+    "id": "LIO",
+    "british": false,
+    "label": "Limon International Airport (Costa Rica) (MRLM / LIO)"
+  },
+  {
+    "id": "NOB",
+    "british": false,
+    "label": "Nosara Airport (Costa Rica) (MRNS / NOB)"
+  },
+  {
+    "id": "SJO",
+    "british": false,
+    "label": "Juan Santamaria International Airport (Costa Rica) (MROC / SJO)"
+  },
+  {
+    "id": "MRPD",
+    "british": false,
+    "label": "Pandora Airport (Costa Rica) (MRPD)"
+  },
+  {
+    "id": "PMZ",
+    "british": false,
+    "label": "Palmar Sur Airport (Costa Rica) (MRPM / PMZ)"
+  },
+  {
+    "id": "XQP",
+    "british": false,
+    "label": "Quepos Managua Airport (Costa Rica) (MRQP / XQP)"
+  },
+  {
+    "id": "MRSG",
+    "british": false,
+    "label": "Santa Clara De Guapiles Airport (Costa Rica) (MRSG)"
+  },
+  {
+    "id": "TOO",
+    "british": false,
+    "label": "San Vito De Java Airport (Costa Rica) (MRSV / TOO)"
+  },
+  {
+    "id": "SAL",
+    "british": false,
+    "label": "Monseñor Óscar Arnulfo Romero International Airport (El Salvador) (MSLP / SAL)"
+  },
+  {
+    "id": "MSSS",
+    "british": false,
+    "label": "Ilopango International Airport (El Salvador) (MSSS)"
+  },
+  {
+    "id": "CYA",
+    "british": false,
+    "label": "Les Cayes Airport (Haiti) (MTCA / CYA)"
+  },
+  {
+    "id": "CAP",
+    "british": false,
+    "label": "Cap Haitien International Airport (Haiti) (MTCH / CAP)"
+  },
+  {
+    "id": "JAK",
+    "british": false,
+    "label": "Jacmel Airport (Haiti) (MTJA / JAK)"
+  },
+  {
+    "id": "PAP",
+    "british": false,
+    "label": "Toussaint Louverture International Airport (Haiti) (MTPP / PAP)"
+  },
+  {
+    "id": "BCA",
+    "british": false,
+    "label": "Gustavo Rizo Airport (Cuba) (MUBA / BCA)"
+  },
+  {
+    "id": "BYM",
+    "british": false,
+    "label": "Carlos Manuel de Cespedes Airport (Cuba) (MUBY / BYM)"
+  },
+  {
+    "id": "AVI",
+    "british": false,
+    "label": "Maximo Gomez Airport (Cuba) (MUCA / AVI)"
+  },
+  {
+    "id": "CCC",
+    "british": false,
+    "label": "Jardines Del Rey Airport (Cuba) (MUCC / CCC)"
+  },
+  {
+    "id": "CFG",
+    "british": false,
+    "label": "Jaime Gonzalez Airport (Cuba) (MUCF / CFG)"
+  },
+  {
+    "id": "CYO",
+    "british": false,
+    "label": "Vilo Acuña International Airport (Cuba) (MUCL / CYO)"
+  },
+  {
+    "id": "CMW",
+    "british": false,
+    "label": "Ignacio Agramonte International Airport (Cuba) (MUCM / CMW)"
+  },
+  {
+    "id": "SCU",
+    "british": false,
+    "label": "Antonio Maceo International Airport (Cuba) (MUCU / SCU)"
+  },
+  {
+    "id": "MUFL",
+    "british": false,
+    "label": "Florida Airport (Cuba) (MUFL)"
+  },
+  {
+    "id": "NBW",
+    "british": false,
+    "label": "Leeward Point Field (Cuba) (MUGM / NBW)"
+  },
+  {
+    "id": "GAO",
+    "british": false,
+    "label": "Mariana Grajales Airport (Cuba) (MUGT / GAO)"
+  },
+  {
+    "id": "HAV",
+    "british": false,
+    "label": "José Martí International Airport (Cuba) (MUHA / HAV)"
+  },
+  {
+    "id": "HOG",
+    "british": false,
+    "label": "Frank Pais International Airport (Cuba) (MUHG / HOG)"
+  },
+  {
+    "id": "LCL",
+    "british": false,
+    "label": "La Coloma Airport (Cuba) (MULM / LCL)"
+  },
+  {
+    "id": "MOA",
+    "british": false,
+    "label": "Orestes Acosta Airport (Cuba) (MUMO / MOA)"
+  },
+  {
+    "id": "MZO",
+    "british": false,
+    "label": "Sierra Maestra Airport (Cuba) (MUMZ / MZO)"
+  },
+  {
+    "id": "GER",
+    "british": false,
+    "label": "Rafael Cabrera Airport (Cuba) (MUNG / GER)"
+  },
+  {
+    "id": "UPB",
+    "british": false,
+    "label": "Playa Baracoa Airport (Cuba) (MUPB / UPB)"
+  },
+  {
+    "id": "QPD",
+    "british": false,
+    "label": "Pinar Del Rio Airport (Cuba) (MUPR / QPD)"
+  },
+  {
+    "id": "MUSA",
+    "british": false,
+    "label": "San Antonio De Los Banos Airport (Cuba) (MUSA)"
+  },
+  {
+    "id": "SNU",
+    "british": false,
+    "label": "Abel Santamaria Airport (Cuba) (MUSC / SNU)"
+  },
+  {
+    "id": "MUSL",
+    "british": false,
+    "label": "Joaquín de Agüero Airport (Cuba) (MUSL)"
+  },
+  {
+    "id": "SZJ",
+    "british": false,
+    "label": "Siguanea Airport (Cuba) (MUSN / SZJ)"
+  },
+  {
+    "id": "USS",
+    "british": false,
+    "label": "Sancti Spiritus Airport (Cuba) (MUSS / USS)"
+  },
+  {
+    "id": "VRA",
+    "british": false,
+    "label": "Juan Gualberto Gomez International Airport (Cuba) (MUVR / VRA)"
+  },
+  {
+    "id": "VTU",
+    "british": false,
+    "label": "Hermanos Ameijeiras Airport (Cuba) (MUVT / VTU)"
+  },
+  {
+    "id": "CYB",
+    "british": false,
+    "label": "Gerrard Smith International Airport (Cayman Islands) (MWCB / CYB)"
+  },
+  {
+    "id": "GCM",
+    "british": false,
+    "label": "Owen Roberts International Airport (Cayman Islands) (MWCR / GCM)"
+  },
+  {
+    "id": "MAY",
+    "british": false,
+    "label": "Clarence A. Bain Airport (Bahamas) (MYAB / MAY)"
+  },
+  {
+    "id": "ASD",
+    "british": false,
+    "label": "Andros Town Airport (Bahamas) (MYAF / ASD)"
+  },
+  {
+    "id": "MHH",
+    "british": false,
+    "label": "Leonard M Thompson International Airport (Bahamas) (MYAM / MHH)"
+  },
+  {
+    "id": "SAQ",
+    "british": false,
+    "label": "San Andros Airport (Bahamas) (MYAN / SAQ)"
+  },
+  {
+    "id": "AXP",
+    "british": false,
+    "label": "Spring Point Airport (Bahamas) (MYAP / AXP)"
+  },
+  {
+    "id": "MYAS",
+    "british": false,
+    "label": "Sandy Point Airport (Bahamas) (MYAS)"
+  },
+  {
+    "id": "TCB",
+    "british": false,
+    "label": "Treasure Cay Airport (Bahamas) (MYAT / TCB)"
+  },
+  {
+    "id": "CCZ",
+    "british": false,
+    "label": "Chub Cay Airport (Bahamas) (MYBC / CCZ)"
+  },
+  {
+    "id": "GHC",
+    "british": false,
+    "label": "Great Harbour Cay Airport (Bahamas) (MYBG / GHC)"
+  },
+  {
+    "id": "BIM",
+    "british": false,
+    "label": "South Bimini Airport (Bahamas) (MYBS / BIM)"
+  },
+  {
+    "id": "GGT",
+    "british": false,
+    "label": "Exuma International Airport (Bahamas) (MYEF / GGT)"
+  },
+  {
+    "id": "MYEG",
+    "british": false,
+    "label": "George Town Airport (Bahamas) (MYEG)"
+  },
+  {
+    "id": "ELH",
+    "british": false,
+    "label": "North Eleuthera Airport (Bahamas) (MYEH / ELH)"
+  },
+  {
+    "id": "GHB",
+    "british": false,
+    "label": "Governor's Harbour Airport (Bahamas) (MYEM / GHB)"
+  },
+  {
+    "id": "NMC",
+    "british": false,
+    "label": "Normans Cay Airport (Bahamas) (MYEN / NMC)"
+  },
+  {
+    "id": "RSD",
+    "british": false,
+    "label": "Rock Sound Airport (Bahamas) (MYER / RSD)"
+  },
+  {
+    "id": "TYM",
+    "british": false,
+    "label": "Staniel Cay Airport (Bahamas) (MYES / TYM)"
+  },
+  {
+    "id": "FPO",
+    "british": false,
+    "label": "Grand Bahama International Airport (Bahamas) (MYGF / FPO)"
+  },
+  {
+    "id": "IGA",
+    "british": false,
+    "label": "Inagua Airport (Bahamas) (MYIG / IGA)"
+  },
+  {
+    "id": "LGI",
+    "british": false,
+    "label": "Deadman's Cay Airport (Bahamas) (MYLD / LGI)"
+  },
+  {
+    "id": "SML",
+    "british": false,
+    "label": "Stella Maris Airport (Bahamas) (MYLS / SML)"
+  },
+  {
+    "id": "MYG",
+    "british": false,
+    "label": "Mayaguana Airport (Bahamas) (MYMM / MYG)"
+  },
+  {
+    "id": "NAS",
+    "british": false,
+    "label": "Lynden Pindling International Airport (Bahamas) (MYNN / NAS)"
+  },
+  {
+    "id": "DCT",
+    "british": false,
+    "label": "Duncan Town Airport (Bahamas) (MYRD / DCT)"
+  },
+  {
+    "id": "RCY",
+    "british": false,
+    "label": "Rum Cay Airport (Bahamas) (MYRP / RCY)"
+  },
+  {
+    "id": "ZSA",
+    "british": false,
+    "label": "San Salvador Airport (Bahamas) (MYSM / ZSA)"
+  },
+  {
+    "id": "BZE",
+    "british": false,
+    "label": "Philip S. W. Goldson International Airport (Belize) (MZBZ / BZE)"
+  },
+  {
+    "id": "AIT",
+    "british": false,
+    "label": "Aitutaki Airport (Cook Islands) (NCAI / AIT)"
+  },
+  {
+    "id": "RAR",
+    "british": false,
+    "label": "Rarotonga International Airport (Cook Islands) (NCRG / RAR)"
+  },
+  {
+    "id": "NAN",
+    "british": false,
+    "label": "Nadi International Airport (Fiji) (NFFN / NAN)"
+  },
+  {
+    "id": "SUV",
+    "british": false,
+    "label": "Nausori International Airport (Fiji) (NFNA / SUV)"
+  },
+  {
+    "id": "TBU",
+    "british": false,
+    "label": "Fua'amotu International Airport (Tonga) (NFTF / TBU)"
+  },
+  {
+    "id": "VAV",
+    "british": false,
+    "label": "Vava'u International Airport (Tonga) (NFTV / VAV)"
+  },
+  {
+    "id": "TRW",
+    "british": false,
+    "label": "Bonriki International Airport (Kiribati) (NGTA / TRW)"
+  },
+  {
+    "id": "TBF",
+    "british": false,
+    "label": "Tabiteuea North Airport (Kiribati) (NGTE / TBF)"
+  },
+  {
+    "id": "WLS",
+    "british": false,
+    "label": "Hihifo Airport (Wallis and Futuna) (NLWW / WLS)"
+  },
+  {
+    "id": "APW",
+    "british": false,
+    "label": "Faleolo International Airport (Samoa) (NSFA / APW)"
+  },
+  {
+    "id": "PPG",
+    "british": false,
+    "label": "Pago Pago International Airport (American Samoa) (NSTU / PPG)"
+  },
+  {
+    "id": "RUR",
+    "british": false,
+    "label": "Rurutu Airport (French Polynesia) (NTAR / RUR)"
+  },
+  {
+    "id": "TUB",
+    "british": false,
+    "label": "Tubuai Airport (French Polynesia) (NTAT / TUB)"
+  },
+  {
+    "id": "AAA",
+    "british": false,
+    "label": "Anaa Airport (French Polynesia) (NTGA / AAA)"
+  },
+  {
+    "id": "FGU",
+    "british": false,
+    "label": "Fangatau Airport (French Polynesia) (NTGB / FGU)"
+  },
+  {
+    "id": "TIH",
+    "british": false,
+    "label": "Tikehau Airport (French Polynesia) (NTGC / TIH)"
+  },
+  {
+    "id": "REA",
+    "british": false,
+    "label": "Reao Airport (French Polynesia) (NTGE / REA)"
+  },
+  {
+    "id": "FAV",
+    "british": false,
+    "label": "Fakarava Airport (French Polynesia) (NTGF / FAV)"
+  },
+  {
+    "id": "XMH",
+    "british": false,
+    "label": "Manihi Airport (French Polynesia) (NTGI / XMH)"
+  },
+  {
+    "id": "GMR",
+    "british": false,
+    "label": "Totegegie Airport (French Polynesia) (NTGJ / GMR)"
+  },
+  {
+    "id": "KKR",
+    "british": false,
+    "label": "Kaukura Airport (French Polynesia) (NTGK / KKR)"
+  },
+  {
+    "id": "MKP",
+    "british": false,
+    "label": "Makemo Airport (French Polynesia) (NTGM / MKP)"
+  },
+  {
+    "id": "PKP",
+    "british": false,
+    "label": "Puka Puka Airport (French Polynesia) (NTGP / PKP)"
+  },
+  {
+    "id": "TKP",
+    "british": false,
+    "label": "Takapoto Airport (French Polynesia) (NTGT / TKP)"
+  },
+  {
+    "id": "AXR",
+    "british": false,
+    "label": "Arutua Airport (French Polynesia) (NTGU / AXR)"
+  },
+  {
+    "id": "MVT",
+    "british": false,
+    "label": "Mataiva Airport (French Polynesia) (NTGV / MVT)"
+  },
+  {
+    "id": "TKX",
+    "british": false,
+    "label": "Takaroa Airport (French Polynesia) (NTKR / TKX)"
+  },
+  {
+    "id": "NHV",
+    "british": false,
+    "label": "Nuku Hiva Airport (French Polynesia) (NTMD / NHV)"
+  },
+  {
+    "id": "BOB",
+    "british": false,
+    "label": "Bora Bora Airport (French Polynesia) (NTTB / BOB)"
+  },
+  {
+    "id": "RGI",
+    "british": false,
+    "label": "Rangiroa Airport (French Polynesia) (NTTG / RGI)"
+  },
+  {
+    "id": "HUH",
+    "british": false,
+    "label": "Huahine-Fare Airport (French Polynesia) (NTTH / HUH)"
+  },
+  {
+    "id": "MOZ",
+    "british": false,
+    "label": "Moorea Airport (French Polynesia) (NTTM / MOZ)"
+  },
+  {
+    "id": "HOI",
+    "british": false,
+    "label": "Hao Airport (French Polynesia) (NTTO / HOI)"
+  },
+  {
+    "id": "MAU",
+    "british": false,
+    "label": "Maupiti Airport (French Polynesia) (NTTP / MAU)"
+  },
+  {
+    "id": "RFP",
+    "british": false,
+    "label": "Raiatea Airport (French Polynesia) (NTTR / RFP)"
+  },
+  {
+    "id": "VLI",
+    "british": false,
+    "label": "Bauerfield International Airport (Vanuatu) (NVVV / VLI)"
+  },
+  {
+    "id": "KNQ",
+    "british": false,
+    "label": "Koné Airport (New Caledonia) (NWWD / KNQ)"
+  },
+  {
+    "id": "KOC",
+    "british": false,
+    "label": "Koumac Airport (New Caledonia) (NWWK / KOC)"
+  },
+  {
+    "id": "LIF",
+    "british": false,
+    "label": "Lifou Airport (New Caledonia) (NWWL / LIF)"
+  },
+  {
+    "id": "GEA",
+    "british": false,
+    "label": "Nouméa Magenta Airport (New Caledonia) (NWWM / GEA)"
+  },
+  {
+    "id": "MEE",
+    "british": false,
+    "label": "Maré Airport (New Caledonia) (NWWR / MEE)"
+  },
+  {
+    "id": "TOU",
+    "british": false,
+    "label": "Touho Airport (New Caledonia) (NWWU / TOU)"
+  },
+  {
+    "id": "UVE",
+    "british": false,
+    "label": "Ouvéa Airport (New Caledonia) (NWWV / UVE)"
+  },
+  {
+    "id": "NOU",
+    "british": false,
+    "label": "La Tontouta International Airport (New Caledonia) (NWWW / NOU)"
+  },
+  {
+    "id": "AKL",
+    "british": false,
+    "label": "Auckland International Airport (New Zealand) (NZAA / AKL)"
+  },
+  {
+    "id": "TUO",
+    "british": false,
+    "label": "Taupo Airport (New Zealand) (NZAP / TUO)"
+  },
+  {
+    "id": "AMZ",
+    "british": false,
+    "label": "Ardmore Airport (New Zealand) (NZAR / AMZ)"
+  },
+  {
+    "id": "CHC",
+    "british": false,
+    "label": "Christchurch International Airport (New Zealand) (NZCH / CHC)"
+  },
+  {
+    "id": "CHT",
+    "british": false,
+    "label": "Chatham Islands-Tuuta Airport (New Zealand) (NZCI / CHT)"
+  },
+  {
+    "id": "DUD",
+    "british": false,
+    "label": "Dunedin Airport (New Zealand) (NZDN / DUD)"
+  },
+  {
+    "id": "GIS",
+    "british": false,
+    "label": "Gisborne Airport (New Zealand) (NZGS / GIS)"
+  },
+  {
+    "id": "GTN",
+    "british": false,
+    "label": "Glentanner Airport (New Zealand) (NZGT / GTN)"
+  },
+  {
+    "id": "HKK",
+    "british": false,
+    "label": "Hokitika Airfield (New Zealand) (NZHK / HKK)"
+  },
+  {
+    "id": "HLZ",
+    "british": false,
+    "label": "Hamilton International Airport (New Zealand) (NZHN / HLZ)"
+  },
+  {
+    "id": "NZHS",
+    "british": false,
+    "label": "Hastings Aerodrome (New Zealand) (NZHS)"
+  },
+  {
+    "id": "KKE",
+    "british": false,
+    "label": "Kerikeri Airport (New Zealand) (NZKK / KKE)"
+  },
+  {
+    "id": "KAT",
+    "british": false,
+    "label": "Kaitaia Airport (New Zealand) (NZKT / KAT)"
+  },
+  {
+    "id": "ALR",
+    "british": false,
+    "label": "Alexandra Airport (New Zealand) (NZLX / ALR)"
+  },
+  {
+    "id": "MON",
+    "british": false,
+    "label": "Mount Cook Airport (New Zealand) (NZMC / MON)"
+  },
+  {
+    "id": "TEU",
+    "british": false,
+    "label": "Manapouri Airport (New Zealand) (NZMO / TEU)"
+  },
+  {
+    "id": "MRO",
+    "british": false,
+    "label": "Hood Airport (New Zealand) (NZMS / MRO)"
+  },
+  {
+    "id": "NPL",
+    "british": false,
+    "label": "New Plymouth Airport (New Zealand) (NZNP / NPL)"
+  },
+  {
+    "id": "NSN",
+    "british": false,
+    "label": "Nelson Airport (New Zealand) (NZNS / NSN)"
+  },
+  {
+    "id": "IVC",
+    "british": false,
+    "label": "Invercargill Airport (New Zealand) (NZNV / IVC)"
+  },
+  {
+    "id": "OHA",
+    "british": false,
+    "label": "RNZAF Base Ohakea (New Zealand) (NZOH / OHA)"
+  },
+  {
+    "id": "OAM",
+    "british": false,
+    "label": "Oamaru Airport (New Zealand) (NZOU / OAM)"
+  },
+  {
+    "id": "PMR",
+    "british": false,
+    "label": "Palmerston North Airport (New Zealand) (NZPM / PMR)"
+  },
+  {
+    "id": "PPQ",
+    "british": false,
+    "label": "Paraparaumu Airport (New Zealand) (NZPP / PPQ)"
+  },
+  {
+    "id": "ZQN",
+    "british": false,
+    "label": "Queenstown International Airport (New Zealand) (NZQN / ZQN)"
+  },
+  {
+    "id": "ROT",
+    "british": false,
+    "label": "Rotorua Regional Airport (New Zealand) (NZRO / ROT)"
+  },
+  {
+    "id": "NZRU",
+    "british": false,
+    "label": "Waiouru Airport (New Zealand) (NZRU)"
+  },
+  {
+    "id": "NZSP",
+    "british": false,
+    "label": "South Pole Station Airport (Antarctica) (NZSP)"
+  },
+  {
+    "id": "TRG",
+    "british": false,
+    "label": "Tauranga Airport (New Zealand) (NZTG / TRG)"
+  },
+  {
+    "id": "TIU",
+    "british": false,
+    "label": "Timaru Airport (New Zealand) (NZTU / TIU)"
+  },
+  {
+    "id": "TWZ",
+    "british": false,
+    "label": "Pukaki Airport (New Zealand) (NZUK / TWZ)"
+  },
+  {
+    "id": "BHE",
+    "british": false,
+    "label": "Woodbourne Airport (New Zealand) (NZWB / BHE)"
+  },
+  {
+    "id": "NZWD",
+    "british": false,
+    "label": "Williams Field (Antarctica) (NZWD)"
+  },
+  {
+    "id": "WKA",
+    "british": false,
+    "label": "Wanaka Airport (New Zealand) (NZWF / WKA)"
+  },
+  {
+    "id": "NZWG",
+    "british": false,
+    "label": "Wigram Airport (New Zealand) (NZWG)"
+  },
+  {
+    "id": "WHK",
+    "british": false,
+    "label": "Whakatane Airport (New Zealand) (NZWK / WHK)"
+  },
+  {
+    "id": "WLG",
+    "british": false,
+    "label": "Wellington International Airport (New Zealand) (NZWN / WLG)"
+  },
+  {
+    "id": "WIR",
+    "british": false,
+    "label": "Wairoa Airport (New Zealand) (NZWO / WIR)"
+  },
+  {
+    "id": "NZWP",
+    "british": false,
+    "label": "RNZAF Base Auckland-Whenuapai (New Zealand) (NZWP)"
+  },
+  {
+    "id": "WRE",
+    "british": false,
+    "label": "Whangarei Airport (New Zealand) (NZWR / WRE)"
+  },
+  {
+    "id": "WSZ",
+    "british": false,
+    "label": "Westport Airport (New Zealand) (NZWS / WSZ)"
+  },
+  {
+    "id": "WAG",
+    "british": false,
+    "label": "Wanganui Airport (New Zealand) (NZWU / WAG)"
+  },
+  {
+    "id": "HEA",
+    "british": false,
+    "label": "Herat Airport (Afghanistan) (OAHR / HEA)"
+  },
+  {
+    "id": "JAA",
+    "british": false,
+    "label": "Jalalabad Airport (Afghanistan) (OAJL / JAA)"
+  },
+  {
+    "id": "KBL",
+    "british": false,
+    "label": "Hamid Karzai International Airport (Afghanistan) (OAKB / KBL)"
+  },
+  {
+    "id": "KDH",
+    "british": false,
+    "label": "Kandahar Airport (Afghanistan) (OAKN / KDH)"
+  },
+  {
+    "id": "MMZ",
+    "british": false,
+    "label": "Maimana Airport (Afghanistan) (OAMN / MMZ)"
+  },
+  {
+    "id": "MZR",
+    "british": false,
+    "label": "Mazar I Sharif Airport (Afghanistan) (OAMS / MZR)"
+  },
+  {
+    "id": "OAH",
+    "british": false,
+    "label": "Shindand Airport (Afghanistan) (OASD / OAH)"
+  },
+  {
+    "id": "OASG",
+    "british": false,
+    "label": "Sheberghan Airport (Afghanistan) (OASG)"
+  },
+  {
+    "id": "UND",
+    "british": false,
+    "label": "Konduz Airport (Afghanistan) (OAUZ / UND)"
+  },
+  {
+    "id": "BAH",
+    "british": false,
+    "label": "Bahrain International Airport (Bahrain) (OBBI / BAH)"
+  },
+  {
+    "id": "OBBS",
+    "british": false,
+    "label": "Sheik Isa Air Base (Bahrain) (OBBS)"
+  },
+  {
+    "id": "AHB",
+    "british": false,
+    "label": "Abha Regional Airport (Saudi Arabia) (OEAB / AHB)"
+  },
+  {
+    "id": "HOF",
+    "british": false,
+    "label": "Al Ahsa Airport (Saudi Arabia) (OEAH / HOF)"
+  },
+  {
+    "id": "ABT",
+    "british": false,
+    "label": "Al Baha Airport (Saudi Arabia) (OEBA / ABT)"
+  },
+  {
+    "id": "BHH",
+    "british": false,
+    "label": "Bisha Airport (Saudi Arabia) (OEBH / BHH)"
+  },
+  {
+    "id": "OEBQ",
+    "british": false,
+    "label": "Abqaiq Airport (Saudi Arabia) (OEBQ)"
+  },
+  {
+    "id": "DMM",
+    "british": false,
+    "label": "King Fahd International Airport (Saudi Arabia) (OEDF / DMM)"
+  },
+  {
+    "id": "DHA",
+    "british": false,
+    "label": "King Abdulaziz Air Base (Saudi Arabia) (OEDR / DHA)"
+  },
+  {
+    "id": "GIZ",
+    "british": false,
+    "label": "Jizan Regional Airport (Saudi Arabia) (OEGN / GIZ)"
+  },
+  {
+    "id": "ELQ",
+    "british": false,
+    "label": "Gassim Airport (Saudi Arabia) (OEGS / ELQ)"
+  },
+  {
+    "id": "URY",
+    "british": false,
+    "label": "Gurayat Domestic Airport (Saudi Arabia) (OEGT / URY)"
+  },
+  {
+    "id": "HAS",
+    "british": false,
+    "label": "Ha'il Airport (Saudi Arabia) (OEHL / HAS)"
+  },
+  {
+    "id": "QJB",
+    "british": false,
+    "label": "Jubail Airport (Saudi Arabia) (OEJB / QJB)"
+  },
+  {
+    "id": "OEJF",
+    "british": false,
+    "label": "King Faisal Naval Base (Saudi Arabia) (OEJF)"
+  },
+  {
+    "id": "JED",
+    "british": false,
+    "label": "King Abdulaziz International Airport (Saudi Arabia) (OEJN / JED)"
+  },
+  {
+    "id": "KMC",
+    "british": false,
+    "label": "King Khaled Military City Airport (Saudi Arabia) (OEKK / KMC)"
+  },
+  {
+    "id": "MED",
+    "british": false,
+    "label": "Prince Mohammad Bin Abdulaziz Airport (Saudi Arabia) (OEMA / MED)"
+  },
+  {
+    "id": "EAM",
+    "british": false,
+    "label": "Nejran Airport (Saudi Arabia) (OENG / EAM)"
+  },
+  {
+    "id": "AQI",
+    "british": false,
+    "label": "Al Qaisumah/Hafr Al Batin Airport (Saudi Arabia) (OEPA / AQI)"
+  },
+  {
+    "id": "OEPC",
+    "british": false,
+    "label": "Pump Station 3 Airport (Saudi Arabia) (OEPC)"
+  },
+  {
+    "id": "OEPF",
+    "british": false,
+    "label": "Pump Station 6 Airport (Saudi Arabia) (OEPF)"
+  },
+  {
+    "id": "OEPJ",
+    "british": false,
+    "label": "Pump Station 10 Airport (Saudi Arabia) (OEPJ)"
+  },
+  {
+    "id": "OERB",
+    "british": false,
+    "label": "Rabigh Airport (Saudi Arabia) (OERB)"
+  },
+  {
+    "id": "RAH",
+    "british": false,
+    "label": "Rafha Domestic Airport (Saudi Arabia) (OERF / RAH)"
+  },
+  {
+    "id": "RUH",
+    "british": false,
+    "label": "King Khaled International Airport (Saudi Arabia) (OERK / RUH)"
+  },
+  {
+    "id": "OERM",
+    "british": false,
+    "label": "Ras Mishab Airport (Saudi Arabia) (OERM)"
+  },
+  {
+    "id": "RAE",
+    "british": false,
+    "label": "Arar Domestic Airport (Saudi Arabia) (OERR / RAE)"
+  },
+  {
+    "id": "OERT",
+    "british": false,
+    "label": "Ras Tanura Airport (Saudi Arabia) (OERT)"
+  },
+  {
+    "id": "SHW",
+    "british": false,
+    "label": "Sharurah Airport (Saudi Arabia) (OESH / SHW)"
+  },
+  {
+    "id": "SLF",
+    "british": false,
+    "label": "Sulayel Airport (Saudi Arabia) (OESL / SLF)"
+  },
+  {
+    "id": "TUU",
+    "british": false,
+    "label": "Tabuk Airport (Saudi Arabia) (OETB / TUU)"
+  },
+  {
+    "id": "TIF",
+    "british": false,
+    "label": "Ta’if Regional Airport (Saudi Arabia) (OETF / TIF)"
+  },
+  {
+    "id": "OETH",
+    "british": false,
+    "label": "Thumamah Airport (Saudi Arabia) (OETH)"
+  },
+  {
+    "id": "OETN",
+    "british": false,
+    "label": "Ras Tanajib Airport (Saudi Arabia) (OETN)"
+  },
+  {
+    "id": "TUI",
+    "british": false,
+    "label": "Turaif Domestic Airport (Saudi Arabia) (OETR / TUI)"
+  },
+  {
+    "id": "EJH",
+    "british": false,
+    "label": "Al Wajh Domestic Airport (Saudi Arabia) (OEWJ / EJH)"
+  },
+  {
+    "id": "YNB",
+    "british": false,
+    "label": "Prince Abdulmohsin Bin Abdulaziz Airport (Saudi Arabia) (OEYN / YNB)"
+  },
+  {
+    "id": "ABD",
+    "british": false,
+    "label": "Abadan Airport (Iran) (OIAA / ABD)"
+  },
+  {
+    "id": "DEF",
+    "british": false,
+    "label": "Dezful Airport (Iran) (OIAD / DEF)"
+  },
+  {
+    "id": "AKW",
+    "british": false,
+    "label": "Aghajari Airport (Iran) (OIAG / AKW)"
+  },
+  {
+    "id": "GCH",
+    "british": false,
+    "label": "Gachsaran Airport (Iran) (OIAH / GCH)"
+  },
+  {
+    "id": "OIAI",
+    "british": false,
+    "label": "Shahid Asyaee Airport (Iran) (OIAI)"
+  },
+  {
+    "id": "OMI",
+    "british": false,
+    "label": "Omidiyeh Airport (Iran) (OIAJ / OMI)"
+  },
+  {
+    "id": "MRX",
+    "british": false,
+    "label": "Mahshahr Airport (Iran) (OIAM / MRX)"
+  },
+  {
+    "id": "AWZ",
+    "british": false,
+    "label": "Ahwaz Airport (Iran) (OIAW / AWZ)"
+  },
+  {
+    "id": "AEU",
+    "british": false,
+    "label": "Abu Musa Island Airport (Iran) (OIBA / AEU)"
+  },
+  {
+    "id": "BUZ",
+    "british": false,
+    "label": "Bushehr Airport (Iran) (OIBB / BUZ)"
+  },
+  {
+    "id": "OIBH",
+    "british": false,
+    "label": "Bastak Airport (Iran) (OIBH)"
+  },
+  {
+    "id": "OIBI",
+    "british": false,
+    "label": "Asaloyeh Airport (Iran) (OIBI)"
+  },
+  {
+    "id": "KIH",
+    "british": false,
+    "label": "Kish International Airport (Iran) (OIBK / KIH)"
+  },
+  {
+    "id": "BDH",
+    "british": false,
+    "label": "Bandar Lengeh Airport (Iran) (OIBL / BDH)"
+  },
+  {
+    "id": "KHK",
+    "british": false,
+    "label": "Khark Island Airport (Iran) (OIBQ / KHK)"
+  },
+  {
+    "id": "SXI",
+    "british": false,
+    "label": "Sirri Island Airport (Iran) (OIBS / SXI)"
+  },
+  {
+    "id": "LVP",
+    "british": false,
+    "label": "Lavan Island Airport (Iran) (OIBV / LVP)"
+  },
+  {
+    "id": "KSH",
+    "british": false,
+    "label": "Shahid Ashrafi Esfahani Airport (Iran) (OICC / KSH)"
+  },
+  {
+    "id": "SDG",
+    "british": false,
+    "label": "Sanandaj Airport (Iran) (OICS / SDG)"
+  },
+  {
+    "id": "IFH",
+    "british": false,
+    "label": "Hesa Airport (Iran) (OIFE / IFH)"
+  },
+  {
+    "id": "OIFH",
+    "british": false,
+    "label": "Shahid Vatan Pour Air Base (Iran) (OIFH)"
+  },
+  {
+    "id": "KKS",
+    "british": false,
+    "label": "Kashan Airport (Iran) (OIFK / KKS)"
+  },
+  {
+    "id": "IFN",
+    "british": false,
+    "label": "Esfahan Shahid Beheshti International Airport (Iran) (OIFM / IFN)"
+  },
+  {
+    "id": "OIFP",
+    "british": false,
+    "label": "Badr Air Base (Iran) (OIFP)"
+  },
+  {
+    "id": "RAS",
+    "british": false,
+    "label": "Sardar-e-Jangal Airport (Iran) (OIGG / RAS)"
+  },
+  {
+    "id": "AJK",
+    "british": false,
+    "label": "Arak Airport (Iran) (OIHR / AJK)"
+  },
+  {
+    "id": "OIIA",
+    "british": false,
+    "label": "Ghazvin Azadi Airport (Iran) (OIIA)"
+  },
+  {
+    "id": "OIIC",
+    "british": false,
+    "label": "Kushke Nosrat Airport (Iran) (OIIC)"
+  },
+  {
+    "id": "OIID",
+    "british": false,
+    "label": "Doshan Tappeh Air Base (Iran) (OIID)"
+  },
+  {
+    "id": "OIIG",
+    "british": false,
+    "label": "Ghale Morghi Airport (Iran) (OIIG)"
+  },
+  {
+    "id": "THR",
+    "british": false,
+    "label": "Mehrabad International Airport (Iran) (OIII / THR)"
+  },
+  {
+    "id": "GZW",
+    "british": false,
+    "label": "Qazvin Airport (Iran) (OIIK / GZW)"
+  },
+  {
+    "id": "OIIM",
+    "british": false,
+    "label": "Naja Airport (Iran) (OIIM)"
+  },
+  {
+    "id": "BND",
+    "british": false,
+    "label": "Bandar Abbas International Airport (Iran) (OIKB / BND)"
+  },
+  {
+    "id": "JYR",
+    "british": false,
+    "label": "Jiroft Airport (Iran) (OIKJ / JYR)"
+  },
+  {
+    "id": "KER",
+    "british": false,
+    "label": "Kerman Airport (Iran) (OIKK / KER)"
+  },
+  {
+    "id": "HDR",
+    "british": false,
+    "label": "Havadarya Airport (Iran) (OIKP / HDR)"
+  },
+  {
+    "id": "OIKQ",
+    "british": false,
+    "label": "Dayrestan Airport (Iran) (OIKQ)"
+  },
+  {
+    "id": "SYJ",
+    "british": false,
+    "label": "Sirjan Airport (Iran) (OIKY / SYJ)"
+  },
+  {
+    "id": "XBJ",
+    "british": false,
+    "label": "Birjand Airport (Iran) (OIMB / XBJ)"
+  },
+  {
+    "id": "CKT",
+    "british": false,
+    "label": "Sarakhs Airport (Iran) (OIMC / CKT)"
+  },
+  {
+    "id": "RUD",
+    "british": false,
+    "label": "Shahroud Airport (Iran) (OIMJ / RUD)"
+  },
+  {
+    "id": "TCX",
+    "british": false,
+    "label": "Tabas Airport (Iran) (OIMT / TCX)"
+  },
+  {
+    "id": "KLM",
+    "british": false,
+    "label": "Kalaleh Airport (Iran) (OINE / KLM)"
+  },
+  {
+    "id": "RZR",
+    "british": false,
+    "label": "Ramsar Airport (Iran) (OINR / RZR)"
+  },
+  {
+    "id": "FAZ",
+    "british": false,
+    "label": "Fasa Airport (Iran) (OISF / FAZ)"
+  },
+  {
+    "id": "JAR",
+    "british": false,
+    "label": "Jahrom Airport (Iran) (OISJ / JAR)"
+  },
+  {
+    "id": "LFM",
+    "british": false,
+    "label": "Lamerd Airport (Iran) (OISR / LFM)"
+  },
+  {
+    "id": "SYZ",
+    "british": false,
+    "label": "Shiraz Shahid Dastghaib International Airport (Iran) (OISS / SYZ)"
+  },
+  {
+    "id": "KHY",
+    "british": false,
+    "label": "Khoy Airport (Iran) (OITK / KHY)"
+  },
+  {
+    "id": "TBZ",
+    "british": false,
+    "label": "Tabriz International Airport (Iran) (OITT / TBZ)"
+  },
+  {
+    "id": "JWN",
+    "british": false,
+    "label": "Zanjan Airport (Iran) (OITZ / JWN)"
+  },
+  {
+    "id": "AZD",
+    "british": false,
+    "label": "Shahid Sadooghi Airport (Iran) (OIYY / AZD)"
+  },
+  {
+    "id": "ACZ",
+    "british": false,
+    "label": "Zabol Airport (Iran) (OIZB / ACZ)"
+  },
+  {
+    "id": "ZBR",
+    "british": false,
+    "label": "Konarak Airport (Iran) (OIZC / ZBR)"
+  },
+  {
+    "id": "ZAH",
+    "british": false,
+    "label": "Zahedan International Airport (Iran) (OIZH / ZAH)"
+  },
+  {
+    "id": "IHR",
+    "british": false,
+    "label": "Iran Shahr Airport (Iran) (OIZI / IHR)"
+  },
+  {
+    "id": "OIZS",
+    "british": false,
+    "label": "Saravan Airport (Iran) (OIZS)"
+  },
+  {
+    "id": "AMM",
+    "british": false,
+    "label": "Queen Alia International Airport (Jordan) (OJAI / AMM)"
+  },
+  {
+    "id": "ADJ",
+    "british": false,
+    "label": "Amman-Marka International Airport (Jordan) (OJAM / ADJ)"
+  },
+  {
+    "id": "AQJ",
+    "british": false,
+    "label": "Aqaba King Hussein International Airport (Jordan) (OJAQ / AQJ)"
+  },
+  {
+    "id": "OJHF",
+    "british": false,
+    "label": "Prince Hassan Air Base (Jordan) (OJHF)"
+  },
+  {
+    "id": "OJJR",
+    "british": false,
+    "label": "Jerusalem Airport (West Bank) (OJJR)"
+  },
+  {
+    "id": "OMF",
+    "british": false,
+    "label": "King Hussein Air College (Jordan) (OJMF / OMF)"
+  },
+  {
+    "id": "KWI",
+    "british": false,
+    "label": "Kuwait International Airport (Kuwait) (OKBK / KWI)"
+  },
+  {
+    "id": "BEY",
+    "british": false,
+    "label": "Beirut Rafic Hariri International Airport (Lebanon) (OLBA / BEY)"
+  },
+  {
+    "id": "KYE",
+    "british": false,
+    "label": "Rene Mouawad Air Base (Lebanon) (OLKA / KYE)"
+  },
+  {
+    "id": "AUH",
+    "british": false,
+    "label": "Abu Dhabi International Airport (United Arab Emirates) (OMAA / AUH)"
+  },
+  {
+    "id": "AZI",
+    "british": false,
+    "label": "Bateen Airport (United Arab Emirates) (OMAD / AZI)"
+  },
+  {
+    "id": "OMAH",
+    "british": false,
+    "label": "Al Hamra Aux Airport (United Arab Emirates) (OMAH)"
+  },
+  {
+    "id": "OMAJ",
+    "british": false,
+    "label": "Jebel Dhana Airport (United Arab Emirates) (OMAJ)"
+  },
+  {
+    "id": "DHF",
+    "british": false,
+    "label": "Al Dhafra Air Base (United Arab Emirates) (OMAM / DHF)"
+  },
+  {
+    "id": "OMAR",
+    "british": false,
+    "label": "Arzanah Airport (United Arab Emirates) (OMAR)"
+  },
+  {
+    "id": "OMAS",
+    "british": false,
+    "label": "Das Island Airport (United Arab Emirates) (OMAS)"
+  },
+  {
+    "id": "OMAZ",
+    "british": false,
+    "label": "Zirku Airport (United Arab Emirates) (OMAZ)"
+  },
+  {
+    "id": "DXB",
+    "british": false,
+    "label": "Dubai International Airport (United Arab Emirates) (OMDB / DXB)"
+  },
+  {
+    "id": "FJR",
+    "british": false,
+    "label": "Fujairah International Airport (United Arab Emirates) (OMFJ / FJR)"
+  },
+  {
+    "id": "RKT",
+    "british": false,
+    "label": "Ras Al Khaimah International Airport (United Arab Emirates) (OMRK / RKT)"
+  },
+  {
+    "id": "SHJ",
+    "british": false,
+    "label": "Sharjah International Airport (United Arab Emirates) (OMSJ / SHJ)"
+  },
+  {
+    "id": "KHS",
+    "british": false,
+    "label": "Khasab Air Base (Oman) (OOKB / KHS)"
+  },
+  {
+    "id": "MSH",
+    "british": false,
+    "label": "Masirah Air Base (Oman) (OOMA / MSH)"
+  },
+  {
+    "id": "MCT",
+    "british": false,
+    "label": "Muscat International Airport (Oman) (OOMS / MCT)"
+  },
+  {
+    "id": "SLL",
+    "british": false,
+    "label": "Salalah Airport (Oman) (OOSA / SLL)"
+  },
+  {
+    "id": "TTH",
+    "british": false,
+    "label": "Thumrait Air Base (Oman) (OOTH / TTH)"
+  },
+  {
+    "id": "BHW",
+    "british": false,
+    "label": "Bhagatanwala Airport (Pakistan) (OPBG / BHW)"
+  },
+  {
+    "id": "LYP",
+    "british": false,
+    "label": "Faisalabad International Airport (Pakistan) (OPFA / LYP)"
+  },
+  {
+    "id": "GWD",
+    "british": false,
+    "label": "Gwadar International Airport (Pakistan) (OPGD / GWD)"
+  },
+  {
+    "id": "GIL",
+    "british": false,
+    "label": "Gilgit Airport (Pakistan) (OPGT / GIL)"
+  },
+  {
+    "id": "JAG",
+    "british": false,
+    "label": "Shahbaz Air Base (Pakistan) (OPJA / JAG)"
+  },
+  {
+    "id": "KHI",
+    "british": false,
+    "label": "Jinnah International Airport (Pakistan) (OPKC / KHI)"
+  },
+  {
+    "id": "LHE",
+    "british": false,
+    "label": "Alama Iqbal International Airport (Pakistan) (OPLA / LHE)"
+  },
+  {
+    "id": "OPLH",
+    "british": false,
+    "label": "Walton Airport (Pakistan) (OPLH)"
+  },
+  {
+    "id": "XJM",
+    "british": false,
+    "label": "Mangla Airport (Pakistan) (OPMA / XJM)"
+  },
+  {
+    "id": "MFG",
+    "british": false,
+    "label": "Muzaffarabad Airport (Pakistan) (OPMF / MFG)"
+  },
+  {
+    "id": "MWD",
+    "british": false,
+    "label": "Mianwali Air Base (Pakistan) (OPMI / MWD)"
+  },
+  {
+    "id": "MJD",
+    "british": false,
+    "label": "Moenjodaro Airport (Pakistan) (OPMJ / MJD)"
+  },
+  {
+    "id": "OPMR",
+    "british": false,
+    "label": "Masroor Air Base (Pakistan) (OPMR)"
+  },
+  {
+    "id": "MUX",
+    "british": false,
+    "label": "Multan International Airport (Pakistan) (OPMT / MUX)"
+  },
+  {
+    "id": "WNS",
+    "british": false,
+    "label": "Shaheed Benazirabad Airport (Pakistan) (OPNH / WNS)"
+  },
+  {
+    "id": "OPOK",
+    "british": false,
+    "label": "Okara Cantonment Airstrip (Pakistan) (OPOK)"
+  },
+  {
+    "id": "PJG",
+    "british": false,
+    "label": "Panjgur Airport (Pakistan) (OPPG / PJG)"
+  },
+  {
+    "id": "PSI",
+    "british": false,
+    "label": "Pasni Airport (Pakistan) (OPPI / PSI)"
+  },
+  {
+    "id": "PEW",
+    "british": false,
+    "label": "Peshawar International Airport (Pakistan) (OPPS / PEW)"
+  },
+  {
+    "id": "OPQS",
+    "british": false,
+    "label": "Qasim Airport (Pakistan) (OPQS)"
+  },
+  {
+    "id": "UET",
+    "british": false,
+    "label": "Quetta International Airport (Pakistan) (OPQT / UET)"
+  },
+  {
+    "id": "RYK",
+    "british": false,
+    "label": "Shaikh Zaid Airport (Pakistan) (OPRK / RYK)"
+  },
+  {
+    "id": "OPRN",
+    "british": false,
+    "label": "Benazir Bhutto International Airport (Pakistan) (OPRN)"
+  },
+  {
+    "id": "OPRS",
+    "british": false,
+    "label": "Risalpur Air Base (Pakistan) (OPRS)"
+  },
+  {
+    "id": "RAZ",
+    "british": false,
+    "label": "Rawalakot Airport (Pakistan) (OPRT / RAZ)"
+  },
+  {
+    "id": "SKZ",
+    "british": false,
+    "label": "Sukkur Airport (Pakistan) (OPSK / SKZ)"
+  },
+  {
+    "id": "SDT",
+    "british": false,
+    "label": "Saidu Sharif Airport (Pakistan) (OPSS / SDT)"
+  },
+  {
+    "id": "SUL",
+    "british": false,
+    "label": "Sui Airport (Pakistan) (OPSU / SUL)"
+  },
+  {
+    "id": "BDN",
+    "british": false,
+    "label": "Talhar Airport (Pakistan) (OPTH / BDN)"
+  },
+  {
+    "id": "WAF",
+    "british": false,
+    "label": "Wana Airport (Pakistan) (OPWN / WAF)"
+  },
+  {
+    "id": "PZH",
+    "british": false,
+    "label": "Zhob Airport (Pakistan) (OPZB / PZH)"
+  },
+  {
+    "id": "BSR",
+    "british": false,
+    "label": "Basrah International Airport (Iraq) (ORMM / BSR)"
+  },
+  {
+    "id": "ALP",
+    "british": false,
+    "label": "Aleppo International Airport (Syria) (OSAP / ALP)"
+  },
+  {
+    "id": "DAM",
+    "british": false,
+    "label": "Damascus International Airport (Syria) (OSDI / DAM)"
+  },
+  {
+    "id": "DEZ",
+    "british": false,
+    "label": "Deir ez-Zor Air Base (Syria) (OSDZ / DEZ)"
+  },
+  {
+    "id": "LTK",
+    "british": false,
+    "label": "Bassel Al-Assad International Airport (Syria) (OSLK / LTK)"
+  },
+  {
+    "id": "PMS",
+    "british": false,
+    "label": "Palmyra Airport (Syria) (OSPR / PMS)"
+  },
+  {
+    "id": "DIA",
+    "british": false,
+    "label": "Doha International Airport (Qatar) (OTBD / DIA)"
+  },
+  {
+    "id": "CIS",
+    "british": false,
+    "label": "Canton Island Airport (Kiribati) (PCIS / CIS)"
+  },
+  {
+    "id": "ROP",
+    "british": false,
+    "label": "Rota International Airport (Northern Mariana Islands) (PGRO / ROP)"
+  },
+  {
+    "id": "SPN",
+    "british": false,
+    "label": "Saipan International Airport (Northern Mariana Islands) (PGSN / SPN)"
+  },
+  {
+    "id": "UAM",
+    "british": false,
+    "label": "Andersen Air Force Base (Guam) (PGUA / UAM)"
+  },
+  {
+    "id": "GUM",
+    "british": false,
+    "label": "Antonio B. Won Pat International Airport (Guam) (PGUM / GUM)"
+  },
+  {
+    "id": "TIQ",
+    "british": false,
+    "label": "Tinian International Airport (Northern Mariana Islands) (PGWT / TIQ)"
+  },
+  {
+    "id": "MAJ",
+    "british": false,
+    "label": "Marshall Islands International Airport (Marshall Islands) (PKMJ / MAJ)"
+  },
+  {
+    "id": "PKRO",
+    "british": false,
+    "label": "Dyess Army Air Field (Marshall Islands) (PKRO)"
+  },
+  {
+    "id": "KWA",
+    "british": false,
+    "label": "Bucholz Army Air Field (Marshall Islands) (PKWA / KWA)"
+  },
+  {
+    "id": "CXI",
+    "british": false,
+    "label": "Cassidy International Airport (Kiribati) (PLCH / CXI)"
+  },
+  {
+    "id": "MDY",
+    "british": false,
+    "label": "Henderson Field (Midway Islands) (PMDY / MDY)"
+  },
+  {
+    "id": "TKK",
+    "british": false,
+    "label": "Chuuk International Airport (Micronesia) (PTKK / TKK)"
+  },
+  {
+    "id": "PNI",
+    "british": false,
+    "label": "Pohnpei International Airport (Micronesia) (PTPN / PNI)"
+  },
+  {
+    "id": "ROR",
+    "british": false,
+    "label": "Babelthuap Airport (Palau) (PTRO / ROR)"
+  },
+  {
+    "id": "KSA",
+    "british": false,
+    "label": "Kosrae International Airport (Micronesia) (PTSA / KSA)"
+  },
+  {
+    "id": "YAP",
+    "british": false,
+    "label": "Yap International Airport (Micronesia) (PTYA / YAP)"
+  },
+  {
+    "id": "KNH",
+    "british": false,
+    "label": "Kinmen Airport (Taiwan) (RCBS / KNH)"
+  },
+  {
+    "id": "RCDC",
+    "british": false,
+    "label": "Pingtung South Airport (Taiwan) (RCDC)"
+  },
+  {
+    "id": "RCDI",
+    "british": false,
+    "label": "Longtan Air Base (Taiwan) (RCDI)"
+  },
+  {
+    "id": "TTT",
+    "british": false,
+    "label": "Taitung Airport (Taiwan) (RCFN / TTT)"
+  },
+  {
+    "id": "GNI",
+    "british": false,
+    "label": "Lyudao Airport (Taiwan) (RCGI / GNI)"
+  },
+  {
+    "id": "KHH",
+    "british": false,
+    "label": "Kaohsiung International Airport (Taiwan) (RCKH / KHH)"
+  },
+  {
+    "id": "CYI",
+    "british": false,
+    "label": "Chiayi Airport (Taiwan) (RCKU / CYI)"
+  },
+  {
+    "id": "KYD",
+    "british": false,
+    "label": "Lanyu Airport (Taiwan) (RCLY / KYD)"
+  },
+  {
+    "id": "RMQ",
+    "british": false,
+    "label": "Taichung Ching Chuang Kang Airport (Taiwan) (RCMQ / RMQ)"
+  },
+  {
+    "id": "TNN",
+    "british": false,
+    "label": "Tainan Airport (Taiwan) (RCNN / TNN)"
+  },
+  {
+    "id": "HSZ",
+    "british": false,
+    "label": "Hsinchu Air Base (Taiwan) (RCPO / HSZ)"
+  },
+  {
+    "id": "MZG",
+    "british": false,
+    "label": "Makung Airport (Taiwan) (RCQC / MZG)"
+  },
+  {
+    "id": "RCQS",
+    "british": false,
+    "label": "Chihhang Air Base (Taiwan) (RCQS)"
+  },
+  {
+    "id": "PIF",
+    "british": false,
+    "label": "Pingtung North Airport (Taiwan) (RCSQ / PIF)"
+  },
+  {
+    "id": "TSA",
+    "british": false,
+    "label": "Taipei Songshan Airport (Taiwan) (RCSS / TSA)"
+  },
+  {
+    "id": "TPE",
+    "british": false,
+    "label": "Taiwan Taoyuan International Airport (Taiwan) (RCTP / TPE)"
+  },
+  {
+    "id": "WOT",
+    "british": false,
+    "label": "Wang-an Airport (Taiwan) (RCWA / WOT)"
+  },
+  {
+    "id": "HUN",
+    "british": false,
+    "label": "Hualien Airport (Taiwan) (RCYU / HUN)"
+  },
+  {
+    "id": "NRT",
+    "british": false,
+    "label": "Narita International Airport (Japan) (RJAA / NRT)"
+  },
+  {
+    "id": "MMJ",
+    "british": false,
+    "label": "Matsumoto Airport (Japan) (RJAF / MMJ)"
+  },
+  {
+    "id": "IBR",
+    "british": false,
+    "label": "Hyakuri Airport (Japan) (RJAH / IBR)"
+  },
+  {
+    "id": "MUS",
+    "british": false,
+    "label": "Minami Torishima Airport (Japan) (RJAM / MUS)"
+  },
+  {
+    "id": "IWO",
+    "british": false,
+    "label": "Iwo Jima Airport (Japan) (RJAW / IWO)"
+  },
+  {
+    "id": "SHM",
+    "british": false,
+    "label": "Nanki Shirahama Airport (Japan) (RJBD / SHM)"
+  },
+  {
+    "id": "RJBK",
+    "british": false,
+    "label": "Kohnan Airport (Japan) (RJBK)"
+  },
+  {
+    "id": "OBO",
+    "british": false,
+    "label": "Tokachi-Obihiro Airport (Japan) (RJCB / OBO)"
+  },
+  {
+    "id": "CTS",
+    "british": false,
+    "label": "New Chitose Airport (Japan) (RJCC / CTS)"
+  },
+  {
+    "id": "HKD",
+    "british": false,
+    "label": "Hakodate Airport (Japan) (RJCH / HKD)"
+  },
+  {
+    "id": "RJCJ",
+    "british": false,
+    "label": "Chitose Air Base (Japan) (RJCJ)"
+  },
+  {
+    "id": "MMB",
+    "british": false,
+    "label": "Memanbetsu Airport (Japan) (RJCM / MMB)"
+  },
+  {
+    "id": "SHB",
+    "british": false,
+    "label": "Nakashibetsu Airport (Japan) (RJCN / SHB)"
+  },
+  {
+    "id": "RJCT",
+    "british": false,
+    "label": "Tokachi Airport (Japan) (RJCT)"
+  },
+  {
+    "id": "WKJ",
+    "british": false,
+    "label": "Wakkanai Airport (Japan) (RJCW / WKJ)"
+  },
+  {
+    "id": "IKI",
+    "british": false,
+    "label": "Iki Airport (Japan) (RJDB / IKI)"
+  },
+  {
+    "id": "UBJ",
+    "british": false,
+    "label": "Yamaguchi Ube Airport (Japan) (RJDC / UBJ)"
+  },
+  {
+    "id": "TSJ",
+    "british": false,
+    "label": "Tsushima Airport (Japan) (RJDT / TSJ)"
+  },
+  {
+    "id": "MBE",
+    "british": false,
+    "label": "Monbetsu Airport (Japan) (RJEB / MBE)"
+  },
+  {
+    "id": "AKJ",
+    "british": false,
+    "label": "Asahikawa Airport (Japan) (RJEC / AKJ)"
+  },
+  {
+    "id": "OIR",
+    "british": false,
+    "label": "Okushiri Airport (Japan) (RJEO / OIR)"
+  },
+  {
+    "id": "RIS",
+    "british": false,
+    "label": "Rishiri Airport (Japan) (RJER / RIS)"
+  },
+  {
+    "id": "RJFA",
+    "british": false,
+    "label": "Ashiya Airport (Japan) (RJFA)"
+  },
+  {
+    "id": "KUM",
+    "british": false,
+    "label": "Yakushima Airport (Japan) (RJFC / KUM)"
+  },
+  {
+    "id": "FUJ",
+    "british": false,
+    "label": "Fukue Airport (Japan) (RJFE / FUJ)"
+  },
+  {
+    "id": "FUK",
+    "british": false,
+    "label": "Fukuoka Airport (Japan) (RJFF / FUK)"
+  },
+  {
+    "id": "TNE",
+    "british": false,
+    "label": "New Tanegashima Airport (Japan) (RJFG / TNE)"
+  },
+  {
+    "id": "KOJ",
+    "british": false,
+    "label": "Kagoshima Airport (Japan) (RJFK / KOJ)"
+  },
+  {
+    "id": "KMI",
+    "british": false,
+    "label": "Miyazaki Airport (Japan) (RJFM / KMI)"
+  },
+  {
+    "id": "RJFN",
+    "british": false,
+    "label": "Nyutabaru Airport (Japan) (RJFN)"
+  },
+  {
+    "id": "OIT",
+    "british": false,
+    "label": "Oita Airport (Japan) (RJFO / OIT)"
+  },
+  {
+    "id": "KKJ",
+    "british": false,
+    "label": "Kitakyūshū Airport (Japan) (RJFR / KKJ)"
+  },
+  {
+    "id": "KMJ",
+    "british": false,
+    "label": "Kumamoto Airport (Japan) (RJFT / KMJ)"
+  },
+  {
+    "id": "NGS",
+    "british": false,
+    "label": "Nagasaki Airport (Japan) (RJFU / NGS)"
+  },
+  {
+    "id": "RJFY",
+    "british": false,
+    "label": "Kanoya Airport (Japan) (RJFY)"
+  },
+  {
+    "id": "RJFZ",
+    "british": false,
+    "label": "Tsuiki Air Field (Japan) (RJFZ)"
+  },
+  {
+    "id": "ASJ",
+    "british": false,
+    "label": "Amami Airport (Japan) (RJKA / ASJ)"
+  },
+  {
+    "id": "OKE",
+    "british": false,
+    "label": "Okierabu Airport (Japan) (RJKB / OKE)"
+  },
+  {
+    "id": "TKN",
+    "british": false,
+    "label": "Tokunoshima Airport (Japan) (RJKN / TKN)"
+  },
+  {
+    "id": "FKJ",
+    "british": false,
+    "label": "Fukui Airport (Japan) (RJNF / FKJ)"
+  },
+  {
+    "id": "QGU",
+    "british": false,
+    "label": "Gifu Airport (Japan) (RJNG / QGU)"
+  },
+  {
+    "id": "RJNH",
+    "british": false,
+    "label": "Hamamatsu Airport (Japan) (RJNH)"
+  },
+  {
+    "id": "KMQ",
+    "british": false,
+    "label": "Komatsu Airport (Japan) (RJNK / KMQ)"
+  },
+  {
+    "id": "OKI",
+    "british": false,
+    "label": "Oki Airport (Japan) (RJNO / OKI)"
+  },
+  {
+    "id": "TOY",
+    "british": false,
+    "label": "Toyama Airport (Japan) (RJNT / TOY)"
+  },
+  {
+    "id": "RJNY",
+    "british": false,
+    "label": "Shizuhama Airport (Japan) (RJNY)"
+  },
+  {
+    "id": "HIJ",
+    "british": false,
+    "label": "Hiroshima Airport (Japan) (RJOA / HIJ)"
+  },
+  {
+    "id": "OKJ",
+    "british": false,
+    "label": "Okayama Airport (Japan) (RJOB / OKJ)"
+  },
+  {
+    "id": "IZO",
+    "british": false,
+    "label": "Izumo Airport (Japan) (RJOC / IZO)"
+  },
+  {
+    "id": "RJOF",
+    "british": false,
+    "label": "Hofu Airport (Japan) (RJOF)"
+  },
+  {
+    "id": "YGJ",
+    "british": false,
+    "label": "Miho Yonago Airport (Japan) (RJOH / YGJ)"
+  },
+  {
+    "id": "KCZ",
+    "british": false,
+    "label": "Kōchi Ryōma Airport (Japan) (RJOK / KCZ)"
+  },
+  {
+    "id": "MYJ",
+    "british": false,
+    "label": "Matsuyama Airport (Japan) (RJOM / MYJ)"
+  },
+  {
+    "id": "ITM",
+    "british": false,
+    "label": "Osaka International Airport (Japan) (RJOO / ITM)"
+  },
+  {
+    "id": "TTJ",
+    "british": false,
+    "label": "Tottori Airport (Japan) (RJOR / TTJ)"
+  },
+  {
+    "id": "TKS",
+    "british": false,
+    "label": "Tokushima Airport/JMSDF Air Base (Japan) (RJOS / TKS)"
+  },
+  {
+    "id": "TAK",
+    "british": false,
+    "label": "Takamatsu Airport (Japan) (RJOT / TAK)"
+  },
+  {
+    "id": "RJOY",
+    "british": false,
+    "label": "Yao Airport (Japan) (RJOY)"
+  },
+  {
+    "id": "RJOZ",
+    "british": false,
+    "label": "Ozuki Airport (Japan) (RJOZ)"
+  },
+  {
+    "id": "AOJ",
+    "british": false,
+    "label": "Aomori Airport (Japan) (RJSA / AOJ)"
+  },
+  {
+    "id": "GAJ",
+    "british": false,
+    "label": "Yamagata Airport (Japan) (RJSC / GAJ)"
+  },
+  {
+    "id": "SDS",
+    "british": false,
+    "label": "Sado Airport (Japan) (RJSD / SDS)"
+  },
+  {
+    "id": "HHE",
+    "british": false,
+    "label": "Hachinohe Airport (Japan) (RJSH / HHE)"
+  },
+  {
+    "id": "HNA",
+    "british": false,
+    "label": "Hanamaki Airport (Japan) (RJSI / HNA)"
+  },
+  {
+    "id": "AXT",
+    "british": false,
+    "label": "Akita Airport (Japan) (RJSK / AXT)"
+  },
+  {
+    "id": "MSJ",
+    "british": false,
+    "label": "Misawa Air Base (Japan) (RJSM / MSJ)"
+  },
+  {
+    "id": "SDJ",
+    "british": false,
+    "label": "Sendai Airport (Japan) (RJSS / SDJ)"
+  },
+  {
+    "id": "RJST",
+    "british": false,
+    "label": "Matsushima Air Base (Japan) (RJST)"
+  },
+  {
+    "id": "NJA",
+    "british": false,
+    "label": "Atsugi Naval Air Facility (Japan) (RJTA / NJA)"
+  },
+  {
+    "id": "RJTE",
+    "british": false,
+    "label": "Tateyama Airport (Japan) (RJTE)"
+  },
+  {
+    "id": "HAC",
+    "british": false,
+    "label": "Hachijojima Airport (Japan) (RJTH / HAC)"
+  },
+  {
+    "id": "RJTJ",
+    "british": false,
+    "label": "Iruma Air Base (Japan) (RJTJ)"
+  },
+  {
+    "id": "RJTK",
+    "british": false,
+    "label": "Kisarazu Airport (Japan) (RJTK)"
+  },
+  {
+    "id": "RJTL",
+    "british": false,
+    "label": "Shimofusa Airport (Japan) (RJTL)"
+  },
+  {
+    "id": "OIM",
+    "british": false,
+    "label": "Oshima Airport (Japan) (RJTO / OIM)"
+  },
+  {
+    "id": "RJTR",
+    "british": false,
+    "label": "Kastner Army Heliport (Japan) (RJTR)"
+  },
+  {
+    "id": "HND",
+    "british": false,
+    "label": "Tokyo Haneda International Airport (Japan) (RJTT / HND)"
+  },
+  {
+    "id": "OKO",
+    "british": false,
+    "label": "Yokota Air Base (Japan) (RJTY / OKO)"
+  },
+  {
+    "id": "KWJ",
+    "british": false,
+    "label": "Gwangju Airport (South Korea) (RKJJ / KWJ)"
+  },
+  {
+    "id": "CHN",
+    "british": false,
+    "label": "Jeon Ju Airport (G-703) (South Korea) (RKJU / CHN)"
+  },
+  {
+    "id": "RSU",
+    "british": false,
+    "label": "Yeosu Airport (South Korea) (RKJY / RSU)"
+  },
+  {
+    "id": "RKND",
+    "british": false,
+    "label": "Sokcho Airport (South Korea) (RKND)"
+  },
+  {
+    "id": "KAG",
+    "british": false,
+    "label": "Gangneung Airport (K-18) (South Korea) (RKNN / KAG)"
+  },
+  {
+    "id": "CJU",
+    "british": false,
+    "label": "Jeju International Airport (South Korea) (RKPC / CJU)"
+  },
+  {
+    "id": "CHF",
+    "british": false,
+    "label": "Jinhae Airbase/Airport (G-813/K-10) (South Korea) (RKPE / CHF)"
+  },
+  {
+    "id": "PUS",
+    "british": false,
+    "label": "Gimhae International Airport (South Korea) (RKPK / PUS)"
+  },
+  {
+    "id": "USN",
+    "british": false,
+    "label": "Ulsan Airport (South Korea) (RKPU / USN)"
+  },
+  {
+    "id": "RKSG",
+    "british": false,
+    "label": "A 511 Airport (South Korea) (RKSG)"
+  },
+  {
+    "id": "SSN",
+    "british": false,
+    "label": "Seoul Air Base (K-16) (South Korea) (RKSM / SSN)"
+  },
+  {
+    "id": "OSN",
+    "british": false,
+    "label": "Osan Air Base (South Korea) (RKSO / OSN)"
+  },
+  {
+    "id": "GMP",
+    "british": false,
+    "label": "Gimpo International Airport (South Korea) (RKSS / GMP)"
+  },
+  {
+    "id": "SWU",
+    "british": false,
+    "label": "Suwon Airport (South Korea) (RKSW / SWU)"
+  },
+  {
+    "id": "KPO",
+    "british": false,
+    "label": "Pohang Airport (G-815/K-3) (South Korea) (RKTH / KPO)"
+  },
+  {
+    "id": "TAE",
+    "british": false,
+    "label": "Daegu Airport (South Korea) (RKTN / TAE)"
+  },
+  {
+    "id": "YEC",
+    "british": false,
+    "label": "Yecheon Airbase (South Korea) (RKTY / YEC)"
+  },
+  {
+    "id": "OKA",
+    "british": false,
+    "label": "Naha Airport (Japan) (ROAH / OKA)"
+  },
+  {
+    "id": "RODE",
+    "british": false,
+    "label": "Ie Shima Auxiliary Air Base (Japan) (RODE)"
+  },
+  {
+    "id": "DNA",
+    "british": false,
+    "label": "Kadena Air Base (Japan) (RODN / DNA)"
+  },
+  {
+    "id": "ISG",
+    "british": false,
+    "label": "New Ishigaki Airport (Japan) (ROIG / ISG)"
+  },
+  {
+    "id": "UEO",
+    "british": false,
+    "label": "Kumejima Airport (Japan) (ROKJ / UEO)"
+  },
+  {
+    "id": "MMD",
+    "british": false,
+    "label": "Minami-Daito Airport (Japan) (ROMD / MMD)"
+  },
+  {
+    "id": "MMY",
+    "british": false,
+    "label": "Miyako Airport (Japan) (ROMY / MMY)"
+  },
+  {
+    "id": "KTD",
+    "british": false,
+    "label": "Kitadaito Airport (Japan) (RORK / KTD)"
+  },
+  {
+    "id": "SHI",
+    "british": false,
+    "label": "Shimojishima Airport (Japan) (RORS / SHI)"
+  },
+  {
+    "id": "TRA",
+    "british": false,
+    "label": "Tarama Airport (Japan) (RORT / TRA)"
+  },
+  {
+    "id": "RNJ",
+    "british": false,
+    "label": "Yoron Airport (Japan) (RORY / RNJ)"
+  },
+  {
+    "id": "ROTM",
+    "british": false,
+    "label": "Futenma Marine Corps Air Station (Japan) (ROTM)"
+  },
+  {
+    "id": "OGN",
+    "british": false,
+    "label": "Yonaguni Airport (Japan) (ROYN / OGN)"
+  },
+  {
+    "id": "MNL",
+    "british": false,
+    "label": "Ninoy Aquino International Airport (Philippines) (RPLL / MNL)"
+  },
+  {
+    "id": "CBO",
+    "british": false,
+    "label": "Awang Airport (Philippines) (RPMC / CBO)"
+  },
+  {
+    "id": "RPML",
+    "british": false,
+    "label": "Cagayan De Oro Airport (Philippines) (RPML)"
+  },
+  {
+    "id": "PAG",
+    "british": false,
+    "label": "Pagadian Airport (Philippines) (RPMP / PAG)"
+  },
+  {
+    "id": "GES",
+    "british": false,
+    "label": "General Santos International Airport (Philippines) (RPMR / GES)"
+  },
+  {
+    "id": "ZAM",
+    "british": false,
+    "label": "Zamboanga International Airport (Philippines) (RPMZ / ZAM)"
+  },
+  {
+    "id": "BAG",
+    "british": false,
+    "label": "Loakan Airport (Philippines) (RPUB / BAG)"
+  },
+  {
+    "id": "DTE",
+    "british": false,
+    "label": "Daet Airport (Philippines) (RPUD / DTE)"
+  },
+  {
+    "id": "RPUF",
+    "british": false,
+    "label": "Basa Air Base (Philippines) (RPUF)"
+  },
+  {
+    "id": "RPUG",
+    "british": false,
+    "label": "Lingayen Airport (Philippines) (RPUG)"
+  },
+  {
+    "id": "SJI",
+    "british": false,
+    "label": "San Jose Airport (Philippines) (RPUH / SJI)"
+  },
+  {
+    "id": "RPUL",
+    "british": false,
+    "label": "Fernando Air Base (Philippines) (RPUL)"
+  },
+  {
+    "id": "MBO",
+    "british": false,
+    "label": "Mamburao Airport (Philippines) (RPUM / MBO)"
+  },
+  {
+    "id": "RPUQ",
+    "british": false,
+    "label": "Vigan Airport (Philippines) (RPUQ)"
+  },
+  {
+    "id": "BQA",
+    "british": false,
+    "label": "Dr.Juan C. Angara Airport (Philippines) (RPUR / BQA)"
+  },
+  {
+    "id": "RPUZ",
+    "british": false,
+    "label": "Bagabag Airport (Philippines) (RPUZ)"
+  },
+  {
+    "id": "TAC",
+    "british": false,
+    "label": "Daniel Z. Romualdez Airport (Philippines) (RPVA / TAC)"
+  },
+  {
+    "id": "BCD",
+    "british": false,
+    "label": "Bacolod-Silay Airport (Philippines) (RPVB / BCD)"
+  },
+  {
+    "id": "DGT",
+    "british": false,
+    "label": "Sibulan Airport (Philippines) (RPVD / DGT)"
+  },
+  {
+    "id": "MPH",
+    "british": false,
+    "label": "Godofredo P. Ramos Airport (Philippines) (RPVE / MPH)"
+  },
+  {
+    "id": "RPVG",
+    "british": false,
+    "label": "Guiuan Airport (Philippines) (RPVG)"
+  },
+  {
+    "id": "ILO",
+    "british": false,
+    "label": "Iloilo International Airport (Philippines) (RPVI / ILO)"
+  },
+  {
+    "id": "KLO",
+    "british": false,
+    "label": "Kalibo International Airport (Philippines) (RPVK / KLO)"
+  },
+  {
+    "id": "PPS",
+    "british": false,
+    "label": "Puerto Princesa Airport (Philippines) (RPVP / PPS)"
+  },
+  {
+    "id": "EUQ",
+    "british": false,
+    "label": "Evelio Javier Airport (Philippines) (RPVS / EUQ)"
+  },
+  {
+    "id": "COC",
+    "british": false,
+    "label": "Comodoro Pierrestegui Airport (Argentina) (SAAC / COC)"
+  },
+  {
+    "id": "GHU",
+    "british": false,
+    "label": "Gualeguaychu Airport (Argentina) (SAAG / GHU)"
+  },
+  {
+    "id": "JNI",
+    "british": false,
+    "label": "Junin Airport (Argentina) (SAAJ / JNI)"
+  },
+  {
+    "id": "PRA",
+    "british": false,
+    "label": "General Urquiza Airport (Argentina) (SAAP / PRA)"
+  },
+  {
+    "id": "ROS",
+    "british": false,
+    "label": "Islas Malvinas Airport (Argentina) (SAAR / ROS)"
+  },
+  {
+    "id": "SFN",
+    "british": false,
+    "label": "Sauce Viejo Airport (Argentina) (SAAV / SFN)"
+  },
+  {
+    "id": "AEP",
+    "british": false,
+    "label": "Jorge Newbery Airpark (Argentina) (SABE / AEP)"
+  },
+  {
+    "id": "COR",
+    "british": false,
+    "label": "Ingeniero Ambrosio Taravella Airport (Argentina) (SACO / COR)"
+  },
+  {
+    "id": "SACT",
+    "british": false,
+    "label": "Chamical Airport (Argentina) (SACT)"
+  },
+  {
+    "id": "FDO",
+    "british": false,
+    "label": "San Fernando Airport (Argentina) (SADF / FDO)"
+  },
+  {
+    "id": "SADJ",
+    "british": false,
+    "label": "Mariano Moreno Airport (Argentina) (SADJ)"
+  },
+  {
+    "id": "LPG",
+    "british": false,
+    "label": "La Plata Airport (Argentina) (SADL / LPG)"
+  },
+  {
+    "id": "SADM",
+    "british": false,
+    "label": "Moron Airport (Argentina) (SADM)"
+  },
+  {
+    "id": "EPA",
+    "british": false,
+    "label": "El Palomar Airport (Argentina) (SADP / EPA)"
+  },
+  {
+    "id": "HOS",
+    "british": false,
+    "label": "Chos Malal Airport (Argentina) (SAHC / HOS)"
+  },
+  {
+    "id": "GNR",
+    "british": false,
+    "label": "Dr. Arturo H. Illia Airport (Argentina) (SAHR / GNR)"
+  },
+  {
+    "id": "MDZ",
+    "british": false,
+    "label": "El Plumerillo Airport (Argentina) (SAME / MDZ)"
+  },
+  {
+    "id": "LGS",
+    "british": false,
+    "label": "Comodoro D.R. Salomón Airport (Argentina) (SAMM / LGS)"
+  },
+  {
+    "id": "AFA",
+    "british": false,
+    "label": "Suboficial Ay Santiago Germano Airport (Argentina) (SAMR / AFA)"
+  },
+  {
+    "id": "CTC",
+    "british": false,
+    "label": "Catamarca Airport (Argentina) (SANC / CTC)"
+  },
+  {
+    "id": "SDE",
+    "british": false,
+    "label": "Vicecomodoro Angel D. La Paz Aragonés Airport (Argentina) (SANE / SDE)"
+  },
+  {
+    "id": "SANI",
+    "british": false,
+    "label": "Tinogasta Airport (Argentina) (SANI)"
+  },
+  {
+    "id": "IRJ",
+    "british": false,
+    "label": "Capitan V A Almonacid Airport (Argentina) (SANL / IRJ)"
+  },
+  {
+    "id": "SANO",
+    "british": false,
+    "label": "Chilecito Airport (Argentina) (SANO)"
+  },
+  {
+    "id": "TUC",
+    "british": false,
+    "label": "Teniente Benjamin Matienzo Airport (Argentina) (SANT / TUC)"
+  },
+  {
+    "id": "UAQ",
+    "british": false,
+    "label": "Domingo Faustino Sarmiento Airport (Argentina) (SANU / UAQ)"
+  },
+  {
+    "id": "RCU",
+    "british": false,
+    "label": "Area De Material Airport (Argentina) (SAOC / RCU)"
+  },
+  {
+    "id": "VDR",
+    "british": false,
+    "label": "Villa Dolores Airport (Argentina) (SAOD / VDR)"
+  },
+  {
+    "id": "SAOL",
+    "british": false,
+    "label": "La Quiaca Airport (Argentina) (SAOL)"
+  },
+  {
+    "id": "SAOM",
+    "british": false,
+    "label": "Marcos Juarez Airport (Argentina) (SAOM)"
+  },
+  {
+    "id": "VME",
+    "british": false,
+    "label": "Villa Reynolds Airport (Argentina) (SAOR / VME)"
+  },
+  {
+    "id": "LUQ",
+    "british": false,
+    "label": "Brigadier Mayor D Cesar Raul Ojeda Airport (Argentina) (SAOU / LUQ)"
+  },
+  {
+    "id": "CNQ",
+    "british": false,
+    "label": "Corrientes Airport (Argentina) (SARC / CNQ)"
+  },
+  {
+    "id": "RES",
+    "british": false,
+    "label": "Resistencia International Airport (Argentina) (SARE / RES)"
+  },
+  {
+    "id": "FMA",
+    "british": false,
+    "label": "Formosa Airport (Argentina) (SARF / FMA)"
+  },
+  {
+    "id": "IGR",
+    "british": false,
+    "label": "Cataratas Del Iguazú International Airport (Argentina) (SARI / IGR)"
+  },
+  {
+    "id": "AOL",
+    "british": false,
+    "label": "Paso De Los Libres Airport (Argentina) (SARL / AOL)"
+  },
+  {
+    "id": "MCS",
+    "british": false,
+    "label": "Monte Caseros Airport (Argentina) (SARM / MCS)"
+  },
+  {
+    "id": "PSS",
+    "british": false,
+    "label": "Libertador Gral D Jose De San Martin Airport (Argentina) (SARP / PSS)"
+  },
+  {
+    "id": "PRQ",
+    "british": false,
+    "label": "Termal Airport (Argentina) (SARS / PRQ)"
+  },
+  {
+    "id": "SLA",
+    "british": false,
+    "label": "Martin Miguel De Guemes International Airport (Argentina) (SASA / SLA)"
+  },
+  {
+    "id": "JUJ",
+    "british": false,
+    "label": "Gobernador Horacio Guzman International Airport (Argentina) (SASJ / JUJ)"
+  },
+  {
+    "id": "ORA",
+    "british": false,
+    "label": "Orán Airport (Argentina) (SASO / ORA)"
+  },
+  {
+    "id": "SASQ",
+    "british": false,
+    "label": "Laboulaye Airport (Argentina) (SASQ)"
+  },
+  {
+    "id": "ELO",
+    "british": false,
+    "label": "El Dorado Airport (Argentina) (SATD / ELO)"
+  },
+  {
+    "id": "OYA",
+    "british": false,
+    "label": "Goya Airport (Argentina) (SATG / OYA)"
+  },
+  {
+    "id": "SATO",
+    "british": false,
+    "label": "Oberá Airport (Argentina) (SATO)"
+  },
+  {
+    "id": "RCQ",
+    "british": false,
+    "label": "Reconquista Airport (Argentina) (SATR / RCQ)"
+  },
+  {
+    "id": "UZU",
+    "british": false,
+    "label": "Curuzu Cuatia Airport (Argentina) (SATU / UZU)"
+  },
+  {
+    "id": "EHL",
+    "british": false,
+    "label": "El Bolson Airport (Argentina) (SAVB / EHL)"
+  },
+  {
+    "id": "CRD",
+    "british": false,
+    "label": "General E. Mosconi Airport (Argentina) (SAVC / CRD)"
+  },
+  {
+    "id": "EQS",
+    "british": false,
+    "label": "Brigadier Antonio Parodi Airport (Argentina) (SAVE / EQS)"
+  },
+  {
+    "id": "REL",
+    "british": false,
+    "label": "Almirante Marco Andres Zar Airport (Argentina) (SAVT / REL)"
+  },
+  {
+    "id": "VDM",
+    "british": false,
+    "label": "Gobernador Castello Airport (Argentina) (SAVV / VDM)"
+  },
+  {
+    "id": "PMY",
+    "british": false,
+    "label": "El Tehuelche Airport (Argentina) (SAVY / PMY)"
+  },
+  {
+    "id": "SAWB",
+    "british": false,
+    "label": "Marambio Base (Antarctica) (SAWB)"
+  },
+  {
+    "id": "PUD",
+    "british": false,
+    "label": "Puerto Deseado Airport (Argentina) (SAWD / PUD)"
+  },
+  {
+    "id": "RGA",
+    "british": false,
+    "label": "Hermes Quijada International Airport (Argentina) (SAWE / RGA)"
+  },
+  {
+    "id": "RGL",
+    "british": false,
+    "label": "Piloto Civil N. Fernández Airport (Argentina) (SAWG / RGL)"
+  },
+  {
+    "id": "USH",
+    "british": false,
+    "label": "Malvinas Argentinas Airport (Argentina) (SAWH / USH)"
+  },
+  {
+    "id": "ULA",
+    "british": false,
+    "label": "Capitan D Daniel Vazquez Airport (Argentina) (SAWJ / ULA)"
+  },
+  {
+    "id": "PMQ",
+    "british": false,
+    "label": "Perito Moreno Airport (Argentina) (SAWP / PMQ)"
+  },
+  {
+    "id": "RZA",
+    "british": false,
+    "label": "Santa Cruz Airport (Argentina) (SAWU / RZA)"
+  },
+  {
+    "id": "BHI",
+    "british": false,
+    "label": "Comandante Espora Airport (Argentina) (SAZB / BHI)"
+  },
+  {
+    "id": "CSZ",
+    "british": false,
+    "label": "Brigadier D.H.E. Ruiz Airport (Argentina) (SAZC / CSZ)"
+  },
+  {
+    "id": "OVR",
+    "british": false,
+    "label": "Olavarria Airport (Argentina) (SAZF / OVR)"
+  },
+  {
+    "id": "GPO",
+    "british": false,
+    "label": "General Pico Airport (Argentina) (SAZG / GPO)"
+  },
+  {
+    "id": "OYO",
+    "british": false,
+    "label": "Tres Arroyos Airport (Argentina) (SAZH / OYO)"
+  },
+  {
+    "id": "SAZI",
+    "british": false,
+    "label": "Bolivar Airport (Argentina) (SAZI)"
+  },
+  {
+    "id": "MDQ",
+    "british": false,
+    "label": "Ástor Piazzola International Airport (Argentina) (SAZM / MDQ)"
+  },
+  {
+    "id": "NQN",
+    "british": false,
+    "label": "Presidente Peron Airport (Argentina) (SAZN / NQN)"
+  },
+  {
+    "id": "PEH",
+    "british": false,
+    "label": "Comodoro Pedro Zanni Airport (Argentina) (SAZP / PEH)"
+  },
+  {
+    "id": "RSA",
+    "british": false,
+    "label": "Santa Rosa Airport (Argentina) (SAZR / RSA)"
+  },
+  {
+    "id": "BRC",
+    "british": false,
+    "label": "San Carlos De Bariloche Airport (Argentina) (SAZS / BRC)"
+  },
+  {
+    "id": "TDL",
+    "british": false,
+    "label": "Héroes De Malvinas Airport (Argentina) (SAZT / TDL)"
+  },
+  {
+    "id": "VLG",
+    "british": false,
+    "label": "Villa Gesell Airport (Argentina) (SAZV / VLG)"
+  },
+  {
+    "id": "CUT",
+    "british": false,
+    "label": "Cutral-Co Airport (Argentina) (SAZW / CUT)"
+  },
+  {
+    "id": "CPC",
+    "british": false,
+    "label": "Aviador C. Campos Airport (Argentina) (SAZY / CPC)"
+  },
+  {
+    "id": "CDJ",
+    "british": false,
+    "label": "Conceição do Araguaia Airport (Brazil) (SBAA / CDJ)"
+  },
+  {
+    "id": "SBAF",
+    "british": false,
+    "label": "Campo Délio Jardim de Mattos Airport (Brazil) (SBAF)"
+  },
+  {
+    "id": "SBAM",
+    "british": false,
+    "label": "Amapá Airport (Brazil) (SBAM)"
+  },
+  {
+    "id": "AQA",
+    "british": false,
+    "label": "Araraquara Airport (Brazil) (SBAQ / AQA)"
+  },
+  {
+    "id": "AJU",
+    "british": false,
+    "label": "Santa Maria Airport (Brazil) (SBAR / AJU)"
+  },
+  {
+    "id": "AFL",
+    "british": false,
+    "label": "Piloto Osvaldo Marques Dias Airport (Brazil) (SBAT / AFL)"
+  },
+  {
+    "id": "ARU",
+    "british": false,
+    "label": "Araçatuba Airport (Brazil) (SBAU / ARU)"
+  },
+  {
+    "id": "BEL",
+    "british": false,
+    "label": "Val de Cans/Júlio Cezar Ribeiro International Airport (Brazil) (SBBE / BEL)"
+  },
+  {
+    "id": "BGX",
+    "british": false,
+    "label": "Comandante Gustavo Kraemer Airport (Brazil) (SBBG / BGX)"
+  },
+  {
+    "id": "PLU",
+    "british": false,
+    "label": "Pampulha - Carlos Drummond de Andrade Airport (Brazil) (SBBH / PLU)"
+  },
+  {
+    "id": "BFH",
+    "british": false,
+    "label": "Bacacheri Airport (Brazil) (SBBI / BFH)"
+  },
+  {
+    "id": "SBBQ",
+    "british": false,
+    "label": "Major Brigadeiro Doorgal Borges Airport (Brazil) (SBBQ)"
+  },
+  {
+    "id": "BSB",
+    "british": false,
+    "label": "Presidente Juscelino Kubistschek International Airport (Brazil) (SBBR / BSB)"
+  },
+  {
+    "id": "BAU",
+    "british": false,
+    "label": "Bauru Airport (Brazil) (SBBU / BAU)"
+  },
+  {
+    "id": "BVB",
+    "british": false,
+    "label": "Atlas Brasil Cantanhede Airport (Brazil) (SBBV / BVB)"
+  },
+  {
+    "id": "BPG",
+    "british": false,
+    "label": "Barra do Garças Airport (Brazil) (SBBW / BPG)"
+  },
+  {
+    "id": "CAC",
+    "british": false,
+    "label": "Cascavel Airport (Brazil) (SBCA / CAC)"
+  },
+  {
+    "id": "SBCC",
+    "british": false,
+    "label": "Cachimbo Airport (Brazil) (SBCC)"
+  },
+  {
+    "id": "CNF",
+    "british": false,
+    "label": "Tancredo Neves International Airport (Brazil) (SBCF / CNF)"
+  },
+  {
+    "id": "CGR",
+    "british": false,
+    "label": "Campo Grande Airport (Brazil) (SBCG / CGR)"
+  },
+  {
+    "id": "XAP",
+    "british": false,
+    "label": "Serafin Enoss Bertaso Airport (Brazil) (SBCH / XAP)"
+  },
+  {
+    "id": "CLN",
+    "british": false,
+    "label": "Brig. Lysias Augusto Rodrigues Airport (Brazil) (SBCI / CLN)"
+  },
+  {
+    "id": "CCM",
+    "british": false,
+    "label": "Diomício Freitas Airport (Brazil) (SBCM / CCM)"
+  },
+  {
+    "id": "SBCO",
+    "british": false,
+    "label": "Canoas Air Force Base (Brazil) (SBCO)"
+  },
+  {
+    "id": "CAW",
+    "british": false,
+    "label": "Bartolomeu Lisandro Airport (Brazil) (SBCP / CAW)"
+  },
+  {
+    "id": "CMG",
+    "british": false,
+    "label": "Corumbá International Airport (Brazil) (SBCR / CMG)"
+  },
+  {
+    "id": "CWB",
+    "british": false,
+    "label": "Afonso Pena Airport (Brazil) (SBCT / CWB)"
+  },
+  {
+    "id": "CRQ",
+    "british": false,
+    "label": "Caravelas Airport (Brazil) (SBCV / CRQ)"
+  },
+  {
+    "id": "CXJ",
+    "british": false,
+    "label": "Hugo Cantergiani Regional Airport (Brazil) (SBCX / CXJ)"
+  },
+  {
+    "id": "CGB",
+    "british": false,
+    "label": "Marechal Rondon Airport (Brazil) (SBCY / CGB)"
+  },
+  {
+    "id": "CZS",
+    "british": false,
+    "label": "Cruzeiro do Sul Airport (Brazil) (SBCZ / CZS)"
+  },
+  {
+    "id": "PPB",
+    "british": false,
+    "label": "Presidente Prudente Airport (Brazil) (SBDN / PPB)"
+  },
+  {
+    "id": "MAO",
+    "british": false,
+    "label": "Eduardo Gomes International Airport (Brazil) (SBEG / MAO)"
+  },
+  {
+    "id": "JCR",
+    "british": false,
+    "label": "Jacareacanga Airport (Brazil) (SBEK / JCR)"
+  },
+  {
+    "id": "SBES",
+    "british": false,
+    "label": "São Pedro da Aldeia Airport (Brazil) (SBES)"
+  },
+  {
+    "id": "IGU",
+    "british": false,
+    "label": "Cataratas International Airport (Brazil) (SBFI / IGU)"
+  },
+  {
+    "id": "FLN",
+    "british": false,
+    "label": "Hercílio Luz International Airport (Brazil) (SBFL / FLN)"
+  },
+  {
+    "id": "FEN",
+    "british": false,
+    "label": "Fernando de Noronha Airport (Brazil) (SBFN / FEN)"
+  },
+  {
+    "id": "SBFU",
+    "british": false,
+    "label": "Furnas Airport (Brazil) (SBFU)"
+  },
+  {
+    "id": "FOR",
+    "british": false,
+    "label": "Pinto Martins International Airport (Brazil) (SBFZ / FOR)"
+  },
+  {
+    "id": "GIG",
+    "british": false,
+    "label": "Rio Galeão – Tom Jobim International Airport (Brazil) (SBGL / GIG)"
+  },
+  {
+    "id": "GJM",
+    "british": false,
+    "label": "Guajará-Mirim Airport (Brazil) (SBGM / GJM)"
+  },
+  {
+    "id": "GYN",
+    "british": false,
+    "label": "Santa Genoveva Airport (Brazil) (SBGO / GYN)"
+  },
+  {
+    "id": "SBGP",
+    "british": false,
+    "label": "EMBRAER - Unidade Gavião Peixoto Airport (Brazil) (SBGP)"
+  },
+  {
+    "id": "GRU",
+    "british": false,
+    "label": "Guarulhos - Governador André Franco Montoro International Airport (Brazil) (SBGR / GRU)"
+  },
+  {
+    "id": "GUJ",
+    "british": false,
+    "label": "Guaratinguetá Airport (Brazil) (SBGW / GUJ)"
+  },
+  {
+    "id": "ATM",
+    "british": false,
+    "label": "Altamira Airport (Brazil) (SBHT / ATM)"
+  },
+  {
+    "id": "ITA",
+    "british": false,
+    "label": "Itacoatiara Airport (Brazil) (SBIC / ITA)"
+  },
+  {
+    "id": "ITB",
+    "british": false,
+    "label": "Itaituba Airport (Brazil) (SBIH / ITB)"
+  },
+  {
+    "id": "IOS",
+    "british": false,
+    "label": "Bahia - Jorge Amado Airport (Brazil) (SBIL / IOS)"
+  },
+  {
+    "id": "IPN",
+    "british": false,
+    "label": "Usiminas Airport (Brazil) (SBIP / IPN)"
+  },
+  {
+    "id": "ITR",
+    "british": false,
+    "label": "Francisco Vilela do Amaral Airport (Brazil) (SBIT / ITR)"
+  },
+  {
+    "id": "IMP",
+    "british": false,
+    "label": "Prefeito Renato Moreira Airport (Brazil) (SBIZ / IMP)"
+  },
+  {
+    "id": "SBJC",
+    "british": false,
+    "label": "Belém/Brigadeiro Protásio de Oliveira Airport (Brazil) (SBJC)"
+  },
+  {
+    "id": "JDF",
+    "british": false,
+    "label": "Francisco de Assis Airport (Brazil) (SBJF / JDF)"
+  },
+  {
+    "id": "JPA",
+    "british": false,
+    "label": "Presidente Castro Pinto International Airport (Brazil) (SBJP / JPA)"
+  },
+  {
+    "id": "JOI",
+    "british": false,
+    "label": "Lauro Carneiro de Loyola Airport (Brazil) (SBJV / JOI)"
+  },
+  {
+    "id": "CPV",
+    "british": false,
+    "label": "Presidente João Suassuna Airport (Brazil) (SBKG / CPV)"
+  },
+  {
+    "id": "VCP",
+    "british": false,
+    "label": "Viracopos International Airport (Brazil) (SBKP / VCP)"
+  },
+  {
+    "id": "LAJ",
+    "british": false,
+    "label": "Lages Airport (Brazil) (SBLJ / LAJ)"
+  },
+  {
+    "id": "LIP",
+    "british": false,
+    "label": "Lins Airport (Brazil) (SBLN / LIP)"
+  },
+  {
+    "id": "LDB",
+    "british": false,
+    "label": "Governador José Richa Airport (Brazil) (SBLO / LDB)"
+  },
+  {
+    "id": "LAZ",
+    "british": false,
+    "label": "Bom Jesus da Lapa Airport (Brazil) (SBLP / LAZ)"
+  },
+  {
+    "id": "SBLS",
+    "british": false,
+    "label": "Lagoa Santa Airport (Brazil) (SBLS)"
+  },
+  {
+    "id": "MAB",
+    "british": false,
+    "label": "João Correa da Rocha Airport (Brazil) (SBMA / MAB)"
+  },
+  {
+    "id": "MEU",
+    "british": false,
+    "label": "Monte Dourado Airport (Brazil) (SBMD / MEU)"
+  },
+  {
+    "id": "MGF",
+    "british": false,
+    "label": "Regional de Maringá - Sílvio Nane Junior Airport (Brazil) (SBMG / MGF)"
+  },
+  {
+    "id": "MOC",
+    "british": false,
+    "label": "Mário Ribeiro Airport (Brazil) (SBMK / MOC)"
+  },
+  {
+    "id": "PLL",
+    "british": false,
+    "label": "Ponta Pelada Airport (Brazil) (SBMN / PLL)"
+  },
+  {
+    "id": "MCZ",
+    "british": false,
+    "label": "Zumbi dos Palmares Airport (Brazil) (SBMO / MCZ)"
+  },
+  {
+    "id": "MCP",
+    "british": false,
+    "label": "Alberto Alcolumbre Airport (Brazil) (SBMQ / MCP)"
+  },
+  {
+    "id": "MVF",
+    "british": false,
+    "label": "Dix-Sept Rosado Airport (Brazil) (SBMS / MVF)"
+  },
+  {
+    "id": "SBMT",
+    "british": false,
+    "label": "Campo de Marte Airport (Brazil) (SBMT)"
+  },
+  {
+    "id": "MNX",
+    "british": false,
+    "label": "Manicoré Airport (Brazil) (SBMY / MNX)"
+  },
+  {
+    "id": "NVT",
+    "british": false,
+    "label": "Ministro Victor Konder International Airport (Brazil) (SBNF / NVT)"
+  },
+  {
+    "id": "GEL",
+    "british": false,
+    "label": "Santo Ângelo Airport (Brazil) (SBNM / GEL)"
+  },
+  {
+    "id": "NAT",
+    "british": false,
+    "label": "Governador Aluízio Alves International Airport (Brazil) (SBSG / NAT)"
+  },
+  {
+    "id": "OYK",
+    "british": false,
+    "label": "Oiapoque Airport (Brazil) (SBOI / OYK)"
+  },
+  {
+    "id": "POA",
+    "british": false,
+    "label": "Salgado Filho Airport (Brazil) (SBPA / POA)"
+  },
+  {
+    "id": "PHB",
+    "british": false,
+    "label": "Prefeito Doutor João Silva Filho Airport (Brazil) (SBPB / PHB)"
+  },
+  {
+    "id": "POO",
+    "british": false,
+    "label": "Poços de Caldas - Embaixador Walther Moreira Salles Airport (Brazil) (SBPC / POO)"
+  },
+  {
+    "id": "PFB",
+    "british": false,
+    "label": "Lauro Kurtz Airport (Brazil) (SBPF / PFB)"
+  },
+  {
+    "id": "PET",
+    "british": false,
+    "label": "João Simões Lopes Neto International Airport (Brazil) (SBPK / PET)"
+  },
+  {
+    "id": "PNZ",
+    "british": false,
+    "label": "Senador Nilo Coelho Airport (Brazil) (SBPL / PNZ)"
+  },
+  {
+    "id": "PNB",
+    "british": false,
+    "label": "Porto Nacional Airport (Brazil) (SBPN / PNB)"
+  },
+  {
+    "id": "PMG",
+    "british": false,
+    "label": "Ponta Porã Airport (Brazil) (SBPP / PMG)"
+  },
+  {
+    "id": "PVH",
+    "british": false,
+    "label": "Governador Jorge Teixeira de Oliveira Airport (Brazil) (SBPV / PVH)"
+  },
+  {
+    "id": "RBR",
+    "british": false,
+    "label": "Plácido de Castro Airport (Brazil) (SBRB / RBR)"
+  },
+  {
+    "id": "REC",
+    "british": false,
+    "label": "Guararapes - Gilberto Freyre International Airport (Brazil) (SBRF / REC)"
+  },
+  {
+    "id": "SDU",
+    "british": false,
+    "label": "Santos Dumont Airport (Brazil) (SBRJ / SDU)"
+  },
+  {
+    "id": "RAO",
+    "british": false,
+    "label": "Leite Lopes Airport (Brazil) (SBRP / RAO)"
+  },
+  {
+    "id": "SNZ",
+    "british": false,
+    "label": "Santa Cruz Air Force Base (Brazil) (SBSC / SNZ)"
+  },
+  {
+    "id": "SJK",
+    "british": false,
+    "label": "Professor Urbano Ernesto Stumpf Airport (Brazil) (SBSJ / SJK)"
+  },
+  {
+    "id": "SLZ",
+    "british": false,
+    "label": "Marechal Cunha Machado International Airport (Brazil) (SBSL / SLZ)"
+  },
+  {
+    "id": "CGH",
+    "british": false,
+    "label": "Congonhas Airport (Brazil) (SBSP / CGH)"
+  },
+  {
+    "id": "SJP",
+    "british": false,
+    "label": "Prof. Eribelto Manoel Reino State Airport (Brazil) (SBSR / SJP)"
+  },
+  {
+    "id": "SSZ",
+    "british": false,
+    "label": "Base Aérea de Santos Airport (Brazil) (SBST / SSZ)"
+  },
+  {
+    "id": "SSA",
+    "british": false,
+    "label": "Deputado Luiz Eduardo Magalhães International Airport (Brazil) (SBSV / SSA)"
+  },
+  {
+    "id": "TMT",
+    "british": false,
+    "label": "Trombetas Airport (Brazil) (SBTB / TMT)"
+  },
+  {
+    "id": "THE",
+    "british": false,
+    "label": "Senador Petrônio Portela Airport (Brazil) (SBTE / THE)"
+  },
+  {
+    "id": "TFF",
+    "british": false,
+    "label": "Tefé Airport (Brazil) (SBTF / TFF)"
+  },
+  {
+    "id": "TRQ",
+    "british": false,
+    "label": "Tarauacá Airport (Brazil) (SBTK / TRQ)"
+  },
+  {
+    "id": "TEC",
+    "british": false,
+    "label": "Telêmaco Borba Airport (Brazil) (SBTL / TEC)"
+  },
+  {
+    "id": "SBTS",
+    "british": false,
+    "label": "Tiriós Airport (Brazil) (SBTS)"
+  },
+  {
+    "id": "TBT",
+    "british": false,
+    "label": "Tabatinga Airport (Brazil) (SBTT / TBT)"
+  },
+  {
+    "id": "TUR",
+    "british": false,
+    "label": "Tucuruí Airport (Brazil) (SBTU / TUR)"
+  },
+  {
+    "id": "SJL",
+    "british": false,
+    "label": "São Gabriel da Cachoeira Airport (Brazil) (SBUA / SJL)"
+  },
+  {
+    "id": "PAV",
+    "british": false,
+    "label": "Paulo Afonso Airport (Brazil) (SBUF / PAV)"
+  },
+  {
+    "id": "URG",
+    "british": false,
+    "label": "Rubem Berta Airport (Brazil) (SBUG / URG)"
+  },
+  {
+    "id": "UDI",
+    "british": false,
+    "label": "Ten. Cel. Aviador César Bombonato Airport (Brazil) (SBUL / UDI)"
+  },
+  {
+    "id": "UBA",
+    "british": false,
+    "label": "Mário de Almeida Franco Airport (Brazil) (SBUR / UBA)"
+  },
+  {
+    "id": "VAG",
+    "british": false,
+    "label": "Major Brigadeiro Trompowsky Airport (Brazil) (SBVG / VAG)"
+  },
+  {
+    "id": "BVH",
+    "british": false,
+    "label": "Brigadeiro Camarão Airport (Brazil) (SBVH / BVH)"
+  },
+  {
+    "id": "VIX",
+    "british": false,
+    "label": "Eurico de Aguiar Salles Airport (Brazil) (SBVT / VIX)"
+  },
+  {
+    "id": "SBYA",
+    "british": false,
+    "label": "Iauaretê Airport (Brazil) (SBYA)"
+  },
+  {
+    "id": "QPS",
+    "british": false,
+    "label": "Campo Fontenelle Airport (Brazil) (SBYS / QPS)"
+  },
+  {
+    "id": "ARI",
+    "british": false,
+    "label": "Chacalluta Airport (Chile) (SCAR / ARI)"
+  },
+  {
+    "id": "BBA",
+    "british": false,
+    "label": "Balmaceda Airport (Chile) (SCBA / BBA)"
+  },
+  {
+    "id": "SCBQ",
+    "british": false,
+    "label": "El Bosque Airport (Chile) (SCBQ)"
+  },
+  {
+    "id": "CCH",
+    "british": false,
+    "label": "Chile Chico Airport (Chile) (SCCC / CCH)"
+  },
+  {
+    "id": "CJC",
+    "british": false,
+    "label": "El Loa Airport (Chile) (SCCF / CJC)"
+  },
+  {
+    "id": "YAI",
+    "british": false,
+    "label": "Gral. Bernardo O´Higgins Airport (Chile) (SCCH / YAI)"
+  },
+  {
+    "id": "PUQ",
+    "british": false,
+    "label": "Pdte. Carlos Ibañez del Campo Airport (Chile) (SCCI / PUQ)"
+  },
+  {
+    "id": "GXQ",
+    "british": false,
+    "label": "Teniente Vidal Airport (Chile) (SCCY / GXQ)"
+  },
+  {
+    "id": "IQQ",
+    "british": false,
+    "label": "Diego Aracena Airport (Chile) (SCDA / IQQ)"
+  },
+  {
+    "id": "SCL",
+    "british": false,
+    "label": "Comodoro Arturo Merino Benítez International Airport (Chile) (SCEL / SCL)"
+  },
+  {
+    "id": "ANF",
+    "british": false,
+    "label": "Andrés Sabella Gálvez International Airport (Chile) (SCFA / ANF)"
+  },
+  {
+    "id": "WPR",
+    "british": false,
+    "label": "Capitan Fuentes Martinez Airport Airport (Chile) (SCFM / WPR)"
+  },
+  {
+    "id": "FFU",
+    "british": false,
+    "label": "Futaleufú Airport (Chile) (SCFT / FFU)"
+  },
+  {
+    "id": "LSQ",
+    "british": false,
+    "label": "María Dolores Airport (Chile) (SCGE / LSQ)"
+  },
+  {
+    "id": "WPU",
+    "british": false,
+    "label": "Guardiamarina Zañartu Airport (Chile) (SCGZ / WPU)"
+  },
+  {
+    "id": "CCP",
+    "british": false,
+    "label": "Carriel Sur Airport (Chile) (SCIE / CCP)"
+  },
+  {
+    "id": "IPC",
+    "british": false,
+    "label": "Mataveri Airport (Chile) (SCIP / IPC)"
+  },
+  {
+    "id": "ZOS",
+    "british": false,
+    "label": "Cañal Bajo Carlos - Hott Siebert Airport (Chile) (SCJO / ZOS)"
+  },
+  {
+    "id": "VLR",
+    "british": false,
+    "label": "Vallenar Airport (Chile) (SCLL / VLR)"
+  },
+  {
+    "id": "QRC",
+    "british": false,
+    "label": "De La Independencia Airport (Chile) (SCRG / QRC)"
+  },
+  {
+    "id": "TNM",
+    "british": false,
+    "label": "Teniente Rodolfo Marsh Martin Base (Antarctica) (SCRM / TNM)"
+  },
+  {
+    "id": "LSC",
+    "british": false,
+    "label": "La Florida Airport (Chile) (SCSE / LSC)"
+  },
+  {
+    "id": "SCTB",
+    "british": false,
+    "label": "Eulogio Sánchez Airport (Chile) (SCTB)"
+  },
+  {
+    "id": "PZS",
+    "british": false,
+    "label": "Maquehue Airport (Chile) (SCTC / PZS)"
+  },
+  {
+    "id": "PMC",
+    "british": false,
+    "label": "El Tepual Airport (Chile) (SCTE / PMC)"
+  },
+  {
+    "id": "WCH",
+    "british": false,
+    "label": "Chaitén Airport (Chile) (SCTN / WCH)"
+  },
+  {
+    "id": "ZAL",
+    "british": false,
+    "label": "Pichoy Airport (Chile) (SCVD / ZAL)"
+  },
+  {
+    "id": "ATF",
+    "british": false,
+    "label": "Chachoán Airport (Ecuador) (SEAM / ATF)"
+  },
+  {
+    "id": "SECM",
+    "british": false,
+    "label": "Hacienda Clementina Airport (Ecuador) (SECM)"
+  },
+  {
+    "id": "OCC",
+    "british": false,
+    "label": "Francisco De Orellana Airport (Ecuador) (SECO / OCC)"
+  },
+  {
+    "id": "CUE",
+    "british": false,
+    "label": "Mariscal Lamar Airport (Ecuador) (SECU / CUE)"
+  },
+  {
+    "id": "GPS",
+    "british": false,
+    "label": "Seymour Airport (Ecuador) (SEGS / GPS)"
+  },
+  {
+    "id": "GYE",
+    "british": false,
+    "label": "José Joaquín de Olmedo International Airport (Ecuador) (SEGU / GYE)"
+  },
+  {
+    "id": "SEGZ",
+    "british": false,
+    "label": "Gualaquiza Airport (Ecuador) (SEGZ)"
+  },
+  {
+    "id": "SEIB",
+    "british": false,
+    "label": "Atahualpa Airport (Ecuador) (SEIB)"
+  },
+  {
+    "id": "SEKK",
+    "british": false,
+    "label": "Km 192 Airport (Ecuador) (SEKK)"
+  },
+  {
+    "id": "SELJ",
+    "british": false,
+    "label": "Hacienda La Julia Airport (Ecuador) (SELJ)"
+  },
+  {
+    "id": "LTX",
+    "british": false,
+    "label": "Cotopaxi International Airport (Ecuador) (SELT / LTX)"
+  },
+  {
+    "id": "MRR",
+    "british": false,
+    "label": "Jose Maria Velasco Ibarra Airport (Ecuador) (SEMA / MRR)"
+  },
+  {
+    "id": "XMS",
+    "british": false,
+    "label": "Coronel E Carvajal Airport (Ecuador) (SEMC / XMS)"
+  },
+  {
+    "id": "MCH",
+    "british": false,
+    "label": "General Manuel Serrano Airport (Ecuador) (SEMH / MCH)"
+  },
+  {
+    "id": "SEMO",
+    "british": false,
+    "label": "El Carmen Airport (Ecuador) (SEMO)"
+  },
+  {
+    "id": "MEC",
+    "british": false,
+    "label": "Eloy Alfaro International Airport (Ecuador) (SEMT / MEC)"
+  },
+  {
+    "id": "SEMX",
+    "british": false,
+    "label": "Maragrosa Airport (Ecuador) (SEMX)"
+  },
+  {
+    "id": "SEPS",
+    "british": false,
+    "label": "Amable Calle Gutierrez Airport (Ecuador) (SEPS)"
+  },
+  {
+    "id": "PVO",
+    "british": false,
+    "label": "Reales Tamarindos Airport (Ecuador) (SEPV / PVO)"
+  },
+  {
+    "id": "SEQE",
+    "british": false,
+    "label": "Quevedo Airport (Ecuador) (SEQE)"
+  },
+  {
+    "id": "UIO",
+    "british": false,
+    "label": "Mariscal Sucre International Airport (Ecuador) (SEQM / UIO)"
+  },
+  {
+    "id": "SERB",
+    "british": false,
+    "label": "Chimborazo Airport (Ecuador) (SERB)"
+  },
+  {
+    "id": "ETR",
+    "british": false,
+    "label": "Santa Rosa International Airport (Ecuador) (SERO / ETR)"
+  },
+  {
+    "id": "SNC",
+    "british": false,
+    "label": "General Ulpiano Paez Airport (Ecuador) (SESA / SNC)"
+  },
+  {
+    "id": "SESD",
+    "british": false,
+    "label": "Santo Domingo de Los Colorados Airport (Ecuador) (SESD)"
+  },
+  {
+    "id": "SETA",
+    "british": false,
+    "label": "Taura Airport (Ecuador) (SETA)"
+  },
+  {
+    "id": "SETE",
+    "british": false,
+    "label": "Mayor Galo Torres Airport (Ecuador) (SETE)"
+  },
+  {
+    "id": "TPC",
+    "british": false,
+    "label": "Tarapoa Airport (Ecuador) (SETR / TPC)"
+  },
+  {
+    "id": "TUA",
+    "british": false,
+    "label": "Teniente Coronel Luis a Mantilla Airport (Ecuador) (SETU / TUA)"
+  },
+  {
+    "id": "ASU",
+    "british": false,
+    "label": "Silvio Pettirossi International Airport (Paraguay) (SGAS / ASU)"
+  },
+  {
+    "id": "AYO",
+    "british": false,
+    "label": "Juan De Ayolas Airport (Paraguay) (SGAY / AYO)"
+  },
+  {
+    "id": "CIO",
+    "british": false,
+    "label": "Teniente Col Carmelo Peralta Airport (Paraguay) (SGCO / CIO)"
+  },
+  {
+    "id": "SGIB",
+    "british": false,
+    "label": "Itaipú Airport (Paraguay) (SGIB)"
+  },
+  {
+    "id": "ESG",
+    "british": false,
+    "label": "Dr. Luis Maria Argaña International Airport (Paraguay) (SGME / ESG)"
+  },
+  {
+    "id": "PIL",
+    "british": false,
+    "label": "Carlos Miguel Gimenez Airport (Paraguay) (SGPI / PIL)"
+  },
+  {
+    "id": "AXM",
+    "british": false,
+    "label": "El Eden Airport (Colombia) (SKAR / AXM)"
+  },
+  {
+    "id": "PUU",
+    "british": false,
+    "label": "Tres De Mayo Airport (Colombia) (SKAS / PUU)"
+  },
+  {
+    "id": "ELB",
+    "british": false,
+    "label": "Las Flores Airport (Colombia) (SKBC / ELB)"
+  },
+  {
+    "id": "BGA",
+    "british": false,
+    "label": "Palonegro Airport (Colombia) (SKBG / BGA)"
+  },
+  {
+    "id": "BOG",
+    "british": false,
+    "label": "El Dorado International Airport (Colombia) (SKBO / BOG)"
+  },
+  {
+    "id": "BAQ",
+    "british": false,
+    "label": "Ernesto Cortissoz International Airport (Colombia) (SKBQ / BAQ)"
+  },
+  {
+    "id": "BSC",
+    "british": false,
+    "label": "José Celestino Mutis Airport (Colombia) (SKBS / BSC)"
+  },
+  {
+    "id": "BUN",
+    "british": false,
+    "label": "Gerardo Tobar López Airport (Colombia) (SKBU / BUN)"
+  },
+  {
+    "id": "CUC",
+    "british": false,
+    "label": "Camilo Daza International Airport (Colombia) (SKCC / CUC)"
+  },
+  {
+    "id": "CTG",
+    "british": false,
+    "label": "Rafael Nuñez International Airport (Colombia) (SKCG / CTG)"
+  },
+  {
+    "id": "CLO",
+    "british": false,
+    "label": "Alfonso Bonilla Aragon International Airport (Colombia) (SKCL / CLO)"
+  },
+  {
+    "id": "TCO",
+    "british": false,
+    "label": "La Florida Airport (Colombia) (SKCO / TCO)"
+  },
+  {
+    "id": "CZU",
+    "british": false,
+    "label": "Las Brujas Airport (Colombia) (SKCZ / CZU)"
+  },
+  {
+    "id": "EJA",
+    "british": false,
+    "label": "Yariguíes Airport (Colombia) (SKEJ / EJA)"
+  },
+  {
+    "id": "FLA",
+    "british": false,
+    "label": "Gustavo Artunduaga Paredes Airport (Colombia) (SKFL / FLA)"
+  },
+  {
+    "id": "GIR",
+    "british": false,
+    "label": "Santiago Vila Airport (Colombia) (SKGI / GIR)"
+  },
+  {
+    "id": "GPI",
+    "british": false,
+    "label": "Juan Casiano Airport (Colombia) (SKGP / GPI)"
+  },
+  {
+    "id": "SKGY",
+    "british": false,
+    "label": "Guaymaral Airport (Colombia) (SKGY)"
+  },
+  {
+    "id": "IBE",
+    "british": false,
+    "label": "Perales Airport (Colombia) (SKIB / IBE)"
+  },
+  {
+    "id": "IPI",
+    "british": false,
+    "label": "San Luis Airport (Colombia) (SKIP / IPI)"
+  },
+  {
+    "id": "APO",
+    "british": false,
+    "label": "Antonio Roldan Betancourt Airport (Colombia) (SKLC / APO)"
+  },
+  {
+    "id": "MCJ",
+    "british": false,
+    "label": "Jorge Isaac Airport (Colombia) (SKLM / MCJ)"
+  },
+  {
+    "id": "LET",
+    "british": false,
+    "label": "Alfredo Vásquez Cobo International Airport (Colombia) (SKLT / LET)"
+  },
+  {
+    "id": "EOH",
+    "british": false,
+    "label": "Enrique Olaya Herrera Airport (Colombia) (SKMD / EOH)"
+  },
+  {
+    "id": "MGN",
+    "british": false,
+    "label": "Baracoa Airport (Colombia) (SKMG / MGN)"
+  },
+  {
+    "id": "MTR",
+    "british": false,
+    "label": "Los Garzones Airport (Colombia) (SKMR / MTR)"
+  },
+  {
+    "id": "MVP",
+    "british": false,
+    "label": "Fabio Alberto Leon Bentley Airport (Colombia) (SKMU / MVP)"
+  },
+  {
+    "id": "MZL",
+    "british": false,
+    "label": "La Nubia Airport (Colombia) (SKMZ / MZL)"
+  },
+  {
+    "id": "NVA",
+    "british": false,
+    "label": "Benito Salas Airport (Colombia) (SKNV / NVA)"
+  },
+  {
+    "id": "OCV",
+    "british": false,
+    "label": "Aguas Claras Airport (Colombia) (SKOC / OCV)"
+  },
+  {
+    "id": "OTU",
+    "british": false,
+    "label": "Otu Airport (Colombia) (SKOT / OTU)"
+  },
+  {
+    "id": "SKPB",
+    "british": false,
+    "label": "Puerto Bolívar Airport (Colombia) (SKPB)"
+  },
+  {
+    "id": "PCR",
+    "british": false,
+    "label": "German Olano Airport (Colombia) (SKPC / PCR)"
+  },
+  {
+    "id": "PEI",
+    "british": false,
+    "label": "Matecaña International Airport (Colombia) (SKPE / PEI)"
+  },
+  {
+    "id": "PTX",
+    "british": false,
+    "label": "Pitalito Airport (Colombia) (SKPI / PTX)"
+  },
+  {
+    "id": "PPN",
+    "british": false,
+    "label": "Guillermo León Valencia Airport (Colombia) (SKPP / PPN)"
+  },
+  {
+    "id": "PSO",
+    "british": false,
+    "label": "Antonio Narino Airport (Colombia) (SKPS / PSO)"
+  },
+  {
+    "id": "PVA",
+    "british": false,
+    "label": "El Embrujo Airport (Colombia) (SKPV / PVA)"
+  },
+  {
+    "id": "MQU",
+    "british": false,
+    "label": "Mariquita Airport (Colombia) (SKQU / MQU)"
+  },
+  {
+    "id": "MDE",
+    "british": false,
+    "label": "Jose Maria Córdova International Airport (Colombia) (SKRG / MDE)"
+  },
+  {
+    "id": "RCH",
+    "british": false,
+    "label": "Almirante Padilla Airport (Colombia) (SKRH / RCH)"
+  },
+  {
+    "id": "SJE",
+    "british": false,
+    "label": "Jorge E. Gonzalez Torres Airport (Colombia) (SKSJ / SJE)"
+  },
+  {
+    "id": "SMR",
+    "british": false,
+    "label": "Simón Bolívar International Airport (Colombia) (SKSM / SMR)"
+  },
+  {
+    "id": "ADZ",
+    "british": false,
+    "label": "Gustavo Rojas Pinilla International Airport (Colombia) (SKSP / ADZ)"
+  },
+  {
+    "id": "SVI",
+    "british": false,
+    "label": "Eduardo Falla Solano Airport (Colombia) (SKSV / SVI)"
+  },
+  {
+    "id": "TME",
+    "british": false,
+    "label": "Gustavo Vargas Airport (Colombia) (SKTM / TME)"
+  },
+  {
+    "id": "AUC",
+    "british": false,
+    "label": "Santiago Perez Airport (Colombia) (SKUC / AUC)"
+  },
+  {
+    "id": "UIB",
+    "british": false,
+    "label": "El Caraño Airport (Colombia) (SKUI / UIB)"
+  },
+  {
+    "id": "ULQ",
+    "british": false,
+    "label": "Heriberto Gíl Martínez Airport (Colombia) (SKUL / ULQ)"
+  },
+  {
+    "id": "VUP",
+    "british": false,
+    "label": "Alfonso López Pumarejo Airport (Colombia) (SKVP / VUP)"
+  },
+  {
+    "id": "VVC",
+    "british": false,
+    "label": "Vanguardia Airport (Colombia) (SKVV / VVC)"
+  },
+  {
+    "id": "BJO",
+    "british": false,
+    "label": "Bermejo Airport (Bolivia) (SLBJ / BJO)"
+  },
+  {
+    "id": "CBB",
+    "british": false,
+    "label": "Jorge Wilsterman International Airport (Bolivia) (SLCB / CBB)"
+  },
+  {
+    "id": "CCA",
+    "british": false,
+    "label": "Chimore Airport (Bolivia) (SLCH / CCA)"
+  },
+  {
+    "id": "CIJ",
+    "british": false,
+    "label": "Capitán Aníbal Arab Airport (Bolivia) (SLCO / CIJ)"
+  },
+  {
+    "id": "LPB",
+    "british": false,
+    "label": "El Alto International Airport (Bolivia) (SLLP / LPB)"
+  },
+  {
+    "id": "ORU",
+    "british": false,
+    "label": "Juan Mendoza Airport (Bolivia) (SLOR / ORU)"
+  },
+  {
+    "id": "POI",
+    "british": false,
+    "label": "Capitan Nicolas Rojas Airport (Bolivia) (SLPO / POI)"
+  },
+  {
+    "id": "PSZ",
+    "british": false,
+    "label": "Capitán Av. Salvador Ogaya G. airport (Bolivia) (SLPS / PSZ)"
+  },
+  {
+    "id": "SBL",
+    "british": false,
+    "label": "Santa Ana Del Yacuma Airport (Bolivia) (SLSA / SBL)"
+  },
+  {
+    "id": "SRE",
+    "british": false,
+    "label": "Juana Azurduy De Padilla Airport (Bolivia) (SLSU / SRE)"
+  },
+  {
+    "id": "TJA",
+    "british": false,
+    "label": "Capitan Oriel Lea Plaza Airport (Bolivia) (SLTJ / TJA)"
+  },
+  {
+    "id": "TDD",
+    "british": false,
+    "label": "Teniente Av. Jorge Henrich Arauz Airport (Bolivia) (SLTR / TDD)"
+  },
+  {
+    "id": "VLM",
+    "british": false,
+    "label": "Teniente Coronel Rafael Pabón Airport (Bolivia) (SLVM / VLM)"
+  },
+  {
+    "id": "VVI",
+    "british": false,
+    "label": "Viru Viru International Airport (Bolivia) (SLVR / VVI)"
+  },
+  {
+    "id": "BYC",
+    "british": false,
+    "label": "Yacuiba Airport (Bolivia) (SLYA / BYC)"
+  },
+  {
+    "id": "PBM",
+    "british": false,
+    "label": "Johan Adolf Pengel International Airport (Suriname) (SMJP / PBM)"
+  },
+  {
+    "id": "CAY",
+    "british": false,
+    "label": "Cayenne-Rochambeau Airport (French Guiana) (SOCA / CAY)"
+  },
+  {
+    "id": "OYP",
+    "british": false,
+    "label": "Saint-Georges-de-l'Oyapock Airport (French Guiana) (SOOG / OYP)"
+  },
+  {
+    "id": "SPAB",
+    "british": false,
+    "label": "Huancabamba Airport (Peru) (SPAB)"
+  },
+  {
+    "id": "AOP",
+    "british": false,
+    "label": "Alferez FAP Alfredo Vladimir Sara Bauer Airport (Peru) (SPAS / AOP)"
+  },
+  {
+    "id": "SPAY",
+    "british": false,
+    "label": "Teniente General Gerardo Pérez Pinedo Airport (Peru) (SPAY)"
+  },
+  {
+    "id": "IBP",
+    "british": false,
+    "label": "Iberia Airport (Peru) (SPBR / IBP)"
+  },
+  {
+    "id": "PCL",
+    "british": false,
+    "label": "Cap FAP David Abenzur Rengifo International Airport (Peru) (SPCL / PCL)"
+  },
+  {
+    "id": "CHM",
+    "british": false,
+    "label": "Teniente FAP Jaime A De Montreuil Morales Airport (Peru) (SPEO / CHM)"
+  },
+  {
+    "id": "SPEP",
+    "british": false,
+    "label": "Puerto Esperanza Airport (Peru) (SPEP)"
+  },
+  {
+    "id": "SPEQ",
+    "british": false,
+    "label": "Cesar Torke Podesta Airport (Peru) (SPEQ)"
+  },
+  {
+    "id": "CIX",
+    "british": false,
+    "label": "Capitan FAP Jose A Quinones Gonzales International Airport (Peru) (SPHI / CIX)"
+  },
+  {
+    "id": "AYP",
+    "british": false,
+    "label": "Coronel FAP Alfredo Mendivil Duarte Airport (Peru) (SPHO / AYP)"
+  },
+  {
+    "id": "ANS",
+    "british": false,
+    "label": "Andahuaylas Airport (Peru) (SPHY / ANS)"
+  },
+  {
+    "id": "ATA",
+    "british": false,
+    "label": "Comandante FAP German Arias Graziani Airport (Peru) (SPHZ / ATA)"
+  },
+  {
+    "id": "LIM",
+    "british": false,
+    "label": "Jorge Chávez International Airport (Peru) (SPIM / LIM)"
+  },
+  {
+    "id": "JJI",
+    "british": false,
+    "label": "Juanjui Airport (Peru) (SPJI / JJI)"
+  },
+  {
+    "id": "JAU",
+    "british": false,
+    "label": "Francisco Carle Airport (Peru) (SPJJ / JAU)"
+  },
+  {
+    "id": "JUL",
+    "british": false,
+    "label": "Inca Manco Capac International Airport (Peru) (SPJL / JUL)"
+  },
+  {
+    "id": "ILQ",
+    "british": false,
+    "label": "Ilo Airport (Peru) (SPLO / ILQ)"
+  },
+  {
+    "id": "SPLP",
+    "british": false,
+    "label": "Las Palmas Air Base (Peru) (SPLP)"
+  },
+  {
+    "id": "TBP",
+    "british": false,
+    "label": "Capitan FAP Pedro Canga Rodriguez Airport (Peru) (SPME / TBP)"
+  },
+  {
+    "id": "YMS",
+    "british": false,
+    "label": "Moises Benzaquen Rengifo Airport (Peru) (SPMS / YMS)"
+  },
+  {
+    "id": "SPOL",
+    "british": false,
+    "label": "Collique Airport (Peru) (SPOL)"
+  },
+  {
+    "id": "CHH",
+    "british": false,
+    "label": "Chachapoyas Airport (Peru) (SPPY / CHH)"
+  },
+  {
+    "id": "IQT",
+    "british": false,
+    "label": "Coronel FAP Francisco Secada Vignetta International Airport (Peru) (SPQT / IQT)"
+  },
+  {
+    "id": "AQP",
+    "british": false,
+    "label": "Rodríguez Ballón International Airport (Peru) (SPQU / AQP)"
+  },
+  {
+    "id": "SPRM",
+    "british": false,
+    "label": "Capitán FAP Leonardo Alvariño Herr Airport (Peru) (SPRM)"
+  },
+  {
+    "id": "TRU",
+    "british": false,
+    "label": "Capitan FAP Carlos Martinez De Pinillos International Airport (Peru) (SPRU / TRU)"
+  },
+  {
+    "id": "PIO",
+    "british": false,
+    "label": "Capitán FAP Renán Elías Olivera International Airport (Peru) (SPSO / PIO)"
+  },
+  {
+    "id": "TPP",
+    "british": false,
+    "label": "Cadete FAP Guillermo Del Castillo Paredes Airport (Peru) (SPST / TPP)"
+  },
+  {
+    "id": "TCQ",
+    "british": false,
+    "label": "Coronel FAP Carlos Ciriani Santa Rosa International Airport (Peru) (SPTN / TCQ)"
+  },
+  {
+    "id": "PEM",
+    "british": false,
+    "label": "Padre Aldamiz International Airport (Peru) (SPTU / PEM)"
+  },
+  {
+    "id": "PIU",
+    "british": false,
+    "label": "Capitán FAP Guillermo Concha Iberico International Airport (Peru) (SPUR / PIU)"
+  },
+  {
+    "id": "TYL",
+    "british": false,
+    "label": "Capitan Montes Airport (Peru) (SPYL / TYL)"
+  },
+  {
+    "id": "CUZ",
+    "british": false,
+    "label": "Alejandro Velasco Astete International Airport (Peru) (SPZO / CUZ)"
+  },
+  {
+    "id": "SUAA",
+    "british": false,
+    "label": "Angel S Adami Airport (Uruguay) (SUAA)"
+  },
+  {
+    "id": "DZO",
+    "british": false,
+    "label": "Santa Bernardina International Airport (Uruguay) (SUDU / DZO)"
+  },
+  {
+    "id": "MVD",
+    "british": false,
+    "label": "Carrasco International /General C L Berisso Airport (Uruguay) (SUMU / MVD)"
+  },
+  {
+    "id": "STY",
+    "british": false,
+    "label": "Nueva Hesperides International Airport (Uruguay) (SUSO / STY)"
+  },
+  {
+    "id": "AGV",
+    "british": false,
+    "label": "Oswaldo Guevara Mujica Airport (Venezuela) (SVAC / AGV)"
+  },
+  {
+    "id": "AAO",
+    "british": false,
+    "label": "Anaco Airport (Venezuela) (SVAN / AAO)"
+  },
+  {
+    "id": "SVAT",
+    "british": false,
+    "label": "San Fernando de Atabapo Airport (Venezuela) (SVAT)"
+  },
+  {
+    "id": "BLA",
+    "british": false,
+    "label": "General José Antonio Anzoategui International Airport (Venezuela) (SVBC / BLA)"
+  },
+  {
+    "id": "BNS",
+    "british": false,
+    "label": "Barinas Airport (Venezuela) (SVBI / BNS)"
+  },
+  {
+    "id": "SVBL",
+    "british": false,
+    "label": "El Libertador Airbase (Venezuela) (SVBL)"
+  },
+  {
+    "id": "BRM",
+    "british": false,
+    "label": "Barquisimeto International Airport (Venezuela) (SVBM / BRM)"
+  },
+  {
+    "id": "CBL",
+    "british": false,
+    "label": "Aeropuerto \"General Tomas de Heres\". Ciudad Bolivar (Venezuela) (SVCB / CBL)"
+  },
+  {
+    "id": "CXA",
+    "british": false,
+    "label": "Caicara del Orinoco Airport (Venezuela) (SVCD / CXA)"
+  },
+  {
+    "id": "SVCJ",
+    "british": false,
+    "label": "San Carlos Airport (Venezuela) (SVCJ)"
+  },
+  {
+    "id": "CLZ",
+    "british": false,
+    "label": "Calabozo Airport (Venezuela) (SVCL / CLZ)"
+  },
+  {
+    "id": "CAJ",
+    "british": false,
+    "label": "Canaima Airport (Venezuela) (SVCN / CAJ)"
+  },
+  {
+    "id": "VCR",
+    "british": false,
+    "label": "Carora Airport (Venezuela) (SVCO / VCR)"
+  },
+  {
+    "id": "CUP",
+    "british": false,
+    "label": "General Francisco Bermúdez Airport (Venezuela) (SVCP / CUP)"
+  },
+  {
+    "id": "CZE",
+    "british": false,
+    "label": "José Leonardo Chirinos Airport (Venezuela) (SVCR / CZE)"
+  },
+  {
+    "id": "SVCS",
+    "british": false,
+    "label": "Oscar Machado Zuluaga Airport (Venezuela) (SVCS)"
+  },
+  {
+    "id": "CUM",
+    "british": false,
+    "label": "Cumaná (Antonio José de Sucre) Airport (Venezuela) (SVCU / CUM)"
+  },
+  {
+    "id": "SVCZ",
+    "british": false,
+    "label": "Capitán Manuel Ríos Airbase (Venezuela) (SVCZ)"
+  },
+  {
+    "id": "EOR",
+    "british": false,
+    "label": "El Dorado Airport (Venezuela) (SVED / EOR)"
+  },
+  {
+    "id": "EOZ",
+    "british": false,
+    "label": "Elorza Airport (Venezuela) (SVEZ / EOZ)"
+  },
+  {
+    "id": "GDO",
+    "british": false,
+    "label": "Guasdalito Airport (Venezuela) (SVGD / GDO)"
+  },
+  {
+    "id": "GUI",
+    "british": false,
+    "label": "Guiria Airport (Venezuela) (SVGI / GUI)"
+  },
+  {
+    "id": "GUQ",
+    "british": false,
+    "label": "Guanare Airport (Venezuela) (SVGU / GUQ)"
+  },
+  {
+    "id": "HGE",
+    "british": false,
+    "label": "Higuerote Airport (Venezuela) (SVHG / HGE)"
+  },
+  {
+    "id": "ICC",
+    "british": false,
+    "label": "Andrés Miguel Salazar Marcano Airport (Venezuela) (SVIE / ICC)"
+  },
+  {
+    "id": "LSP",
+    "british": false,
+    "label": "Josefa Camejo International Airport (Venezuela) (SVJC / LSP)"
+  },
+  {
+    "id": "SVJM",
+    "british": false,
+    "label": "San Juan de Los Morros Airport (Venezuela) (SVJM)"
+  },
+  {
+    "id": "LFR",
+    "british": false,
+    "label": "La Fria Airport (Venezuela) (SVLF / LFR)"
+  },
+  {
+    "id": "SVLO",
+    "british": false,
+    "label": "La Orchila Airport (Venezuela) (SVLO)"
+  },
+  {
+    "id": "MAR",
+    "british": false,
+    "label": "La Chinita International Airport (Venezuela) (SVMC / MAR)"
+  },
+  {
+    "id": "MRD",
+    "british": false,
+    "label": "Alberto Carnevalli Airport (Venezuela) (SVMD / MRD)"
+  },
+  {
+    "id": "PMV",
+    "british": false,
+    "label": "Del Caribe Santiago Mariño International Airport (Venezuela) (SVMG / PMV)"
+  },
+  {
+    "id": "CCS",
+    "british": false,
+    "label": "Simón Bolívar International Airport (Venezuela) (SVMI / CCS)"
+  },
+  {
+    "id": "MUN",
+    "british": false,
+    "label": "Maturín Airport (Venezuela) (SVMT / MUN)"
+  },
+  {
+    "id": "PYH",
+    "british": false,
+    "label": "Cacique Aramare Airport (Venezuela) (SVPA / PYH)"
+  },
+  {
+    "id": "PBL",
+    "british": false,
+    "label": "General Bartolome Salom International Airport (Venezuela) (SVPC / PBL)"
+  },
+  {
+    "id": "SCI",
+    "british": false,
+    "label": "Paramillo Airport (Venezuela) (SVPM / SCI)"
+  },
+  {
+    "id": "PZO",
+    "british": false,
+    "label": "General Manuel Carlos Piar International Airport (Venezuela) (SVPR / PZO)"
+  },
+  {
+    "id": "PTM",
+    "british": false,
+    "label": "Palmarito Airport (Venezuela) (SVPT / PTM)"
+  },
+  {
+    "id": "SVZ",
+    "british": false,
+    "label": "San Antonio Del Tachira Airport (Venezuela) (SVSA / SVZ)"
+  },
+  {
+    "id": "SBB",
+    "british": false,
+    "label": "Santa Bárbara de Barinas Airport (Venezuela) (SVSB / SBB)"
+  },
+  {
+    "id": "SNV",
+    "british": false,
+    "label": "Santa Elena de Uairen Airport (Venezuela) (SVSE / SNV)"
+  },
+  {
+    "id": "STD",
+    "british": false,
+    "label": "Mayor Buenaventura Vivas International Airport (Venezuela) (SVSO / STD)"
+  },
+  {
+    "id": "SNF",
+    "british": false,
+    "label": "Sub Teniente Nestor Arias Airport (Venezuela) (SVSP / SNF)"
+  },
+  {
+    "id": "SFD",
+    "british": false,
+    "label": "San Fernando De Apure Airport (Venezuela) (SVSR / SFD)"
+  },
+  {
+    "id": "SOM",
+    "british": false,
+    "label": "San Tomé Airport (Venezuela) (SVST / SOM)"
+  },
+  {
+    "id": "STB",
+    "british": false,
+    "label": "Santa Bárbara del Zulia Airport (Venezuela) (SVSZ / STB)"
+  },
+  {
+    "id": "TUV",
+    "british": false,
+    "label": "Tucupita Airport (Venezuela) (SVTC / TUV)"
+  },
+  {
+    "id": "TMO",
+    "british": false,
+    "label": "Tumeremo Airport (Venezuela) (SVTM / TMO)"
+  },
+  {
+    "id": "VLN",
+    "british": false,
+    "label": "Arturo Michelena International Airport (Venezuela) (SVVA / VLN)"
+  },
+  {
+    "id": "VLV",
+    "british": false,
+    "label": "Dr. Antonio Nicolás Briceño Airport (Venezuela) (SVVL / VLV)"
+  },
+  {
+    "id": "VDP",
+    "british": false,
+    "label": "Valle de La Pascua Airport (Venezuela) (SVVP / VDP)"
+  },
+  {
+    "id": "SYLD",
+    "british": false,
+    "label": "Linden Airport (Guyana) (SYLD)"
+  },
+  {
+    "id": "LTM",
+    "british": false,
+    "label": "Lethem Airport (Guyana) (SYLT / LTM)"
+  },
+  {
+    "id": "ANU",
+    "british": false,
+    "label": "V.C. Bird International Airport (Antigua and Barbuda) (TAPA / ANU)"
+  },
+  {
+    "id": "BGI",
+    "british": false,
+    "label": "Sir Grantley Adams International Airport (Barbados) (TBPB / BGI)"
+  },
+  {
+    "id": "DCF",
+    "british": false,
+    "label": "Canefield Airport (Dominica) (TDCF / DCF)"
+  },
+  {
+    "id": "DOM",
+    "british": false,
+    "label": "Douglas-Charles Airport (Dominica) (TDPD / DOM)"
+  },
+  {
+    "id": "FDF",
+    "british": false,
+    "label": "Martinique Aimé Césaire International Airport (Martinique) (TFFF / FDF)"
+  },
+  {
+    "id": "SFG",
+    "british": false,
+    "label": "L'Espérance Airport (Guadeloupe) (TFFG / SFG)"
+  },
+  {
+    "id": "PTP",
+    "british": false,
+    "label": "Pointe-à-Pitre Le Raizet (Guadeloupe) (TFFR / PTP)"
+  },
+  {
+    "id": "GND",
+    "british": false,
+    "label": "Point Salines International Airport (Grenada) (TGPY / GND)"
+  },
+  {
+    "id": "STT",
+    "british": false,
+    "label": "Cyril E. King Airport (Virgin Islands) (TIST / STT)"
+  },
+  {
+    "id": "STX",
+    "british": false,
+    "label": "Henry E Rohlsen Airport (Virgin Islands) (TISX / STX)"
+  },
+  {
+    "id": "BQN",
+    "british": false,
+    "label": "Rafael Hernandez Airport (Puerto Rico) (TJBQ / BQN)"
+  },
+  {
+    "id": "FAJ",
+    "british": false,
+    "label": "Diego Jimenez Torres Airport (Puerto Rico) (TJFA / FAJ)"
+  },
+  {
+    "id": "SIG",
+    "british": false,
+    "label": "Fernando Luis Ribas Dominicci Airport (Puerto Rico) (TJIG / SIG)"
+  },
+  {
+    "id": "MAZ",
+    "british": false,
+    "label": "Eugenio Maria De Hostos Airport (Puerto Rico) (TJMZ / MAZ)"
+  },
+  {
+    "id": "PSE",
+    "british": false,
+    "label": "Mercedita Airport (Puerto Rico) (TJPS / PSE)"
+  },
+  {
+    "id": "SJU",
+    "british": false,
+    "label": "Luis Munoz Marin International Airport (Puerto Rico) (TJSJ / SJU)"
+  },
+  {
+    "id": "SKB",
+    "british": false,
+    "label": "Robert L. Bradshaw International Airport (Saint Kitts and Nevis) (TKPK / SKB)"
+  },
+  {
+    "id": "SLU",
+    "british": false,
+    "label": "George F. L. Charles Airport (Saint Lucia) (TLPC / SLU)"
+  },
+  {
+    "id": "UVF",
+    "british": false,
+    "label": "Hewanorra International Airport (Saint Lucia) (TLPL / UVF)"
+  },
+  {
+    "id": "AUA",
+    "british": false,
+    "label": "Queen Beatrix International Airport (Aruba) (TNCA / AUA)"
+  },
+  {
+    "id": "BON",
+    "british": false,
+    "label": "Flamingo International Airport (Netherlands Antilles) (TNCB / BON)"
+  },
+  {
+    "id": "CUR",
+    "british": false,
+    "label": "Hato International Airport (Netherlands Antilles) (TNCC / CUR)"
+  },
+  {
+    "id": "EUX",
+    "british": false,
+    "label": "F. D. Roosevelt Airport (Netherlands Antilles) (TNCE / EUX)"
+  },
+  {
+    "id": "SXM",
+    "british": false,
+    "label": "Princess Juliana International Airport (Netherlands Antilles) (TNCM / SXM)"
+  },
+  {
+    "id": "AXA",
+    "british": false,
+    "label": "Clayton J Lloyd International Airport (Anguilla) (TQPF / AXA)"
+  },
+  {
+    "id": "TAB",
+    "british": false,
+    "label": "Tobago-Crown Point Airport (Trinidad and Tobago) (TTCP / TAB)"
+  },
+  {
+    "id": "POS",
+    "british": false,
+    "label": "Piarco International Airport (Trinidad and Tobago) (TTPP / POS)"
+  },
+  {
+    "id": "EIS",
+    "british": false,
+    "label": "Terrance B. Lettsome International Airport (British Virgin Islands) (TUPJ / EIS)"
+  },
+  {
+    "id": "CIW",
+    "british": false,
+    "label": "Canouan Airport (Saint Vincent and the Grenadines) (TVSC / CIW)"
+  },
+  {
+    "id": "MQS",
+    "british": false,
+    "label": "Mustique Airport (Saint Vincent and the Grenadines) (TVSM / MQS)"
+  },
+  {
+    "id": "SVD",
+    "british": false,
+    "label": "Argyle International Airport (Saint Vincent and the Grenadines) (TVSA / SVD)"
+  },
+  {
+    "id": "ALA",
+    "british": false,
+    "label": "Almaty Airport (Kazakhstan) (UAAA / ALA)"
+  },
+  {
+    "id": "BXH",
+    "british": false,
+    "label": "Balkhash Airport (Kazakhstan) (UAAH / BXH)"
+  },
+  {
+    "id": "TSE",
+    "british": false,
+    "label": "Astana International Airport (Kazakhstan) (UACC / TSE)"
+  },
+  {
+    "id": "DMB",
+    "british": false,
+    "label": "Taraz Airport (Kazakhstan) (UADD / DMB)"
+  },
+  {
+    "id": "FRU",
+    "british": false,
+    "label": "Manas International Airport (Kyrgyzstan) (UAFM / FRU)"
+  },
+  {
+    "id": "OSS",
+    "british": false,
+    "label": "Osh Airport (Kyrgyzstan) (UAFO / OSS)"
+  },
+  {
+    "id": "CIT",
+    "british": false,
+    "label": "Shymkent Airport (Kazakhstan) (UAII / CIT)"
+  },
+  {
+    "id": "URA",
+    "british": false,
+    "label": "Uralsk Airport (Kazakhstan) (UARR / URA)"
+  },
+  {
+    "id": "PWQ",
+    "british": false,
+    "label": "Pavlodar Airport (Kazakhstan) (UASP / PWQ)"
+  },
+  {
+    "id": "PLX",
+    "british": false,
+    "label": "Semipalatinsk Airport (Kazakhstan) (UASS / PLX)"
+  },
+  {
+    "id": "AKX",
+    "british": false,
+    "label": "Aktobe Airport (Kazakhstan) (UATT / AKX)"
+  },
+  {
+    "id": "GYD",
+    "british": false,
+    "label": "Heydar Aliyev International Airport (Azerbaijan) (UBBB / GYD)"
+  },
+  {
+    "id": "YKS",
+    "british": false,
+    "label": "Yakutsk Airport (Russia) (UEEE / YKS)"
+  },
+  {
+    "id": "MJZ",
+    "british": false,
+    "label": "Mirny Airport (Russia) (UERR / MJZ)"
+  },
+  {
+    "id": "BQS",
+    "british": false,
+    "label": "Ignatyevo Airport (Russia) (UHBB / BQS)"
+  },
+  {
+    "id": "KHV",
+    "british": false,
+    "label": "Khabarovsk-Novy Airport (Russia) (UHHH / KHV)"
+  },
+  {
+    "id": "PVS",
+    "british": false,
+    "label": "Provideniya Bay Airport (Russia) (UHMD / PVS)"
+  },
+  {
+    "id": "GDX",
+    "british": false,
+    "label": "Sokol Airport (Russia) (UHMM / GDX)"
+  },
+  {
+    "id": "PWE",
+    "british": false,
+    "label": "Pevek Airport (Russia) (UHMP / PWE)"
+  },
+  {
+    "id": "PKC",
+    "british": false,
+    "label": "Yelizovo Airport (Russia) (UHPP / PKC)"
+  },
+  {
+    "id": "UUS",
+    "british": false,
+    "label": "Yuzhno-Sakhalinsk Airport (Russia) (UHSS / UUS)"
+  },
+  {
+    "id": "VVO",
+    "british": false,
+    "label": "Vladivostok International Airport (Russia) (UHWW / VVO)"
+  },
+  {
+    "id": "HTA",
+    "british": false,
+    "label": "Chita-Kadala Airport (Russia) (UIAA / HTA)"
+  },
+  {
+    "id": "BTK",
+    "british": false,
+    "label": "Bratsk Airport (Russia) (UIBB / BTK)"
+  },
+  {
+    "id": "IKT",
+    "british": false,
+    "label": "Irkutsk Airport (Russia) (UIII / IKT)"
+  },
+  {
+    "id": "UUD",
+    "british": false,
+    "label": "Ulan-Ude Airport (Mukhino) (Russia) (UIUU / UUD)"
+  },
+  {
+    "id": "KBP",
+    "british": false,
+    "label": "Boryspil International Airport (Ukraine) (UKBB / KBP)"
+  },
+  {
+    "id": "DOK",
+    "british": false,
+    "label": "Donetsk International Airport (Ukraine) (UKCC / DOK)"
+  },
+  {
+    "id": "DNK",
+    "british": false,
+    "label": "Dnipropetrovsk International Airport (Ukraine) (UKDD / DNK)"
+  },
+  {
+    "id": "SIP",
+    "british": false,
+    "label": "Simferopol International Airport (Ukraine) (UKFF / SIP)"
+  },
+  {
+    "id": "IEV",
+    "british": false,
+    "label": "Kiev Zhuliany International Airport (Ukraine) (UKKK / IEV)"
+  },
+  {
+    "id": "LWO",
+    "british": false,
+    "label": "Lviv International Airport (Ukraine) (UKLL / LWO)"
+  },
+  {
+    "id": "ODS",
+    "british": false,
+    "label": "Odessa International Airport (Ukraine) (UKOO / ODS)"
+  },
+  {
+    "id": "LED",
+    "british": false,
+    "label": "Pulkovo Airport (Russia) (ULLI / LED)"
+  },
+  {
+    "id": "MMK",
+    "british": false,
+    "label": "Murmansk Airport (Russia) (ULMM / MMK)"
+  },
+  {
+    "id": "GME",
+    "british": false,
+    "label": "Gomel Airport (Belarus) (UMGG / GME)"
+  },
+  {
+    "id": "VTB",
+    "british": false,
+    "label": "Vitebsk Vostochny Airport (Belarus) (UMII / VTB)"
+  },
+  {
+    "id": "KGD",
+    "british": false,
+    "label": "Khrabrovo Airport (Russia) (UMKK / KGD)"
+  },
+  {
+    "id": "MHP",
+    "british": false,
+    "label": "Minsk 1 Airport (Belarus) (UMMM / MHP)"
+  },
+  {
+    "id": "MSQ",
+    "british": false,
+    "label": "Minsk National Airport (Belarus) (UMMS / MSQ)"
+  },
+  {
+    "id": "ABA",
+    "british": false,
+    "label": "Abakan Airport (Russia) (UNAA / ABA)"
+  },
+  {
+    "id": "BAX",
+    "british": false,
+    "label": "Barnaul Airport (Russia) (UNBB / BAX)"
+  },
+  {
+    "id": "KEJ",
+    "british": false,
+    "label": "Kemerovo Airport (Russia) (UNEE / KEJ)"
+  },
+  {
+    "id": "OMS",
+    "british": false,
+    "label": "Omsk Central Airport (Russia) (UNOO / OMS)"
+  },
+  {
+    "id": "KRR",
+    "british": false,
+    "label": "Krasnodar Pashkovsky International Airport (Russia) (URKK / KRR)"
+  },
+  {
+    "id": "MCX",
+    "british": false,
+    "label": "Uytash Airport (Russia) (URML / MCX)"
+  },
+  {
+    "id": "MRV",
+    "british": false,
+    "label": "Mineralnyye Vody Airport (Russia) (URMM / MRV)"
+  },
+  {
+    "id": "STW",
+    "british": false,
+    "label": "Stavropol Shpakovskoye Airport (Russia) (URMT / STW)"
+  },
+  {
+    "id": "ROV",
+    "british": false,
+    "label": "Platov International Airport (Russia) (URRP / ROV)"
+  },
+  {
+    "id": "AER",
+    "british": false,
+    "label": "Sochi International Airport (Russia) (URSS / AER)"
+  },
+  {
+    "id": "ASF",
+    "british": false,
+    "label": "Astrakhan Airport (Russia) (URWA / ASF)"
+  },
+  {
+    "id": "VOG",
+    "british": false,
+    "label": "Volgograd International Airport (Russia) (URWW / VOG)"
+  },
+  {
+    "id": "CEK",
+    "british": false,
+    "label": "Chelyabinsk Balandino Airport (Russia) (USCC / CEK)"
+  },
+  {
+    "id": "MQF",
+    "british": false,
+    "label": "Magnitogorsk International Airport (Russia) (USCM / MQF)"
+  },
+  {
+    "id": "NJC",
+    "british": false,
+    "label": "Nizhnevartovsk Airport (Russia) (USNN / NJC)"
+  },
+  {
+    "id": "PEE",
+    "british": false,
+    "label": "Bolshoye Savino Airport (Russia) (USPP / PEE)"
+  },
+  {
+    "id": "SGC",
+    "british": false,
+    "label": "Surgut Airport (Russia) (USRR / SGC)"
+  },
+  {
+    "id": "SVX",
+    "british": false,
+    "label": "Koltsovo Airport (Russia) (USSS / SVX)"
+  },
+  {
+    "id": "ASB",
+    "british": false,
+    "label": "Ashgabat International Airport (Turkmenistan) (UTAA / ASB)"
+  },
+  {
+    "id": "KRW",
+    "british": false,
+    "label": "Turkmenbashi Airport (Turkmenistan) (UTAK / KRW)"
+  },
+  {
+    "id": "CRZ",
+    "british": false,
+    "label": "Turkmenabat Airport (Turkmenistan) (UTAV / CRZ)"
+  },
+  {
+    "id": "DYU",
+    "british": false,
+    "label": "Dushanbe Airport (Tajikistan) (UTDD / DYU)"
+  },
+  {
+    "id": "BHK",
+    "british": false,
+    "label": "Bukhara Airport (Uzbekistan) (UTSB / BHK)"
+  },
+  {
+    "id": "SKD",
+    "british": false,
+    "label": "Samarkand Airport (Uzbekistan) (UTSS / SKD)"
+  },
+  {
+    "id": "TAS",
+    "british": false,
+    "label": "Tashkent International Airport (Uzbekistan) (UTTT / TAS)"
+  },
+  {
+    "id": "BZK",
+    "british": false,
+    "label": "Bryansk Airport (Russia) (UUBP / BZK)"
+  },
+  {
+    "id": "SVO",
+    "british": false,
+    "label": "Sheremetyevo International Airport (Russia) (UUEE / SVO)"
+  },
+  {
+    "id": "KLD",
+    "british": false,
+    "label": "Migalovo Air Base (Russia) (UUEM / KLD)"
+  },
+  {
+    "id": "VOZ",
+    "british": false,
+    "label": "Voronezh International Airport (Russia) (UUOO / VOZ)"
+  },
+  {
+    "id": "VKO",
+    "british": false,
+    "label": "Vnukovo International Airport (Russia) (UUWW / VKO)"
+  },
+  {
+    "id": "SCW",
+    "british": false,
+    "label": "Syktyvkar Airport (Russia) (UUYY / SCW)"
+  },
+  {
+    "id": "KZN",
+    "british": false,
+    "label": "Kazan International Airport (Russia) (UWKD / KZN)"
+  },
+  {
+    "id": "REN",
+    "british": false,
+    "label": "Orenburg Central Airport (Russia) (UWOO / REN)"
+  },
+  {
+    "id": "UFA",
+    "british": false,
+    "label": "Ufa International Airport (Russia) (UWUU / UFA)"
+  },
+  {
+    "id": "KUF",
+    "british": false,
+    "label": "Kurumoch International Airport (Russia) (UWWW / KUF)"
+  },
+  {
+    "id": "AMD",
+    "british": false,
+    "label": "Sardar Vallabhbhai Patel International Airport (India) (VAAH / AMD)"
+  },
+  {
+    "id": "AKD",
+    "british": false,
+    "label": "Akola Airport (India) (VAAK / AKD)"
+  },
+  {
+    "id": "IXU",
+    "british": false,
+    "label": "Aurangabad Airport (India) (VAAU / IXU)"
+  },
+  {
+    "id": "BOM",
+    "british": false,
+    "label": "Chhatrapati Shivaji International Airport (India) (VABB / BOM)"
+  },
+  {
+    "id": "PAB",
+    "british": false,
+    "label": "Bilaspur Airport (India) (VABI / PAB)"
+  },
+  {
+    "id": "BHJ",
+    "british": false,
+    "label": "Bhuj Airport (India) (VABJ / BHJ)"
+  },
+  {
+    "id": "IXG",
+    "british": false,
+    "label": "Belgaum Airport (India) (VABM / IXG)"
+  },
+  {
+    "id": "BDQ",
+    "british": false,
+    "label": "Vadodara Airport (India) (VABO / BDQ)"
+  },
+  {
+    "id": "BHO",
+    "british": false,
+    "label": "Raja Bhoj International Airport (India) (VABP / BHO)"
+  },
+  {
+    "id": "BHU",
+    "british": false,
+    "label": "Bhavnagar Airport (India) (VABV / BHU)"
+  },
+  {
+    "id": "NMB",
+    "british": false,
+    "label": "Daman Airport (India) (VADN / NMB)"
+  },
+  {
+    "id": "VADS",
+    "british": false,
+    "label": "Deesa Airport (India) (VADS)"
+  },
+  {
+    "id": "GUX",
+    "british": false,
+    "label": "Guna Airport (India) (VAGN / GUX)"
+  },
+  {
+    "id": "GOI",
+    "british": false,
+    "label": "Dabolim Airport (India) (VAGO / GOI)"
+  },
+  {
+    "id": "IDR",
+    "british": false,
+    "label": "Devi Ahilyabai Holkar Airport (India) (VAID / IDR)"
+  },
+  {
+    "id": "JLR",
+    "british": false,
+    "label": "Jabalpur Airport (India) (VAJB / JLR)"
+  },
+  {
+    "id": "JGA",
+    "british": false,
+    "label": "Jamnagar Airport (India) (VAJM / JGA)"
+  },
+  {
+    "id": "IXY",
+    "british": false,
+    "label": "Kandla Airport (India) (VAKE / IXY)"
+  },
+  {
+    "id": "HJR",
+    "british": false,
+    "label": "Khajuraho Airport (India) (VAKJ / HJR)"
+  },
+  {
+    "id": "KLH",
+    "british": false,
+    "label": "Kolhapur Airport (India) (VAKP / KLH)"
+  },
+  {
+    "id": "IXK",
+    "british": false,
+    "label": "Keshod Airport (India) (VAKS / IXK)"
+  },
+  {
+    "id": "NAG",
+    "british": false,
+    "label": "Dr. Babasaheb Ambedkar International Airport (India) (VANP / NAG)"
+  },
+  {
+    "id": "ISK",
+    "british": false,
+    "label": "Nashik Airport (India) (VAOZ / ISK)"
+  },
+  {
+    "id": "PNQ",
+    "british": false,
+    "label": "Pune Airport (India) (VAPO / PNQ)"
+  },
+  {
+    "id": "PBD",
+    "british": false,
+    "label": "Porbandar Airport (India) (VAPR / PBD)"
+  },
+  {
+    "id": "RAJ",
+    "british": false,
+    "label": "Rajkot Airport (India) (VARK / RAJ)"
+  },
+  {
+    "id": "RPR",
+    "british": false,
+    "label": "Raipur Airport (India) (VARP / RPR)"
+  },
+  {
+    "id": "SSE",
+    "british": false,
+    "label": "Solapur Airport (India) (VASL / SSE)"
+  },
+  {
+    "id": "STV",
+    "british": false,
+    "label": "Surat Airport (India) (VASU / STV)"
+  },
+  {
+    "id": "UDR",
+    "british": false,
+    "label": "Maharana Pratap Airport (India) (VAUD / UDR)"
+  },
+  {
+    "id": "CMB",
+    "british": false,
+    "label": "Bandaranaike International Colombo Airport (Sri Lanka) (VCBI / CMB)"
+  },
+  {
+    "id": "ACJ",
+    "british": false,
+    "label": "Anuradhapura Air Force Base (Sri Lanka) (VCCA / ACJ)"
+  },
+  {
+    "id": "BTC",
+    "british": false,
+    "label": "Batticaloa Airport (Sri Lanka) (VCCB / BTC)"
+  },
+  {
+    "id": "RML",
+    "british": false,
+    "label": "Colombo Ratmalana Airport (Sri Lanka) (VCCC / RML)"
+  },
+  {
+    "id": "ADP",
+    "british": false,
+    "label": "Ampara Airport (Sri Lanka) (VCCG / ADP)"
+  },
+  {
+    "id": "JAF",
+    "british": false,
+    "label": "Kankesanturai Airport (Sri Lanka) (VCCJ / JAF)"
+  },
+  {
+    "id": "TRR",
+    "british": false,
+    "label": "China Bay Airport (Sri Lanka) (VCCT / TRR)"
+  },
+  {
+    "id": "KZC",
+    "british": false,
+    "label": "Kampong Chhnang Airport (Cambodia) (VDKH / KZC)"
+  },
+  {
+    "id": "PNH",
+    "british": false,
+    "label": "Phnom Penh International Airport (Cambodia) (VDPP / PNH)"
+  },
+  {
+    "id": "REP",
+    "british": false,
+    "label": "Siem Reap International Airport (Cambodia) (VDSR / REP)"
+  },
+  {
+    "id": "TNX",
+    "british": false,
+    "label": "Stung Treng Airport (Cambodia) (VDST / TNX)"
+  },
+  {
+    "id": "IXV",
+    "british": false,
+    "label": "Along Airport (India) (VEAN / IXV)"
+  },
+  {
+    "id": "IXA",
+    "british": false,
+    "label": "Agartala Airport (India) (VEAT / IXA)"
+  },
+  {
+    "id": "AJL",
+    "british": false,
+    "label": "Lengpui Airport (India) (VELP / AJL)"
+  },
+  {
+    "id": "IXB",
+    "british": false,
+    "label": "Bagdogra Airport (India) (VEBD / IXB)"
+  },
+  {
+    "id": "VEBK",
+    "british": false,
+    "label": "Bokaro Airport (India) (VEBK)"
+  },
+  {
+    "id": "BBI",
+    "british": false,
+    "label": "Biju Patnaik Airport (India) (VEBS / BBI)"
+  },
+  {
+    "id": "CCU",
+    "british": false,
+    "label": "Netaji Subhash Chandra Bose International Airport (India) (VECC / CCU)"
+  },
+  {
+    "id": "COH",
+    "british": false,
+    "label": "Cooch Behar Airport (India) (VECO / COH)"
+  },
+  {
+    "id": "DBD",
+    "british": false,
+    "label": "Dhanbad Airport (India) (VEDB / DBD)"
+  },
+  {
+    "id": "GAY",
+    "british": false,
+    "label": "Gaya Airport (India) (VEGY / GAY)"
+  },
+  {
+    "id": "VEHK",
+    "british": false,
+    "label": "Hirakud Airport (India) (VEHK)"
+  },
+  {
+    "id": "IMF",
+    "british": false,
+    "label": "Imphal Airport (India) (VEIM / IMF)"
+  },
+  {
+    "id": "VEJH",
+    "british": false,
+    "label": "Jharsuguda Airport (India) (VEJH)"
+  },
+  {
+    "id": "IXW",
+    "british": false,
+    "label": "Sonari Airport (India) (VEJS / IXW)"
+  },
+  {
+    "id": "JRH",
+    "british": false,
+    "label": "Jorhat Airport (India) (VEJT / JRH)"
+  },
+  {
+    "id": "IXH",
+    "british": false,
+    "label": "Kailashahar Airport (India) (VEKR / IXH)"
+  },
+  {
+    "id": "IXS",
+    "british": false,
+    "label": "Silchar Airport (India) (VEKU / IXS)"
+  },
+  {
+    "id": "IXI",
+    "british": false,
+    "label": "North Lakhimpur Airport (India) (VELR / IXI)"
+  },
+  {
+    "id": "DIB",
+    "british": false,
+    "label": "Dibrugarh Airport (India) (VEMN / DIB)"
+  },
+  {
+    "id": "MZU",
+    "british": false,
+    "label": "Muzaffarpur Airport (India) (VEMZ / MZU)"
+  },
+  {
+    "id": "VENP",
+    "british": false,
+    "label": "Nawapara Airport (India) (VENP)"
+  },
+  {
+    "id": "VEPH",
+    "british": false,
+    "label": "Panagarh Air Force Station (India) (VEPH)"
+  },
+  {
+    "id": "PAT",
+    "british": false,
+    "label": "Lok Nayak Jayaprakash Airport (India) (VEPT / PAT)"
+  },
+  {
+    "id": "VEPU",
+    "british": false,
+    "label": "Purnea Airport (India) (VEPU)"
+  },
+  {
+    "id": "IXR",
+    "british": false,
+    "label": "Birsa Munda Airport (India) (VERC / IXR)"
+  },
+  {
+    "id": "RRK",
+    "british": false,
+    "label": "Rourkela Airport (India) (VERK / RRK)"
+  },
+  {
+    "id": "VEUK",
+    "british": false,
+    "label": "Utkela Airport (India) (VEUK)"
+  },
+  {
+    "id": "VTZ",
+    "british": false,
+    "label": "Vishakhapatnam Airport (India) (VEVZ / VTZ)"
+  },
+  {
+    "id": "ZER",
+    "british": false,
+    "label": "Ziro Airport (India) (VEZO / ZER)"
+  },
+  {
+    "id": "CXB",
+    "british": false,
+    "label": "Cox's Bazar Airport (Bangladesh) (VGCB / CXB)"
+  },
+  {
+    "id": "CGP",
+    "british": false,
+    "label": "Shah Amanat International Airport (Bangladesh) (VGEG / CGP)"
+  },
+  {
+    "id": "IRD",
+    "british": false,
+    "label": "Ishurdi Airport (Bangladesh) (VGIS / IRD)"
+  },
+  {
+    "id": "JSR",
+    "british": false,
+    "label": "Jessore Airport (Bangladesh) (VGJR / JSR)"
+  },
+  {
+    "id": "RJH",
+    "british": false,
+    "label": "Shah Mokhdum Airport (Bangladesh) (VGRJ / RJH)"
+  },
+  {
+    "id": "SPD",
+    "british": false,
+    "label": "Saidpur Airport (Bangladesh) (VGSD / SPD)"
+  },
+  {
+    "id": "ZYL",
+    "british": false,
+    "label": "Osmany International Airport (Bangladesh) (VGSY / ZYL)"
+  },
+  {
+    "id": "VGTJ",
+    "british": false,
+    "label": "Tejgaon Airport (Bangladesh) (VGTJ)"
+  },
+  {
+    "id": "DAC",
+    "british": false,
+    "label": "Hazrat Shahjalal International Airport (Bangladesh) (VGZR / DAC)"
+  },
+  {
+    "id": "HKG",
+    "british": false,
+    "label": "Hong Kong International Airport (Hong Kong) (VHHH / HKG)"
+  },
+  {
+    "id": "VHSK",
+    "british": false,
+    "label": "Shek Kong Air Base (Hong Kong) (VHSK)"
+  },
+  {
+    "id": "AGR",
+    "british": false,
+    "label": "Agra Airport (India) (VIAG / AGR)"
+  },
+  {
+    "id": "IXD",
+    "british": false,
+    "label": "Allahabad Airport (India) (VIAL / IXD)"
+  },
+  {
+    "id": "ATQ",
+    "british": false,
+    "label": "Sri Guru Ram Dass Jee International Airport (India) (VIAR / ATQ)"
+  },
+  {
+    "id": "BKB",
+    "british": false,
+    "label": "Nal Airport (India) (VIBK / BKB)"
+  },
+  {
+    "id": "VIBL",
+    "british": false,
+    "label": "Bakshi Ka Talab Air Force Station (India) (VIBL)"
+  },
+  {
+    "id": "VNS",
+    "british": false,
+    "label": "Lal Bahadur Shastri Airport (India) (VIBN / VNS)"
+  },
+  {
+    "id": "KUU",
+    "british": false,
+    "label": "Kullu Manali Airport (India) (VIBR / KUU)"
+  },
+  {
+    "id": "BUP",
+    "british": false,
+    "label": "Bhatinda Air Force Station (India) (VIBT / BUP)"
+  },
+  {
+    "id": "VIBW",
+    "british": false,
+    "label": "Bhiwani Airport (India) (VIBW)"
+  },
+  {
+    "id": "BEK",
+    "british": false,
+    "label": "Bareilly Air Force Station (India) (VIBY / BEK)"
+  },
+  {
+    "id": "IXC",
+    "british": false,
+    "label": "Chandigarh Airport (India) (VICG / IXC)"
+  },
+  {
+    "id": "KNU",
+    "british": false,
+    "label": "Kanpur Airport (India) (VICX / KNU)"
+  },
+  {
+    "id": "VIDD",
+    "british": false,
+    "label": "Safdarjung Airport (India) (VIDD)"
+  },
+  {
+    "id": "DED",
+    "british": false,
+    "label": "Dehradun Airport (India) (VIDN / DED)"
+  },
+  {
+    "id": "DEL",
+    "british": false,
+    "label": "Indira Gandhi International Airport (India) (VIDP / DEL)"
+  },
+  {
+    "id": "GWL",
+    "british": false,
+    "label": "Gwalior Airport (India) (VIGR / GWL)"
+  },
+  {
+    "id": "HSS",
+    "british": false,
+    "label": "Hissar Airport (India) (VIHR / HSS)"
+  },
+  {
+    "id": "VIJN",
+    "british": false,
+    "label": "Jhansi Airport (India) (VIJN)"
+  },
+  {
+    "id": "JDH",
+    "british": false,
+    "label": "Jodhpur Airport (India) (VIJO / JDH)"
+  },
+  {
+    "id": "JAI",
+    "british": false,
+    "label": "Jaipur International Airport (India) (VIJP / JAI)"
+  },
+  {
+    "id": "JSA",
+    "british": false,
+    "label": "Jaisalmer Airport (India) (VIJR / JSA)"
+  },
+  {
+    "id": "IXJ",
+    "british": false,
+    "label": "Jammu Airport (India) (VIJU / IXJ)"
+  },
+  {
+    "id": "VIKA",
+    "british": false,
+    "label": "Kanpur Civil Airport (India) (VIKA)"
+  },
+  {
+    "id": "KTU",
+    "british": false,
+    "label": "Kota Airport (India) (VIKO / KTU)"
+  },
+  {
+    "id": "LUH",
+    "british": false,
+    "label": "Ludhiana Airport (India) (VILD / LUH)"
+  },
+  {
+    "id": "IXL",
+    "british": false,
+    "label": "Leh Kushok Bakula Rimpochee Airport (India) (VILH / IXL)"
+  },
+  {
+    "id": "LKO",
+    "british": false,
+    "label": "Chaudhary Charan Singh International Airport (India) (VILK / LKO)"
+  },
+  {
+    "id": "IXP",
+    "british": false,
+    "label": "Pathankot Airport (India) (VIPK / IXP)"
+  },
+  {
+    "id": "VIPL",
+    "british": false,
+    "label": "Patiala Airport (India) (VIPL)"
+  },
+  {
+    "id": "PGH",
+    "british": false,
+    "label": "Pantnagar Airport (India) (VIPT / PGH)"
+  },
+  {
+    "id": "VIRB",
+    "british": false,
+    "label": "Fursatganj Airport (India) (VIRB)"
+  },
+  {
+    "id": "VISP",
+    "british": false,
+    "label": "Sarsawa Air Force Station (India) (VISP)"
+  },
+  {
+    "id": "SXR",
+    "british": false,
+    "label": "Sheikh ul Alam Airport (India) (VISR / SXR)"
+  },
+  {
+    "id": "TNI",
+    "british": false,
+    "label": "Satna Airport (India) (VIST / TNI)"
+  },
+  {
+    "id": "LPQ",
+    "british": false,
+    "label": "Luang Phabang International Airport (Laos) (VLLB / LPQ)"
+  },
+  {
+    "id": "PKZ",
+    "british": false,
+    "label": "Pakse International Airport (Laos) (VLPS / PKZ)"
+  },
+  {
+    "id": "VLPV",
+    "british": false,
+    "label": "Phonesavanh Airport (Laos) (VLPV)"
+  },
+  {
+    "id": "ZVK",
+    "british": false,
+    "label": "Savannakhet Airport (Laos) (VLSK / ZVK)"
+  },
+  {
+    "id": "NEU",
+    "british": false,
+    "label": "Sam Neua Airport (Laos) (VLSN / NEU)"
+  },
+  {
+    "id": "VTE",
+    "british": false,
+    "label": "Wattay International Airport (Laos) (VLVT / VTE)"
+  },
+  {
+    "id": "MFM",
+    "british": false,
+    "label": "Macau International Airport (Macau) (VMMC / MFM)"
+  },
+  {
+    "id": "BWA",
+    "british": false,
+    "label": "Gautam Buddha Airport (Nepal) (VNBW / BWA)"
+  },
+  {
+    "id": "JKR",
+    "british": false,
+    "label": "Janakpur Airport (Nepal) (VNJP / JKR)"
+  },
+  {
+    "id": "KTM",
+    "british": false,
+    "label": "Tribhuvan International Airport (Nepal) (VNKT / KTM)"
+  },
+  {
+    "id": "PKR",
+    "british": false,
+    "label": "Pokhara Airport (Nepal) (VNPK / PKR)"
+  },
+  {
+    "id": "SIF",
+    "british": false,
+    "label": "Simara Airport (Nepal) (VNSI / SIF)"
+  },
+  {
+    "id": "BIR",
+    "british": false,
+    "label": "Biratnagar Airport (Nepal) (VNVT / BIR)"
+  },
+  {
+    "id": "AGX",
+    "british": false,
+    "label": "Agatti Airport (India) (VOAT / AGX)"
+  },
+  {
+    "id": "BLR",
+    "british": false,
+    "label": "Kempegowda International Airport (India) (VOBL / BLR)"
+  },
+  {
+    "id": "BEP",
+    "british": false,
+    "label": "Bellary Airport (India) (VOBI / BEP)"
+  },
+  {
+    "id": "VOBR",
+    "british": false,
+    "label": "Bidar Air Force Station (India) (VOBR)"
+  },
+  {
+    "id": "VGA",
+    "british": false,
+    "label": "Vijayawada Airport (India) (VOBZ / VGA)"
+  },
+  {
+    "id": "CJB",
+    "british": false,
+    "label": "Coimbatore International Airport (India) (VOCB / CJB)"
+  },
+  {
+    "id": "COK",
+    "british": false,
+    "label": "Cochin International Airport (India) (VOCI / COK)"
+  },
+  {
+    "id": "CCJ",
+    "british": false,
+    "label": "Calicut International Airport (India) (VOCL / CCJ)"
+  },
+  {
+    "id": "CDP",
+    "british": false,
+    "label": "Kadapa Airport (India) (VOCP / CDP)"
+  },
+  {
+    "id": "CBD",
+    "british": false,
+    "label": "Car Nicobar Air Force Station (India) (VOCX / CBD)"
+  },
+  {
+    "id": "VODG",
+    "british": false,
+    "label": "Dundigul Air Force Academy (India) (VODG)"
+  },
+  {
+    "id": "BPM",
+    "british": false,
+    "label": "Begumpet Airport (India) (VOHY / BPM)"
+  },
+  {
+    "id": "IXM",
+    "british": false,
+    "label": "Madurai Airport (India) (VOMD / IXM)"
+  },
+  {
+    "id": "IXE",
+    "british": false,
+    "label": "Mangalore International Airport (India) (VOML / IXE)"
+  },
+  {
+    "id": "MAA",
+    "british": false,
+    "label": "Chennai International Airport (India) (VOMM / MAA)"
+  },
+  {
+    "id": "VONS",
+    "british": false,
+    "label": "Nagarjuna Sagar Airport (India) (VONS)"
+  },
+  {
+    "id": "IXZ",
+    "british": false,
+    "label": "Vir Savarkar International Airport (India) (VOPB / IXZ)"
+  },
+  {
+    "id": "PNY",
+    "british": false,
+    "label": "Pondicherry Airport (India) (VOPC / PNY)"
+  },
+  {
+    "id": "RJA",
+    "british": false,
+    "label": "Rajahmundry Airport (India) (VORY / RJA)"
+  },
+  {
+    "id": "SXV",
+    "british": false,
+    "label": "Salem Airport (India) (VOSM / SXV)"
+  },
+  {
+    "id": "TJV",
+    "british": false,
+    "label": "Tanjore Air Force Base (India) (VOTJ / TJV)"
+  },
+  {
+    "id": "TIR",
+    "british": false,
+    "label": "Tirupati Airport (India) (VOTP / TIR)"
+  },
+  {
+    "id": "TRZ",
+    "british": false,
+    "label": "Tiruchirapally Civil Airport Airport (India) (VOTR / TRZ)"
+  },
+  {
+    "id": "TRV",
+    "british": false,
+    "label": "Trivandrum International Airport (India) (VOTV / TRV)"
+  },
+  {
+    "id": "VOTX",
+    "british": false,
+    "label": "Tambaram Air Force Station (India) (VOTX)"
+  },
+  {
+    "id": "PBH",
+    "british": false,
+    "label": "Paro Airport (Bhutan) (VQPR / PBH)"
+  },
+  {
+    "id": "MLE",
+    "british": false,
+    "label": "Malé International Airport (Maldives) (VRMM / MLE)"
+  },
+  {
+    "id": "DMK",
+    "british": false,
+    "label": "Don Mueang International Airport (Thailand) (VTBD / DMK)"
+  },
+  {
+    "id": "KDT",
+    "british": false,
+    "label": "Kamphaeng Saen Airport (Thailand) (VTBK / KDT)"
+  },
+  {
+    "id": "VTBL",
+    "british": false,
+    "label": "Khok Kathiam Airport (Thailand) (VTBL)"
+  },
+  {
+    "id": "UTP",
+    "british": false,
+    "label": "U-Tapao International Airport (Thailand) (VTBU / UTP)"
+  },
+  {
+    "id": "VTBW",
+    "british": false,
+    "label": "Watthana Nakhon Airport (Thailand) (VTBW)"
+  },
+  {
+    "id": "LPT",
+    "british": false,
+    "label": "Lampang Airport (Thailand) (VTCL / LPT)"
+  },
+  {
+    "id": "PRH",
+    "british": false,
+    "label": "Phrae Airport (Thailand) (VTCP / PRH)"
+  },
+  {
+    "id": "HHQ",
+    "british": false,
+    "label": "Hua Hin Airport (Thailand) (VTPH / HHQ)"
+  },
+  {
+    "id": "TKH",
+    "british": false,
+    "label": "Takhli Airport (Thailand) (VTPI / TKH)"
+  },
+  {
+    "id": "VTPL",
+    "british": false,
+    "label": "Sak Long Airport (Thailand) (VTPL)"
+  },
+  {
+    "id": "VTPN",
+    "british": false,
+    "label": "Nakhon Sawan Airport (Thailand) (VTPN)"
+  },
+  {
+    "id": "PHS",
+    "british": false,
+    "label": "Phitsanulok Airport (Thailand) (VTPP / PHS)"
+  },
+  {
+    "id": "VTPY",
+    "british": false,
+    "label": "Khunan Phumipol Airport (Thailand) (VTPY)"
+  },
+  {
+    "id": "VTSA",
+    "british": false,
+    "label": "Khoun Khan Airport (Thailand) (VTSA)"
+  },
+  {
+    "id": "NAW",
+    "british": false,
+    "label": "Narathiwat Airport (Thailand) (VTSC / NAW)"
+  },
+  {
+    "id": "KBV",
+    "british": false,
+    "label": "Krabi Airport (Thailand) (VTSG / KBV)"
+  },
+  {
+    "id": "SGZ",
+    "british": false,
+    "label": "Songkhla Airport (Thailand) (VTSH / SGZ)"
+  },
+  {
+    "id": "PAN",
+    "british": false,
+    "label": "Pattani Airport (Thailand) (VTSK / PAN)"
+  },
+  {
+    "id": "USM",
+    "british": false,
+    "label": "Samui Airport (Thailand) (VTSM / USM)"
+  },
+  {
+    "id": "VTSN",
+    "british": false,
+    "label": "Cha Eian Airport (Thailand) (VTSN)"
+  },
+  {
+    "id": "HKT",
+    "british": false,
+    "label": "Phuket International Airport (Thailand) (VTSP / HKT)"
+  },
+  {
+    "id": "UNN",
+    "british": false,
+    "label": "Ranong Airport (Thailand) (VTSR / UNN)"
+  },
+  {
+    "id": "HDY",
+    "british": false,
+    "label": "Hat Yai International Airport (Thailand) (VTSS / HDY)"
+  },
+  {
+    "id": "TST",
+    "british": false,
+    "label": "Trang Airport (Thailand) (VTST / TST)"
+  },
+  {
+    "id": "UTH",
+    "british": false,
+    "label": "Udon Thani Airport (Thailand) (VTUD / UTH)"
+  },
+  {
+    "id": "SNO",
+    "british": false,
+    "label": "Sakon Nakhon Airport (Thailand) (VTUI / SNO)"
+  },
+  {
+    "id": "PXR",
+    "british": false,
+    "label": "Surin Airport (Thailand) (VTUJ / PXR)"
+  },
+  {
+    "id": "LOE",
+    "british": false,
+    "label": "Loei Airport (Thailand) (VTUL / LOE)"
+  },
+  {
+    "id": "VTUN",
+    "british": false,
+    "label": "Khorat Airport (Thailand) (VTUN)"
+  },
+  {
+    "id": "VTUR",
+    "british": false,
+    "label": "Rob Muang Airport (Thailand) (VTUR)"
+  },
+  {
+    "id": "DAD",
+    "british": false,
+    "label": "Da Nang International Airport (Vietnam) (VVDN / DAD)"
+  },
+  {
+    "id": "VVGL",
+    "british": false,
+    "label": "Gia Lam Air Base (Vietnam) (VVGL)"
+  },
+  {
+    "id": "VVKP",
+    "british": false,
+    "label": "Kep Air Base (Vietnam) (VVKP)"
+  },
+  {
+    "id": "HAN",
+    "british": false,
+    "label": "Noi Bai International Airport (Vietnam) (VVNB / HAN)"
+  },
+  {
+    "id": "NHA",
+    "british": false,
+    "label": "Nha Trang Air Base (Vietnam) (VVNT / NHA)"
+  },
+  {
+    "id": "HUI",
+    "british": false,
+    "label": "Phu Bai Airport (Vietnam) (VVPB / HUI)"
+  },
+  {
+    "id": "PQC",
+    "british": false,
+    "label": "Phu Quoc International Airport (Vietnam) (VVPQ / PQC)"
+  },
+  {
+    "id": "SGN",
+    "british": false,
+    "label": "Tan Son Nhat International Airport (Vietnam) (VVTS / SGN)"
+  },
+  {
+    "id": "VBA",
+    "british": false,
+    "label": "Ann Airport (Burma) (VYAN / VBA)"
+  },
+  {
+    "id": "VYAS",
+    "british": false,
+    "label": "Anisakan Airport (Burma) (VYAS)"
+  },
+  {
+    "id": "NYU",
+    "british": false,
+    "label": "Bagan Airport (Burma) (VYBG / NYU)"
+  },
+  {
+    "id": "VYCI",
+    "british": false,
+    "label": "Coco Island Airport (Burma) (VYCI)"
+  },
+  {
+    "id": "HEH",
+    "british": false,
+    "label": "Heho Airport (Burma) (VYHH / HEH)"
+  },
+  {
+    "id": "HOX",
+    "british": false,
+    "label": "Hommalinn Airport (Burma) (VYHL / HOX)"
+  },
+  {
+    "id": "KET",
+    "british": false,
+    "label": "Kengtung Airport (Burma) (VYKG / KET)"
+  },
+  {
+    "id": "KYP",
+    "british": false,
+    "label": "Kyaukpyu Airport (Burma) (VYKP / KYP)"
+  },
+  {
+    "id": "LSH",
+    "british": false,
+    "label": "Lashio Airport (Burma) (VYLS / LSH)"
+  },
+  {
+    "id": "VYLY",
+    "british": false,
+    "label": "Lanywa Airport (Burma) (VYLY)"
+  },
+  {
+    "id": "MDL",
+    "british": false,
+    "label": "Mandalay International Airport (Burma) (VYMD / MDL)"
+  },
+  {
+    "id": "MGZ",
+    "british": false,
+    "label": "Myeik Airport (Burma) (VYME / MGZ)"
+  },
+  {
+    "id": "MYT",
+    "british": false,
+    "label": "Myitkyina Airport (Burma) (VYMK / MYT)"
+  },
+  {
+    "id": "MOE",
+    "british": false,
+    "label": "Momeik Airport (Burma) (VYMO / MOE)"
+  },
+  {
+    "id": "MOG",
+    "british": false,
+    "label": "Mong Hsat Airport (Burma) (VYMS / MOG)"
+  },
+  {
+    "id": "VYNP",
+    "british": false,
+    "label": "Nampong Air Base (Burma) (VYNP)"
+  },
+  {
+    "id": "NMS",
+    "british": false,
+    "label": "Namsang Airport (Burma) (VYNS / NMS)"
+  },
+  {
+    "id": "PAA",
+    "british": false,
+    "label": "Hpa-N Airport (Burma) (VYPA / PAA)"
+  },
+  {
+    "id": "PBU",
+    "british": false,
+    "label": "Putao Airport (Burma) (VYPT / PBU)"
+  },
+  {
+    "id": "PRU",
+    "british": false,
+    "label": "Pyay Airport (Burma) (VYPY / PRU)"
+  },
+  {
+    "id": "VYST",
+    "british": false,
+    "label": "Shante Air Base (Burma) (VYST)"
+  },
+  {
+    "id": "AKY",
+    "british": false,
+    "label": "Sittwe Airport (Burma) (VYSW / AKY)"
+  },
+  {
+    "id": "SNW",
+    "british": false,
+    "label": "Thandwe Airport (Burma) (VYTD / SNW)"
+  },
+  {
+    "id": "THL",
+    "british": false,
+    "label": "Tachileik Airport (Burma) (VYTL / THL)"
+  },
+  {
+    "id": "VYTO",
+    "british": false,
+    "label": "Taungoo Airport (Burma) (VYTO)"
+  },
+  {
+    "id": "RGN",
+    "british": false,
+    "label": "Yangon International Airport (Burma) (VYYY / RGN)"
+  },
+  {
+    "id": "UPG",
+    "british": false,
+    "label": "Hasanuddin International Airport (Indonesia) (WAAA / UPG)"
+  },
+  {
+    "id": "BIK",
+    "british": false,
+    "label": "Frans Kaisiepo Airport (Indonesia) (WABB / BIK)"
+  },
+  {
+    "id": "NBX",
+    "british": false,
+    "label": "Nabire Airport (Indonesia) (WABI / NBX)"
+  },
+  {
+    "id": "TIM",
+    "british": false,
+    "label": "Moses Kilangin Airport (Indonesia) (WABP / TIM)"
+  },
+  {
+    "id": "DJJ",
+    "british": false,
+    "label": "Sentani International Airport (Indonesia) (WAJJ / DJJ)"
+  },
+  {
+    "id": "WMX",
+    "british": false,
+    "label": "Wamena Airport (Indonesia) (WAJW / WMX)"
+  },
+  {
+    "id": "MKQ",
+    "british": false,
+    "label": "Mopah Airport (Indonesia) (WAKK / MKQ)"
+  },
+  {
+    "id": "GTO",
+    "british": false,
+    "label": "Jalaluddin Airport (Indonesia) (WAMG / GTO)"
+  },
+  {
+    "id": "PLW",
+    "british": false,
+    "label": "Mutiara Airport (Indonesia) (WAML / PLW)"
+  },
+  {
+    "id": "MDC",
+    "british": false,
+    "label": "Sam Ratulangi Airport (Indonesia) (WAMM / MDC)"
+  },
+  {
+    "id": "PSJ",
+    "british": false,
+    "label": "Kasiguncu Airport (Indonesia) (WAMP / PSJ)"
+  },
+  {
+    "id": "OTI",
+    "british": false,
+    "label": "Pitu Airport (Indonesia) (WAMR / OTI)"
+  },
+  {
+    "id": "TTE",
+    "british": false,
+    "label": "Sultan Khairun Babullah Airport (Indonesia) (WAMT / TTE)"
+  },
+  {
+    "id": "LUW",
+    "british": false,
+    "label": "Syukuran Aminuddin Amir Airport (Indonesia) (WAMW / LUW)"
+  },
+  {
+    "id": "AMQ",
+    "british": false,
+    "label": "Pattimura Airport, Ambon (Indonesia) (WAPP / AMQ)"
+  },
+  {
+    "id": "FKQ",
+    "british": false,
+    "label": "Fakfak Airport (Indonesia) (WASF / FKQ)"
+  },
+  {
+    "id": "KNG",
+    "british": false,
+    "label": "Kaimana Airport (Indonesia) (WASK / KNG)"
+  },
+  {
+    "id": "BXB",
+    "british": false,
+    "label": "Babo Airport (Indonesia) (WASO / BXB)"
+  },
+  {
+    "id": "MKW",
+    "british": false,
+    "label": "Rendani Airport (Indonesia) (WASR / MKW)"
+  },
+  {
+    "id": "SOQ",
+    "british": false,
+    "label": "Dominique Edward Osok Airport (Indonesia) (WAXX / SOQ)"
+  },
+  {
+    "id": "BTU",
+    "british": false,
+    "label": "Bintulu Airport (Malaysia) (WBGB / BTU)"
+  },
+  {
+    "id": "KCH",
+    "british": false,
+    "label": "Kuching International Airport (Malaysia) (WBGG / KCH)"
+  },
+  {
+    "id": "LMN",
+    "british": false,
+    "label": "Limbang Airport (Malaysia) (WBGJ / LMN)"
+  },
+  {
+    "id": "MUR",
+    "british": false,
+    "label": "Marudi Airport (Malaysia) (WBGM / MUR)"
+  },
+  {
+    "id": "MYY",
+    "british": false,
+    "label": "Miri Airport (Malaysia) (WBGR / MYY)"
+  },
+  {
+    "id": "SBW",
+    "british": false,
+    "label": "Sibu Airport (Malaysia) (WBGS / SBW)"
+  },
+  {
+    "id": "LDU",
+    "british": false,
+    "label": "Lahad Datu Airport (Malaysia) (WBKD / LDU)"
+  },
+  {
+    "id": "BKI",
+    "british": false,
+    "label": "Kota Kinabalu International Airport (Malaysia) (WBKK / BKI)"
+  },
+  {
+    "id": "LBU",
+    "british": false,
+    "label": "Labuan Airport (Malaysia) (WBKL / LBU)"
+  },
+  {
+    "id": "TWU",
+    "british": false,
+    "label": "Tawau Airport (Malaysia) (WBKW / TWU)"
+  },
+  {
+    "id": "BWN",
+    "british": false,
+    "label": "Brunei International Airport (Brunei) (WBSB / BWN)"
+  },
+  {
+    "id": "PKU",
+    "british": false,
+    "label": "Sultan Syarif Kasim Ii (Simpang Tiga) Airport (Indonesia) (WIBB / PKU)"
+  },
+  {
+    "id": "DUM",
+    "british": false,
+    "label": "Pinang Kampai Airport (Indonesia) (WIBD / DUM)"
+  },
+  {
+    "id": "CGK",
+    "british": false,
+    "label": "Soekarno-Hatta International Airport (Indonesia) (WIII / CGK)"
+  },
+  {
+    "id": "GNS",
+    "british": false,
+    "label": "Binaka Airport (Indonesia) (WIMB / GNS)"
+  },
+  {
+    "id": "AEG",
+    "british": false,
+    "label": "Aek Godang Airport (Indonesia) (WIME / AEG)"
+  },
+  {
+    "id": "PDG",
+    "british": false,
+    "label": "Minangkabau International Airport (Indonesia) (WIPT / PDG)"
+  },
+  {
+    "id": "MES",
+    "british": false,
+    "label": "Soewondo Air Force Base (Indonesia) (WIMK / MES)"
+  },
+  {
+    "id": "FLZ",
+    "british": false,
+    "label": "Dr Ferdinand Lumban Tobing Airport (Indonesia) (WIMS / FLZ)"
+  },
+  {
+    "id": "NPO",
+    "british": false,
+    "label": "Nanga Pinoh Airport (Indonesia) (WIOG / NPO)"
+  },
+  {
+    "id": "KTG",
+    "british": false,
+    "label": "Ketapang(Rahadi Usman) Airport (Indonesia) (WIOK / KTG)"
+  },
+  {
+    "id": "PNK",
+    "british": false,
+    "label": "Supadio Airport (Indonesia) (WIOO / PNK)"
+  },
+  {
+    "id": "DJB",
+    "british": false,
+    "label": "Sultan Thaha Airport (Indonesia) (WIPA / DJB)"
+  },
+  {
+    "id": "BKS",
+    "british": false,
+    "label": "Fatmawati Soekarno Airport (Indonesia) (WIPL / BKS)"
+  },
+  {
+    "id": "PLM",
+    "british": false,
+    "label": "Sultan Mahmud Badaruddin II Airport (Indonesia) (WIPP / PLM)"
+  },
+  {
+    "id": "RGT",
+    "british": false,
+    "label": "Japura Airport (Indonesia) (WIPR / RGT)"
+  },
+  {
+    "id": "LSX",
+    "british": false,
+    "label": "Lhok Sukon Airport (Indonesia) (WITL / LSX)"
+  },
+  {
+    "id": "BTJ",
+    "british": false,
+    "label": "Sultan Iskandar Muda International Airport (Indonesia) (WITT / BTJ)"
+  },
+  {
+    "id": "WMAP",
+    "british": false,
+    "label": "Kluang Airport (Malaysia) (WMAP)"
+  },
+  {
+    "id": "AOR",
+    "british": false,
+    "label": "Sultan Abdul Halim Airport (Malaysia) (WMKA / AOR)"
+  },
+  {
+    "id": "BWH",
+    "british": false,
+    "label": "Butterworth Airport (Malaysia) (WMKB / BWH)"
+  },
+  {
+    "id": "KBR",
+    "british": false,
+    "label": "Sultan Ismail Petra Airport (Malaysia) (WMKC / KBR)"
+  },
+  {
+    "id": "KUA",
+    "british": false,
+    "label": "Kuantan Airport (Malaysia) (WMKD / KUA)"
+  },
+  {
+    "id": "KTE",
+    "british": false,
+    "label": "Kerteh Airport (Malaysia) (WMKE / KTE)"
+  },
+  {
+    "id": "WMKF",
+    "british": false,
+    "label": "Simpang Airport (Malaysia) (WMKF)"
+  },
+  {
+    "id": "IPH",
+    "british": false,
+    "label": "Sultan Azlan Shah Airport (Malaysia) (WMKI / IPH)"
+  },
+  {
+    "id": "JHB",
+    "british": false,
+    "label": "Senai International Airport (Malaysia) (WMKJ / JHB)"
+  },
+  {
+    "id": "KUL",
+    "british": false,
+    "label": "Kuala Lumpur International Airport (Malaysia) (WMKK / KUL)"
+  },
+  {
+    "id": "LGK",
+    "british": false,
+    "label": "Langkawi International Airport (Malaysia) (WMKL / LGK)"
+  },
+  {
+    "id": "MKZ",
+    "british": false,
+    "label": "Malacca Airport (Malaysia) (WMKM / MKZ)"
+  },
+  {
+    "id": "TGG",
+    "british": false,
+    "label": "Sultan Mahmud Airport (Malaysia) (WMKN / TGG)"
+  },
+  {
+    "id": "PEN",
+    "british": false,
+    "label": "Penang International Airport (Malaysia) (WMKP / PEN)"
+  },
+  {
+    "id": "UAI",
+    "british": false,
+    "label": "Suai Airport (East Timor) (WPDB / UAI)"
+  },
+  {
+    "id": "DIL",
+    "british": false,
+    "label": "Presidente Nicolau Lobato International Airport (East Timor) (WPDL / DIL)"
+  },
+  {
+    "id": "BCH",
+    "british": false,
+    "label": "Cakung Airport (East Timor) (WPEC / BCH)"
+  },
+  {
+    "id": "WSAG",
+    "british": false,
+    "label": "Sembawang Air Base (Singapore) (WSAG)"
+  },
+  {
+    "id": "QPG",
+    "british": false,
+    "label": "Paya Lebar Air Base (Singapore) (WSAP / QPG)"
+  },
+  {
+    "id": "TGA",
+    "british": false,
+    "label": "Tengah Air Base (Singapore) (WSAT / TGA)"
+  },
+  {
+    "id": "XSP",
+    "british": false,
+    "label": "Seletar Airport (Singapore) (WSSL / XSP)"
+  },
+  {
+    "id": "SIN",
+    "british": false,
+    "label": "Singapore Changi Airport (Singapore) (WSSS / SIN)"
+  },
+  {
+    "id": "ACF",
+    "british": false,
+    "label": "Brisbane Archerfield Airport (Australia) (YBAF / ACF)"
+  },
+  {
+    "id": "ABM",
+    "british": false,
+    "label": "Northern Peninsula Airport (Australia) (YBAM / ABM)"
+  },
+  {
+    "id": "ASP",
+    "british": false,
+    "label": "Alice Springs Airport (Australia) (YBAS / ASP)"
+  },
+  {
+    "id": "BNE",
+    "british": false,
+    "label": "Brisbane International Airport (Australia) (YBBN / BNE)"
+  },
+  {
+    "id": "OOL",
+    "british": false,
+    "label": "Gold Coast Airport (Australia) (YBCG / OOL)"
+  },
+  {
+    "id": "CNS",
+    "british": false,
+    "label": "Cairns International Airport (Australia) (YBCS / CNS)"
+  },
+  {
+    "id": "CTL",
+    "british": false,
+    "label": "Charleville Airport (Australia) (YBCV / CTL)"
+  },
+  {
+    "id": "ISA",
+    "british": false,
+    "label": "Mount Isa Airport (Australia) (YBMA / ISA)"
+  },
+  {
+    "id": "MCY",
+    "british": false,
+    "label": "Sunshine Coast Airport (Australia) (YBMC / MCY)"
+  },
+  {
+    "id": "MKY",
+    "british": false,
+    "label": "Mackay Airport (Australia) (YBMK / MKY)"
+  },
+  {
+    "id": "PPP",
+    "british": false,
+    "label": "Proserpine Whitsunday Coast Airport (Australia) (YBPN / PPP)"
+  },
+  {
+    "id": "ROK",
+    "british": false,
+    "label": "Rockhampton Airport (Australia) (YBRK / ROK)"
+  },
+  {
+    "id": "TSV",
+    "british": false,
+    "label": "Townsville Airport (Australia) (YBTL / TSV)"
+  },
+  {
+    "id": "WEI",
+    "british": false,
+    "label": "Weipa Airport (Australia) (YBWP / WEI)"
+  },
+  {
+    "id": "AVV",
+    "british": false,
+    "label": "Avalon Airport (Australia) (YMAV / AVV)"
+  },
+  {
+    "id": "ABX",
+    "british": false,
+    "label": "Albury Airport (Australia) (YMAY / ABX)"
+  },
+  {
+    "id": "MEB",
+    "british": false,
+    "label": "Melbourne Essendon Airport (Australia) (YMEN / MEB)"
+  },
+  {
+    "id": "YMES",
+    "british": false,
+    "label": "RAAF Base East Sale (Australia) (YMES)"
+  },
+  {
+    "id": "HBA",
+    "british": false,
+    "label": "Hobart International Airport (Australia) (YMHB / HBA)"
+  },
+  {
+    "id": "LST",
+    "british": false,
+    "label": "Launceston Airport (Australia) (YMLT / LST)"
+  },
+  {
+    "id": "MBW",
+    "british": false,
+    "label": "Melbourne Moorabbin Airport (Australia) (YMMB / MBW)"
+  },
+  {
+    "id": "MEL",
+    "british": false,
+    "label": "Melbourne International Airport (Australia) (YMML / MEL)"
+  },
+  {
+    "id": "YMPC",
+    "british": false,
+    "label": "RAAF Williams, Point Cook Base (Australia) (YMPC)"
+  },
+  {
+    "id": "ADL",
+    "british": false,
+    "label": "Adelaide International Airport (Australia) (YPAD / ADL)"
+  },
+  {
+    "id": "YPED",
+    "british": false,
+    "label": "RAAF Base Edinburgh (Australia) (YPED)"
+  },
+  {
+    "id": "JAD",
+    "british": false,
+    "label": "Perth Jandakot Airport (Australia) (YPJT / JAD)"
+  },
+  {
+    "id": "KTA",
+    "british": false,
+    "label": "Karratha Airport (Australia) (YPKA / KTA)"
+  },
+  {
+    "id": "KGI",
+    "british": false,
+    "label": "Kalgoorlie Boulder Airport (Australia) (YPKG / KGI)"
+  },
+  {
+    "id": "KNX",
+    "british": false,
+    "label": "Kununurra Airport (Australia) (YPKU / KNX)"
+  },
+  {
+    "id": "LEA",
+    "british": false,
+    "label": "Learmonth Airport (Australia) (YPLM / LEA)"
+  },
+  {
+    "id": "PHE",
+    "british": false,
+    "label": "Port Hedland International Airport (Australia) (YPPD / PHE)"
+  },
+  {
+    "id": "YPPF",
+    "british": false,
+    "label": "Adelaide Parafield Airport (Australia) (YPPF)"
+  },
+  {
+    "id": "PER",
+    "british": false,
+    "label": "Perth International Airport (Australia) (YPPH / PER)"
+  },
+  {
+    "id": "UMR",
+    "british": false,
+    "label": "Woomera Airfield (Australia) (YPWR / UMR)"
+  },
+  {
+    "id": "XCH",
+    "british": false,
+    "label": "Christmas Island Airport (Christmas Island) (YPXM / XCH)"
+  },
+  {
+    "id": "BWU",
+    "british": false,
+    "label": "Sydney Bankstown Airport (Australia) (YSBK / BWU)"
+  },
+  {
+    "id": "CBR",
+    "british": false,
+    "label": "Canberra International Airport (Australia) (YSCB / CBR)"
+  },
+  {
+    "id": "CFS",
+    "british": false,
+    "label": "Coffs Harbour Airport (Australia) (YSCH / CFS)"
+  },
+  {
+    "id": "CDU",
+    "british": false,
+    "label": "Camden Airport (Australia) (YSCN / CDU)"
+  },
+  {
+    "id": "DBO",
+    "british": false,
+    "label": "Dubbo City Regional Airport (Australia) (YSDU / DBO)"
+  },
+  {
+    "id": "NLK",
+    "british": false,
+    "label": "Norfolk Island International Airport (Norfolk Island) (YSNF / NLK)"
+  },
+  {
+    "id": "XRH",
+    "british": false,
+    "label": "RAAF Base Richmond (Australia) (YSRI / XRH)"
+  },
+  {
+    "id": "SYD",
+    "british": false,
+    "label": "Sydney Kingsford Smith International Airport (Australia) (YSSY / SYD)"
+  },
+  {
+    "id": "TMW",
+    "british": false,
+    "label": "Tamworth Airport (Australia) (YSTW / TMW)"
+  },
+  {
+    "id": "WGA",
+    "british": false,
+    "label": "Wagga Wagga City Airport (Australia) (YSWG / WGA)"
+  },
+  {
+    "id": "PEK",
+    "british": false,
+    "label": "Beijing Capital International Airport (China) (ZBAA / PEK)"
+  },
+  {
+    "id": "HLD",
+    "british": false,
+    "label": "Dongshan Airport (China) (ZBLA / HLD)"
+  },
+  {
+    "id": "TSN",
+    "british": false,
+    "label": "Tianjin Binhai International Airport (China) (ZBTJ / TSN)"
+  },
+  {
+    "id": "TYN",
+    "british": false,
+    "label": "Taiyuan Wusu Airport (China) (ZBYN / TYN)"
+  },
+  {
+    "id": "CAN",
+    "british": false,
+    "label": "Guangzhou Baiyun International Airport (China) (ZGGG / CAN)"
+  },
+  {
+    "id": "CSX",
+    "british": false,
+    "label": "Changsha Huanghua International Airport (China) (ZGHA / CSX)"
+  },
+  {
+    "id": "KWL",
+    "british": false,
+    "label": "Guilin Liangjiang International Airport (China) (ZGKL / KWL)"
+  },
+  {
+    "id": "NNG",
+    "british": false,
+    "label": "Nanning Wuxu Airport (China) (ZGNN / NNG)"
+  },
+  {
+    "id": "SZX",
+    "british": false,
+    "label": "Shenzhen Bao'an International Airport (China) (ZGSZ / SZX)"
+  },
+  {
+    "id": "CGO",
+    "british": false,
+    "label": "Zhengzhou Xinzheng International Airport (China) (ZHCC / CGO)"
+  },
+  {
+    "id": "WUH",
+    "british": false,
+    "label": "Wuhan Tianhe International Airport (China) (ZHHH / WUH)"
+  },
+  {
+    "id": "FNJ",
+    "british": false,
+    "label": "Pyongyang Sunan International Airport (North Korea) (ZKPY / FNJ)"
+  },
+  {
+    "id": "LHW",
+    "british": false,
+    "label": "Lanzhou Zhongchuan Airport (China) (ZLLL / LHW)"
+  },
+  {
+    "id": "XIY",
+    "british": false,
+    "label": "Xi'an Xianyang International Airport (China) (ZLXY / XIY)"
+  },
+  {
+    "id": "ULN",
+    "british": false,
+    "label": "Chinggis Khaan International Airport (Mongolia) (ZMUB / ULN)"
+  },
+  {
+    "id": "JHG",
+    "british": false,
+    "label": "Xishuangbanna Gasa Airport (China) (ZPJH / JHG)"
+  },
+  {
+    "id": "KMG",
+    "british": false,
+    "label": "Kunming Changshui International Airport (China) (ZPPP / KMG)"
+  },
+  {
+    "id": "XMN",
+    "british": false,
+    "label": "Xiamen Gaoqi International Airport (China) (ZSAM / XMN)"
+  },
+  {
+    "id": "KHN",
+    "british": false,
+    "label": "Nanchang Changbei International Airport (China) (ZSCN / KHN)"
+  },
+  {
+    "id": "FOC",
+    "british": false,
+    "label": "Fuzhou Changle International Airport (China) (ZSFZ / FOC)"
+  },
+  {
+    "id": "HGH",
+    "british": false,
+    "label": "Hangzhou Xiaoshan International Airport (China) (ZSHC / HGH)"
+  },
+  {
+    "id": "NGB",
+    "british": false,
+    "label": "Ningbo Lishe International Airport (China) (ZSNB / NGB)"
+  },
+  {
+    "id": "NKG",
+    "british": false,
+    "label": "Nanjing Lukou Airport (China) (ZSNJ / NKG)"
+  },
+  {
+    "id": "HFE",
+    "british": false,
+    "label": "Hefei Luogang International Airport (China) (ZSOF / HFE)"
+  },
+  {
+    "id": "TAO",
+    "british": false,
+    "label": "Liuting Airport (China) (ZSQD / TAO)"
+  },
+  {
+    "id": "SHA",
+    "british": false,
+    "label": "Shanghai Hongqiao International Airport (China) (ZSSS / SHA)"
+  },
+  {
+    "id": "YNT",
+    "british": false,
+    "label": "Yantai Laishan Airport (China) (ZSYT / YNT)"
+  },
+  {
+    "id": "CKG",
+    "british": false,
+    "label": "Chongqing Jiangbei International Airport (China) (ZUCK / CKG)"
+  },
+  {
+    "id": "KWE",
+    "british": false,
+    "label": "Longdongbao Airport (China) (ZUGY / KWE)"
+  },
+  {
+    "id": "CTU",
+    "british": false,
+    "label": "Chengdu Shuangliu International Airport (China) (ZUUU / CTU)"
+  },
+  {
+    "id": "XIC",
+    "british": false,
+    "label": "Xichang Qingshan Airport (China) (ZUXC / XIC)"
+  },
+  {
+    "id": "KHG",
+    "british": false,
+    "label": "Kashgar Airport (China) (ZWSH / KHG)"
+  },
+  {
+    "id": "HTN",
+    "british": false,
+    "label": "Hotan Airport (China) (ZWTN / HTN)"
+  },
+  {
+    "id": "URC",
+    "british": false,
+    "label": "Ürümqi Diwopu International Airport (China) (ZWWW / URC)"
+  },
+  {
+    "id": "HRB",
+    "british": false,
+    "label": "Taiping Airport (China) (ZYHB / HRB)"
+  },
+  {
+    "id": "MDG",
+    "british": false,
+    "label": "Mudanjiang Hailang International Airport (China) (ZYMD / MDG)"
+  },
+  {
+    "id": "DLC",
+    "british": false,
+    "label": "Zhoushuizi Airport (China) (ZYTL / DLC)"
+  },
+  {
+    "id": "PVG",
+    "british": false,
+    "label": "Shanghai Pudong International Airport (China) (ZSPD / PVG)"
+  },
+  {
+    "id": "TOD",
+    "british": false,
+    "label": "Pulau Tioman Airport (Malaysia) (WMBT / TOD)"
+  },
+  {
+    "id": "SZB",
+    "british": false,
+    "label": "Sultan Abdul Aziz Shah International Airport (Malaysia) (WMSA / SZB)"
+  },
+  {
+    "id": "NTQ",
+    "british": false,
+    "label": "Noto Airport (Japan) (RJNW / NTQ)"
+  },
+  {
+    "id": "HBE",
+    "british": false,
+    "label": "Borg El Arab International Airport (Egypt) (HEBA / HBE)"
+  },
+  {
+    "id": "BTI",
+    "british": false,
+    "label": "Barter Island LRRS Airport (United States) (PABA / BTI)"
+  },
+  {
+    "id": "PAWT",
+    "british": false,
+    "label": "Wainwright Air Station (United States) (PAWT)"
+  },
+  {
+    "id": "LUR",
+    "british": false,
+    "label": "Cape Lisburne LRRS Airport (United States) (PALU / LUR)"
+  },
+  {
+    "id": "PIZ",
+    "british": false,
+    "label": "Point Lay LRRS Airport (United States) (PPIZ / PIZ)"
+  },
+  {
+    "id": "ITO",
+    "british": false,
+    "label": "Hilo International Airport (United States) (PHTO / ITO)"
+  },
+  {
+    "id": "ORL",
+    "british": false,
+    "label": "Orlando Executive Airport (United States) (KORL / ORL)"
+  },
+  {
+    "id": "BTT",
+    "british": false,
+    "label": "Bettles Airport (United States) (PABT / BTT)"
+  },
+  {
+    "id": "PACL",
+    "british": false,
+    "label": "Clear Airport (United States) (PACL)"
+  },
+  {
+    "id": "UTO",
+    "british": false,
+    "label": "Indian Mountain LRRS Airport (United States) (PAIM / UTO)"
+  },
+  {
+    "id": "FYU",
+    "british": false,
+    "label": "Fort Yukon Airport (United States) (PFYU / FYU)"
+  },
+  {
+    "id": "SVW",
+    "british": false,
+    "label": "Sparrevohn LRRS Airport (United States) (PASV / SVW)"
+  },
+  {
+    "id": "FRN",
+    "british": false,
+    "label": "Bryant Army Heliport (United States) (PAFR / FRN)"
+  },
+  {
+    "id": "TLJ",
+    "british": false,
+    "label": "Tatalina LRRS Airport (United States) (PATL / TLJ)"
+  },
+  {
+    "id": "CZF",
+    "british": false,
+    "label": "Cape Romanzof LRRS Airport (United States) (PACZ / CZF)"
+  },
+  {
+    "id": "BED",
+    "british": false,
+    "label": "Laurence G Hanscom Field (United States) (KBED / BED)"
+  },
+  {
+    "id": "SNP",
+    "british": false,
+    "label": "St Paul Island Airport (United States) (PASN / SNP)"
+  },
+  {
+    "id": "EHM",
+    "british": false,
+    "label": "Cape Newenham LRRS Airport (United States) (PAEH / EHM)"
+  },
+  {
+    "id": "STG",
+    "british": false,
+    "label": "St George Airport (United States) (PAPB / STG)"
+  },
+  {
+    "id": "ILI",
+    "british": false,
+    "label": "Iliamna Airport (United States) (PAIL / ILI)"
+  },
+  {
+    "id": "PTU",
+    "british": false,
+    "label": "Platinum Airport (United States) (PAPM / PTU)"
+  },
+  {
+    "id": "BMX",
+    "british": false,
+    "label": "Big Mountain Airport (United States) (PABM / BMX)"
+  },
+  {
+    "id": "OSC",
+    "british": false,
+    "label": "Oscoda Wurtsmith Airport (United States) (KOSC / OSC)"
+  },
+  {
+    "id": "OAR",
+    "british": false,
+    "label": "Marina Municipal Airport (United States) (KOAR / OAR)"
+  },
+  {
+    "id": "MHR",
+    "british": false,
+    "label": "Sacramento Mather Airport (United States) (KMHR / MHR)"
+  },
+  {
+    "id": "BYS",
+    "british": false,
+    "label": "Bicycle Lake Army Air Field (United States) (KBYS / BYS)"
+  },
+  {
+    "id": "KNXP",
+    "british": false,
+    "label": "Twentynine Palms (Self) Airport (United States) (KNXP)"
+  },
+  {
+    "id": "FSM",
+    "british": false,
+    "label": "Fort Smith Regional Airport (United States) (KFSM / FSM)"
+  },
+  {
+    "id": "MRI",
+    "british": false,
+    "label": "Merrill Field (United States) (PAMR / MRI)"
+  },
+  {
+    "id": "GNT",
+    "british": false,
+    "label": "Grants-Milan Municipal Airport (United States) (KGNT / GNT)"
+  },
+  {
+    "id": "PNC",
+    "british": false,
+    "label": "Ponca City Regional Airport (United States) (KPNC / PNC)"
+  },
+  {
+    "id": "SVN",
+    "british": false,
+    "label": "Hunter Army Air Field (United States) (KSVN / SVN)"
+  },
+  {
+    "id": "GFK",
+    "british": false,
+    "label": "Grand Forks International Airport (United States) (KGFK / GFK)"
+  },
+  {
+    "id": "PBF",
+    "british": false,
+    "label": "Pine Bluff Regional Airport, Grider Field (United States) (KPBF / PBF)"
+  },
+  {
+    "id": "NSE",
+    "british": false,
+    "label": "Whiting Field Naval Air Station - North (United States) (KNSE / NSE)"
+  },
+  {
+    "id": "HNM",
+    "british": false,
+    "label": "Hana Airport (United States) (PHHN / HNM)"
+  },
+  {
+    "id": "PRC",
+    "british": false,
+    "label": "Ernest A. Love Field (United States) (KPRC / PRC)"
+  },
+  {
+    "id": "TTN",
+    "british": false,
+    "label": "Trenton Mercer Airport (United States) (KTTN / TTN)"
+  },
+  {
+    "id": "BOS",
+    "british": false,
+    "label": "General Edward Lawrence Logan International Airport (United States) (KBOS / BOS)"
+  },
+  {
+    "id": "SUU",
+    "british": false,
+    "label": "Travis Air Force Base (United States) (KSUU / SUU)"
+  },
+  {
+    "id": "RME",
+    "british": false,
+    "label": "Griffiss International Airport (United States) (KRME / RME)"
+  },
+  {
+    "id": "ENV",
+    "british": false,
+    "label": "Wendover Airport (United States) (KENV / ENV)"
+  },
+  {
+    "id": "BFM",
+    "british": false,
+    "label": "Mobile Downtown Airport (United States) (KBFM / BFM)"
+  },
+  {
+    "id": "OAK",
+    "british": false,
+    "label": "Metropolitan Oakland International Airport (United States) (KOAK / OAK)"
+  },
+  {
+    "id": "OMA",
+    "british": false,
+    "label": "Eppley Airfield (United States) (KOMA / OMA)"
+  },
+  {
+    "id": "KNOW",
+    "british": false,
+    "label": "Port Angeles Cgas Airport (United States) (KNOW)"
+  },
+  {
+    "id": "OGG",
+    "british": false,
+    "label": "Kahului Airport (United States) (PHOG / OGG)"
+  },
+  {
+    "id": "ICT",
+    "british": false,
+    "label": "Wichita Eisenhower National Airport (United States) (KICT / ICT)"
+  },
+  {
+    "id": "MCI",
+    "british": false,
+    "label": "Kansas City International Airport (United States) (KMCI / MCI)"
+  },
+  {
+    "id": "MSN",
+    "british": false,
+    "label": "Dane County Regional Truax Field (United States) (KMSN / MSN)"
+  },
+  {
+    "id": "DLG",
+    "british": false,
+    "label": "Dillingham Airport (United States) (PADL / DLG)"
+  },
+  {
+    "id": "HRO",
+    "british": false,
+    "label": "Boone County Airport (United States) (KHRO / HRO)"
+  },
+  {
+    "id": "PHX",
+    "british": false,
+    "label": "Phoenix Sky Harbor International Airport (United States) (KPHX / PHX)"
+  },
+  {
+    "id": "BGR",
+    "british": false,
+    "label": "Bangor International Airport (United States) (KBGR / BGR)"
+  },
+  {
+    "id": "FXE",
+    "british": false,
+    "label": "Fort Lauderdale Executive Airport (United States) (KFXE / FXE)"
+  },
+  {
+    "id": "GGG",
+    "british": false,
+    "label": "East Texas Regional Airport (United States) (KGGG / GGG)"
+  },
+  {
+    "id": "AND",
+    "british": false,
+    "label": "Anderson Regional Airport (United States) (KAND / AND)"
+  },
+  {
+    "id": "GEG",
+    "british": false,
+    "label": "Spokane International Airport (United States) (KGEG / GEG)"
+  },
+  {
+    "id": "HWO",
+    "british": false,
+    "label": "North Perry Airport (United States) (KHWO / HWO)"
+  },
+  {
+    "id": "SFO",
+    "british": false,
+    "label": "San Francisco International Airport (United States) (KSFO / SFO)"
+  },
+  {
+    "id": "CTB",
+    "british": false,
+    "label": "Cut Bank International Airport (United States) (KCTB / CTB)"
+  },
+  {
+    "id": "ARA",
+    "british": false,
+    "label": "Acadiana Regional Airport (United States) (KARA / ARA)"
+  },
+  {
+    "id": "GNV",
+    "british": false,
+    "label": "Gainesville Regional Airport (United States) (KGNV / GNV)"
+  },
+  {
+    "id": "MEM",
+    "british": false,
+    "label": "Memphis International Airport (United States) (KMEM / MEM)"
+  },
+  {
+    "id": "DUG",
+    "british": false,
+    "label": "Bisbee Douglas International Airport (United States) (KDUG / DUG)"
+  },
+  {
+    "id": "BIG",
+    "british": false,
+    "label": "Allen Army Airfield (United States) (PABI / BIG)"
+  },
+  {
+    "id": "CNW",
+    "british": false,
+    "label": "TSTC Waco Airport (United States) (KCNW / CNW)"
+  },
+  {
+    "id": "ANN",
+    "british": false,
+    "label": "Annette Island Airport (United States) (PANT / ANN)"
+  },
+  {
+    "id": "CAR",
+    "british": false,
+    "label": "Caribou Municipal Airport (United States) (KCAR / CAR)"
+  },
+  {
+    "id": "LRF",
+    "british": false,
+    "label": "Little Rock Air Force Base (United States) (KLRF / LRF)"
+  },
+  {
+    "id": "HUA",
+    "british": false,
+    "label": "Redstone Army Air Field (United States) (KHUA / HUA)"
+  },
+  {
+    "id": "POB",
+    "british": false,
+    "label": "Pope Field (United States) (KPOB / POB)"
+  },
+  {
+    "id": "DHT",
+    "british": false,
+    "label": "Dalhart Municipal Airport (United States) (KDHT / DHT)"
+  },
+  {
+    "id": "DLF",
+    "british": false,
+    "label": "DLF Airport (United States) (KDLF / DLF)"
+  },
+  {
+    "id": "LAX",
+    "british": false,
+    "label": "Los Angeles International Airport (United States) (KLAX / LAX)"
+  },
+  {
+    "id": "ANB",
+    "british": false,
+    "label": "Anniston Regional Airport (United States) (KANB / ANB)"
+  },
+  {
+    "id": "CLE",
+    "british": false,
+    "label": "Cleveland Hopkins International Airport (United States) (KCLE / CLE)"
+  },
+  {
+    "id": "DOV",
+    "british": false,
+    "label": "Dover Air Force Base (United States) (KDOV / DOV)"
+  },
+  {
+    "id": "CVG",
+    "british": false,
+    "label": "Cincinnati Northern Kentucky International Airport (United States) (KCVG / CVG)"
+  },
+  {
+    "id": "FME",
+    "british": false,
+    "label": "Tipton Airport (United States) (KFME / FME)"
+  },
+  {
+    "id": "KNID",
+    "british": false,
+    "label": "China Lake Naws (Armitage Field) Airport (United States) (KNID)"
+  },
+  {
+    "id": "HON",
+    "british": false,
+    "label": "Huron Regional Airport (United States) (KHON / HON)"
+  },
+  {
+    "id": "JNU",
+    "british": false,
+    "label": "Juneau International Airport (United States) (PAJN / JNU)"
+  },
+  {
+    "id": "LFT",
+    "british": false,
+    "label": "Lafayette Regional Airport (United States) (KLFT / LFT)"
+  },
+  {
+    "id": "EWR",
+    "british": false,
+    "label": "Newark Liberty International Airport (United States) (KEWR / EWR)"
+  },
+  {
+    "id": "BOI",
+    "british": false,
+    "label": "Boise Air Terminal/Gowen Field (United States) (KBOI / BOI)"
+  },
+  {
+    "id": "INS",
+    "british": false,
+    "label": "Creech Air Force Base (United States) (KINS / INS)"
+  },
+  {
+    "id": "GCK",
+    "british": false,
+    "label": "Garden City Regional Airport (United States) (KGCK / GCK)"
+  },
+  {
+    "id": "MOT",
+    "british": false,
+    "label": "Minot International Airport (United States) (KMOT / MOT)"
+  },
+  {
+    "id": "HHI",
+    "british": false,
+    "label": "Wheeler Army Airfield (United States) (PHHI / HHI)"
+  },
+  {
+    "id": "MXF",
+    "british": false,
+    "label": "Maxwell Air Force Base (United States) (KMXF / MXF)"
+  },
+  {
+    "id": "KRBM",
+    "british": false,
+    "label": "Robinson Army Air Field (United States) (KRBM)"
+  },
+  {
+    "id": "DAL",
+    "british": false,
+    "label": "Dallas Love Field (United States) (KDAL / DAL)"
+  },
+  {
+    "id": "FCS",
+    "british": false,
+    "label": "Butts AAF (Fort Carson) Air Field (United States) (KFCS / FCS)"
+  },
+  {
+    "id": "HLN",
+    "british": false,
+    "label": "Helena Regional Airport (United States) (KHLN / HLN)"
+  },
+  {
+    "id": "NKX",
+    "british": false,
+    "label": "Miramar Marine Corps Air Station - Mitscher Field (United States) (KNKX / NKX)"
+  },
+  {
+    "id": "LUF",
+    "british": false,
+    "label": "Luke Air Force Base (United States) (KLUF / LUF)"
+  },
+  {
+    "id": "KHRT",
+    "british": false,
+    "label": "Hurlburt Field (United States) (KHRT)"
+  },
+  {
+    "id": "HHR",
+    "british": false,
+    "label": "Jack Northrop Field Hawthorne Municipal Airport (United States) (KHHR / HHR)"
+  },
+  {
+    "id": "HUL",
+    "british": false,
+    "label": "Houlton International Airport (United States) (KHUL / HUL)"
+  },
+  {
+    "id": "END",
+    "british": false,
+    "label": "Vance Air Force Base (United States) (KEND / END)"
+  },
+  {
+    "id": "NTD",
+    "british": false,
+    "label": "Point Mugu Naval Air Station (Naval Base Ventura Co) (United States) (KNTD / NTD)"
+  },
+  {
+    "id": "EDW",
+    "british": false,
+    "label": "Edwards Air Force Base (United States) (KEDW / EDW)"
+  },
+  {
+    "id": "LCH",
+    "british": false,
+    "label": "Lake Charles Regional Airport (United States) (KLCH / LCH)"
+  },
+  {
+    "id": "KOA",
+    "british": false,
+    "label": "Ellison Onizuka Kona International At Keahole Airport (United States) (PHKO / KOA)"
+  },
+  {
+    "id": "MYR",
+    "british": false,
+    "label": "Myrtle Beach International Airport (United States) (KMYR / MYR)"
+  },
+  {
+    "id": "NLC",
+    "british": false,
+    "label": "Lemoore Naval Air Station (Reeves Field) Airport (United States) (KNLC / NLC)"
+  },
+  {
+    "id": "ACK",
+    "british": false,
+    "label": "Nantucket Memorial Airport (United States) (KACK / ACK)"
+  },
+  {
+    "id": "FAF",
+    "british": false,
+    "label": "Felker Army Air Field (United States) (KFAF / FAF)"
+  },
+  {
+    "id": "HOP",
+    "british": false,
+    "label": "Campbell AAF (Fort Campbell) Air Field (United States) (KHOP / HOP)"
+  },
+  {
+    "id": "DCA",
+    "british": false,
+    "label": "Ronald Reagan Washington National Airport (United States) (KDCA / DCA)"
+  },
+  {
+    "id": "NHK",
+    "british": false,
+    "label": "Patuxent River Naval Air Station (Trapnell Field) (United States) (KNHK / NHK)"
+  },
+  {
+    "id": "PSX",
+    "british": false,
+    "label": "Palacios Municipal Airport (United States) (KPSX / PSX)"
+  },
+  {
+    "id": "BYH",
+    "british": false,
+    "label": "Arkansas International Airport (United States) (KBYH / BYH)"
+  },
+  {
+    "id": "ACY",
+    "british": false,
+    "label": "Atlantic City International Airport (United States) (KACY / ACY)"
+  },
+  {
+    "id": "TIK",
+    "british": false,
+    "label": "Tinker Air Force Base (United States) (KTIK / TIK)"
+  },
+  {
+    "id": "ECG",
+    "british": false,
+    "label": "Elizabeth City Regional Airport & Coast Guard Air Station (United States) (KECG / ECG)"
+  },
+  {
+    "id": "PUB",
+    "british": false,
+    "label": "Pueblo Memorial Airport (United States) (KPUB / PUB)"
+  },
+  {
+    "id": "PQI",
+    "british": false,
+    "label": "Northern Maine Regional Airport at Presque Isle (United States) (KPQI / PQI)"
+  },
+  {
+    "id": "GRF",
+    "british": false,
+    "label": "Gray Army Air Field (United States) (KGRF / GRF)"
+  },
+  {
+    "id": "ADQ",
+    "british": false,
+    "label": "Kodiak Airport (United States) (PADQ / ADQ)"
+  },
+  {
+    "id": "UPP",
+    "british": false,
+    "label": "Upolu Airport (United States) (PHUP / UPP)"
+  },
+  {
+    "id": "FLL",
+    "british": false,
+    "label": "Fort Lauderdale Hollywood International Airport (United States) (KFLL / FLL)"
+  },
+  {
+    "id": "KMKO",
+    "british": false,
+    "label": "Muskogee-Davis Regional Airport (United States) (KMKO)"
+  },
+  {
+    "id": "INL",
+    "british": false,
+    "label": "Falls International Airport (United States) (KINL / INL)"
+  },
+  {
+    "id": "SLC",
+    "british": false,
+    "label": "Salt Lake City International Airport (United States) (KSLC / SLC)"
+  },
+  {
+    "id": "CDS",
+    "british": false,
+    "label": "Childress Municipal Airport (United States) (KCDS / CDS)"
+  },
+  {
+    "id": "BIX",
+    "british": false,
+    "label": "Keesler Air Force Base (United States) (KBIX / BIX)"
+  },
+  {
+    "id": "LSF",
+    "british": false,
+    "label": "Lawson Army Air Field (Fort Benning) (United States) (KLSF / LSF)"
+  },
+  {
+    "id": "NQI",
+    "british": false,
+    "label": "Kingsville Naval Air Station (United States) (KNQI / NQI)"
+  },
+  {
+    "id": "FRI",
+    "british": false,
+    "label": "Marshall Army Air Field (United States) (KFRI / FRI)"
+  },
+  {
+    "id": "MDT",
+    "british": false,
+    "label": "Harrisburg International Airport (United States) (KMDT / MDT)"
+  },
+  {
+    "id": "LNK",
+    "british": false,
+    "label": "Lincoln Airport (United States) (KLNK / LNK)"
+  },
+  {
+    "id": "LAN",
+    "british": false,
+    "label": "Capital City Airport (United States) (KLAN / LAN)"
+  },
+  {
+    "id": "MUE",
+    "british": false,
+    "label": "Waimea Kohala Airport (United States) (PHMU / MUE)"
+  },
+  {
+    "id": "MSS",
+    "british": false,
+    "label": "Massena International Richards Field (United States) (KMSS / MSS)"
+  },
+  {
+    "id": "HKY",
+    "british": false,
+    "label": "Hickory Regional Airport (United States) (KHKY / HKY)"
+  },
+  {
+    "id": "SPG",
+    "british": false,
+    "label": "Albert Whitted Airport (United States) (KSPG / SPG)"
+  },
+  {
+    "id": "FMY",
+    "british": false,
+    "label": "Page Field (United States) (KFMY / FMY)"
+  },
+  {
+    "id": "IAH",
+    "british": false,
+    "label": "George Bush Intercontinental Houston Airport (United States) (KIAH / IAH)"
+  },
+  {
+    "id": "KMLT",
+    "british": false,
+    "label": "Millinocket Municipal Airport (United States) (KMLT)"
+  },
+  {
+    "id": "ADW",
+    "british": false,
+    "label": "Joint Base Andrews (United States) (KADW / ADW)"
+  },
+  {
+    "id": "INT",
+    "british": false,
+    "label": "Smith Reynolds Airport (United States) (KINT / INT)"
+  },
+  {
+    "id": "VCV",
+    "british": false,
+    "label": "Southern California Logistics Airport (United States) (KVCV / VCV)"
+  },
+  {
+    "id": "CEW",
+    "british": false,
+    "label": "Bob Sikes Airport (United States) (KCEW / CEW)"
+  },
+  {
+    "id": "KGTB",
+    "british": false,
+    "label": "Wheeler Sack Army Air Field (United States) (KGTB)"
+  },
+  {
+    "id": "PHN",
+    "british": false,
+    "label": "St Clair County International Airport (United States) (KPHN / PHN)"
+  },
+  {
+    "id": "BFL",
+    "british": false,
+    "label": "Meadows Field (United States) (KBFL / BFL)"
+  },
+  {
+    "id": "ELP",
+    "british": false,
+    "label": "El Paso International Airport (United States) (KELP / ELP)"
+  },
+  {
+    "id": "HRL",
+    "british": false,
+    "label": "Valley International Airport (United States) (KHRL / HRL)"
+  },
+  {
+    "id": "CAE",
+    "british": false,
+    "label": "Columbia Metropolitan Airport (United States) (KCAE / CAE)"
+  },
+  {
+    "id": "DMA",
+    "british": false,
+    "label": "Davis Monthan Air Force Base (United States) (KDMA / DMA)"
+  },
+  {
+    "id": "NPA",
+    "british": false,
+    "label": "Pensacola Naval Air Station/Forrest Sherman Field (United States) (KNPA / NPA)"
+  },
+  {
+    "id": "PNS",
+    "british": false,
+    "label": "Pensacola Regional Airport (United States) (KPNS / PNS)"
+  },
+  {
+    "id": "RDR",
+    "british": false,
+    "label": "Grand Forks Air Force Base (United States) (KRDR / RDR)"
+  },
+  {
+    "id": "HOU",
+    "british": false,
+    "label": "William P Hobby Airport (United States) (KHOU / HOU)"
+  },
+  {
+    "id": "BFK",
+    "british": false,
+    "label": "Buckley Air Force Base (United States) (KBKF / BFK)"
+  },
+  {
+    "id": "ORT",
+    "british": false,
+    "label": "Northway Airport (United States) (PAOR / ORT)"
+  },
+  {
+    "id": "PAQ",
+    "british": false,
+    "label": "Warren \"Bud\" Woods Palmer Municipal Airport (United States) (PAAQ / PAQ)"
+  },
+  {
+    "id": "PIT",
+    "british": false,
+    "label": "Pittsburgh International Airport (United States) (KPIT / PIT)"
+  },
+  {
+    "id": "BRW",
+    "british": false,
+    "label": "Wiley Post Will Rogers Memorial Airport (United States) (PABR / BRW)"
+  },
+  {
+    "id": "EFD",
+    "british": false,
+    "label": "Ellington Airport (United States) (KEFD / EFD)"
+  },
+  {
+    "id": "NUW",
+    "british": false,
+    "label": "Whidbey Island Naval Air Station (Ault Field) (United States) (KNUW / NUW)"
+  },
+  {
+    "id": "ALI",
+    "british": false,
+    "label": "Alice International Airport (United States) (KALI / ALI)"
+  },
+  {
+    "id": "VAD",
+    "british": false,
+    "label": "Moody Air Force Base (United States) (KVAD / VAD)"
+  },
+  {
+    "id": "MIA",
+    "british": false,
+    "label": "Miami International Airport (United States) (KMIA / MIA)"
+  },
+  {
+    "id": "SEA",
+    "british": false,
+    "label": "Seattle Tacoma International Airport (United States) (KSEA / SEA)"
+  },
+  {
+    "id": "CHA",
+    "british": false,
+    "label": "Lovell Field (United States) (KCHA / CHA)"
+  },
+  {
+    "id": "BDR",
+    "british": false,
+    "label": "Igor I Sikorsky Memorial Airport (United States) (KBDR / BDR)"
+  },
+  {
+    "id": "JAN",
+    "british": false,
+    "label": "Jackson-Medgar Wiley Evers International Airport (United States) (KJAN / JAN)"
+  },
+  {
+    "id": "GLS",
+    "british": false,
+    "label": "Scholes International At Galveston Airport (United States) (KGLS / GLS)"
+  },
+  {
+    "id": "LGB",
+    "british": false,
+    "label": "Long Beach /Daugherty Field/ Airport (United States) (KLGB / LGB)"
+  },
+  {
+    "id": "HDH",
+    "british": false,
+    "label": "Dillingham Airfield (United States) (PHDH / HDH)"
+  },
+  {
+    "id": "IPT",
+    "british": false,
+    "label": "Williamsport Regional Airport (United States) (KIPT / IPT)"
+  },
+  {
+    "id": "IND",
+    "british": false,
+    "label": "Indianapolis International Airport (United States) (KIND / IND)"
+  },
+  {
+    "id": "SZL",
+    "british": false,
+    "label": "Whiteman Air Force Base (United States) (KSZL / SZL)"
+  },
+  {
+    "id": "AKC",
+    "british": false,
+    "label": "Akron Fulton International Airport (United States) (KAKR / AKC)"
+  },
+  {
+    "id": "GWO",
+    "british": false,
+    "label": "Greenwood–Leflore Airport (United States) (KGWO / GWO)"
+  },
+  {
+    "id": "HPN",
+    "british": false,
+    "label": "Westchester County Airport (United States) (KHPN / HPN)"
+  },
+  {
+    "id": "FOK",
+    "british": false,
+    "label": "Francis S Gabreski Airport (United States) (KFOK / FOK)"
+  },
+  {
+    "id": "JBR",
+    "british": false,
+    "label": "Jonesboro Municipal Airport (United States) (KJBR / JBR)"
+  },
+  {
+    "id": "XSD",
+    "british": false,
+    "label": "Tonopah Test Range Airport (United States) (KTNX / XSD)"
+  },
+  {
+    "id": "LNA",
+    "british": false,
+    "label": "Palm Beach County Park Airport (United States) (KLNA / LNA)"
+  },
+  {
+    "id": "NZY",
+    "british": false,
+    "label": "North Island Naval Air Station-Halsey Field (United States) (KNZY / NZY)"
+  },
+  {
+    "id": "BIF",
+    "british": false,
+    "label": "Biggs Army Air Field (Fort Bliss) (United States) (KBIF / BIF)"
+  },
+  {
+    "id": "YUM",
+    "british": false,
+    "label": "Yuma MCAS/Yuma International Airport (United States) (KNYL / YUM)"
+  },
+  {
+    "id": "CNM",
+    "british": false,
+    "label": "Cavern City Air Terminal (United States) (KCNM / CNM)"
+  },
+  {
+    "id": "DLH",
+    "british": false,
+    "label": "Duluth International Airport (United States) (KDLH / DLH)"
+  },
+  {
+    "id": "BET",
+    "british": false,
+    "label": "Bethel Airport (United States) (PABE / BET)"
+  },
+  {
+    "id": "LOU",
+    "british": false,
+    "label": "Bowman Field (United States) (KLOU / LOU)"
+  },
+  {
+    "id": "FHU",
+    "british": false,
+    "label": "Sierra Vista Municipal Libby Army Air Field (United States) (KFHU / FHU)"
+  },
+  {
+    "id": "LIH",
+    "british": false,
+    "label": "Lihue Airport (United States) (PHLI / LIH)"
+  },
+  {
+    "id": "HUF",
+    "british": false,
+    "label": "Terre Haute Regional Airport, Hulman Field (United States) (KHUF / HUF)"
+  },
+  {
+    "id": "HVR",
+    "british": false,
+    "label": "Havre City County Airport (United States) (KHVR / HVR)"
+  },
+  {
+    "id": "MWH",
+    "british": false,
+    "label": "Grant County International Airport (United States) (KMWH / MWH)"
+  },
+  {
+    "id": "MPV",
+    "british": false,
+    "label": "Edward F Knapp State Airport (United States) (KMPV / MPV)"
+  },
+  {
+    "id": "KNSI",
+    "british": false,
+    "label": "San Nicolas Island Nolf Airport (United States) (KNSI)"
+  },
+  {
+    "id": "RIC",
+    "british": false,
+    "label": "Richmond International Airport (United States) (KRIC / RIC)"
+  },
+  {
+    "id": "SHV",
+    "british": false,
+    "label": "Shreveport Regional Airport (United States) (KSHV / SHV)"
+  },
+  {
+    "id": "CDV",
+    "british": false,
+    "label": "Merle K (Mudhole) Smith Airport (United States) (PACV / CDV)"
+  },
+  {
+    "id": "ORF",
+    "british": false,
+    "label": "Norfolk International Airport (United States) (KORF / ORF)"
+  },
+  {
+    "id": "BPT",
+    "british": false,
+    "label": "Southeast Texas Regional Airport (United States) (KBPT / BPT)"
+  },
+  {
+    "id": "SAV",
+    "british": false,
+    "label": "Savannah Hilton Head International Airport (United States) (KSAV / SAV)"
+  },
+  {
+    "id": "HIF",
+    "british": false,
+    "label": "Hill Air Force Base (United States) (KHIF / HIF)"
+  },
+  {
+    "id": "OME",
+    "british": false,
+    "label": "Nome Airport (United States) (PAOM / OME)"
+  },
+  {
+    "id": "KSPB",
+    "british": false,
+    "label": "Scappoose Industrial Airpark (United States) (KSPB)"
+  },
+  {
+    "id": "PIE",
+    "british": false,
+    "label": "St Petersburg Clearwater International Airport (United States) (KPIE / PIE)"
+  },
+  {
+    "id": "MNM",
+    "british": false,
+    "label": "Menominee Regional Airport (United States) (KMNM / MNM)"
+  },
+  {
+    "id": "CXO",
+    "british": false,
+    "label": "Conroe-North Houston Regional Airport (United States) (KCXO / CXO)"
+  },
+  {
+    "id": "SCC",
+    "british": false,
+    "label": "Deadhorse Airport (United States) (PASC / SCC)"
+  },
+  {
+    "id": "SAT",
+    "british": false,
+    "label": "San Antonio International Airport (United States) (KSAT / SAT)"
+  },
+  {
+    "id": "ROC",
+    "british": false,
+    "label": "Greater Rochester International Airport (United States) (KROC / ROC)"
+  },
+  {
+    "id": "COF",
+    "british": false,
+    "label": "Patrick Air Force Base (United States) (KCOF / COF)"
+  },
+  {
+    "id": "TEB",
+    "british": false,
+    "label": "Teterboro Airport (United States) (KTEB / TEB)"
+  },
+  {
+    "id": "RCA",
+    "british": false,
+    "label": "Ellsworth Air Force Base (United States) (KRCA / RCA)"
+  },
+  {
+    "id": "RDU",
+    "british": false,
+    "label": "Raleigh Durham International Airport (United States) (KRDU / RDU)"
+  },
+  {
+    "id": "DAY",
+    "british": false,
+    "label": "James M Cox Dayton International Airport (United States) (KDAY / DAY)"
+  },
+  {
+    "id": "ENA",
+    "british": false,
+    "label": "Kenai Municipal Airport (United States) (PAEN / ENA)"
+  },
+  {
+    "id": "MLC",
+    "british": false,
+    "label": "Mc Alester Regional Airport (United States) (KMLC / MLC)"
+  },
+  {
+    "id": "IAG",
+    "british": false,
+    "label": "Niagara Falls International Airport (United States) (KIAG / IAG)"
+  },
+  {
+    "id": "CFD",
+    "british": false,
+    "label": "Coulter Field (United States) (KCFD / CFD)"
+  },
+  {
+    "id": "LIY",
+    "british": false,
+    "label": "Wright AAF (Fort Stewart)/Midcoast Regional Airport (United States) (KLHW / LIY)"
+  },
+  {
+    "id": "PHF",
+    "british": false,
+    "label": "Newport News Williamsburg International Airport (United States) (KPHF / PHF)"
+  },
+  {
+    "id": "ESF",
+    "british": false,
+    "label": "Esler Regional Airport (United States) (KESF / ESF)"
+  },
+  {
+    "id": "LTS",
+    "british": false,
+    "label": "Altus Air Force Base (United States) (KLTS / LTS)"
+  },
+  {
+    "id": "TUS",
+    "british": false,
+    "label": "Tucson International Airport (United States) (KTUS / TUS)"
+  },
+  {
+    "id": "MIB",
+    "british": false,
+    "label": "Minot Air Force Base (United States) (KMIB / MIB)"
+  },
+  {
+    "id": "BAB",
+    "british": false,
+    "label": "Beale Air Force Base (United States) (KBAB / BAB)"
+  },
+  {
+    "id": "IKK",
+    "british": false,
+    "label": "Greater Kankakee Airport (United States) (KIKK / IKK)"
+  },
+  {
+    "id": "GSB",
+    "british": false,
+    "label": "Seymour Johnson Air Force Base (United States) (KGSB / GSB)"
+  },
+  {
+    "id": "PVD",
+    "british": false,
+    "label": "Theodore Francis Green State Airport (United States) (KPVD / PVD)"
+  },
+  {
+    "id": "SBY",
+    "british": false,
+    "label": "Salisbury Ocean City Wicomico Regional Airport (United States) (KSBY / SBY)"
+  },
+  {
+    "id": "KRIU",
+    "british": false,
+    "label": "Rancho Murieta Airport (United States) (KRIU)"
+  },
+  {
+    "id": "BUR",
+    "british": false,
+    "label": "Bob Hope Airport (United States) (KBUR / BUR)"
+  },
+  {
+    "id": "DTW",
+    "british": false,
+    "label": "Detroit Metropolitan Wayne County Airport (United States) (KDTW / DTW)"
+  },
+  {
+    "id": "TPA",
+    "british": false,
+    "label": "Tampa International Airport (United States) (KTPA / TPA)"
+  },
+  {
+    "id": "PMB",
+    "british": false,
+    "label": "Pembina Municipal Airport (United States) (KPMB / PMB)"
+  },
+  {
+    "id": "POE",
+    "british": false,
+    "label": "Polk Army Air Field (United States) (KPOE / POE)"
+  },
+  {
+    "id": "EIL",
+    "british": false,
+    "label": "Eielson Air Force Base (United States) (PAEI / EIL)"
+  },
+  {
+    "id": "HIB",
+    "british": false,
+    "label": "Range Regional Airport (United States) (KHIB / HIB)"
+  },
+  {
+    "id": "LFK",
+    "british": false,
+    "label": "Angelina County Airport (United States) (KLFK / LFK)"
+  },
+  {
+    "id": "MAF",
+    "british": false,
+    "label": "Midland International Airport (United States) (KMAF / MAF)"
+  },
+  {
+    "id": "GRB",
+    "british": false,
+    "label": "Austin Straubel International Airport (United States) (KGRB / GRB)"
+  },
+  {
+    "id": "ADM",
+    "british": false,
+    "label": "Ardmore Municipal Airport (United States) (KADM / ADM)"
+  },
+  {
+    "id": "WRI",
+    "british": false,
+    "label": "Mc Guire Air Force Base (United States) (KWRI / WRI)"
+  },
+  {
+    "id": "KNKT",
+    "british": false,
+    "label": "Cherry Point MCAS /Cunningham Field/ (United States) (KNKT)"
+  },
+  {
+    "id": "KSBO",
+    "british": false,
+    "label": "Emanuel County Airport (United States) (KSBO)"
+  },
+  {
+    "id": "AGS",
+    "british": false,
+    "label": "Augusta Regional At Bush Field (United States) (KAGS / AGS)"
+  },
+  {
+    "id": "ISN",
+    "british": false,
+    "label": "Sloulin Field International Airport (United States) (KISN / ISN)"
+  },
+  {
+    "id": "LIT",
+    "british": false,
+    "label": "Bill & Hillary Clinton National Airport/Adams Field (United States) (KLIT / LIT)"
+  },
+  {
+    "id": "SWF",
+    "british": false,
+    "label": "Stewart International Airport (United States) (KSWF / SWF)"
+  },
+  {
+    "id": "BDE",
+    "british": false,
+    "label": "Baudette International Airport (United States) (KBDE / BDE)"
+  },
+  {
+    "id": "SAC",
+    "british": false,
+    "label": "Sacramento Executive Airport (United States) (KSAC / SAC)"
+  },
+  {
+    "id": "HOM",
+    "british": false,
+    "label": "Homer Airport (United States) (PAHO / HOM)"
+  },
+  {
+    "id": "TBN",
+    "british": false,
+    "label": "Waynesville-St. Robert Regional Forney field (United States) (KTBN / TBN)"
+  },
+  {
+    "id": "MGE",
+    "british": false,
+    "label": "Dobbins Air Reserve Base (United States) (KMGE / MGE)"
+  },
+  {
+    "id": "SKA",
+    "british": false,
+    "label": "Fairchild Air Force Base (United States) (KSKA / SKA)"
+  },
+  {
+    "id": "HTL",
+    "british": false,
+    "label": "Roscommon County - Blodgett Memorial Airport (United States) (KHTL / HTL)"
+  },
+  {
+    "id": "PAM",
+    "british": false,
+    "label": "Tyndall Air Force Base (United States) (KPAM / PAM)"
+  },
+  {
+    "id": "DFW",
+    "british": false,
+    "label": "Dallas Fort Worth International Airport (United States) (KDFW / DFW)"
+  },
+  {
+    "id": "MLB",
+    "british": false,
+    "label": "Melbourne International Airport (United States) (KMLB / MLB)"
+  },
+  {
+    "id": "TCM",
+    "british": false,
+    "label": "McChord Air Force Base (United States) (KTCM / TCM)"
+  },
+  {
+    "id": "AUS",
+    "british": false,
+    "label": "Austin Bergstrom International Airport (United States) (KAUS / AUS)"
+  },
+  {
+    "id": "LCK",
+    "british": false,
+    "label": "Rickenbacker International Airport (United States) (KLCK / LCK)"
+  },
+  {
+    "id": "MQT",
+    "british": false,
+    "label": "Sawyer International Airport (United States) (KSAW / MQT)"
+  },
+  {
+    "id": "TYS",
+    "british": false,
+    "label": "McGhee Tyson Airport (United States) (KTYS / TYS)"
+  },
+  {
+    "id": "HLR",
+    "british": false,
+    "label": "Hood Army Air Field (United States) (KHLR / HLR)"
+  },
+  {
+    "id": "STL",
+    "british": false,
+    "label": "St Louis Lambert International Airport (United States) (KSTL / STL)"
+  },
+  {
+    "id": "MIV",
+    "british": false,
+    "label": "Millville Municipal Airport (United States) (KMIV / MIV)"
+  },
+  {
+    "id": "SPS",
+    "british": false,
+    "label": "Sheppard Air Force Base-Wichita Falls Municipal Airport (United States) (KSPS / SPS)"
+  },
+  {
+    "id": "LUK",
+    "british": false,
+    "label": "Cincinnati Municipal Airport Lunken Field (United States) (KLUK / LUK)"
+  },
+  {
+    "id": "ATL",
+    "british": false,
+    "label": "Hartsfield Jackson Atlanta International Airport (United States) (KATL / ATL)"
+  },
+  {
+    "id": "MER",
+    "british": false,
+    "label": "Castle Airport (United States) (KMER / MER)"
+  },
+  {
+    "id": "MCC",
+    "british": false,
+    "label": "Mc Clellan Airfield (United States) (KMCC / MCC)"
+  },
+  {
+    "id": "GRR",
+    "british": false,
+    "label": "Gerald R. Ford International Airport (United States) (KGRR / GRR)"
+  },
+  {
+    "id": "INK",
+    "british": false,
+    "label": "Winkler County Airport (United States) (KINK / INK)"
+  },
+  {
+    "id": "FAT",
+    "british": false,
+    "label": "Fresno Yosemite International Airport (United States) (KFAT / FAT)"
+  },
+  {
+    "id": "VRB",
+    "british": false,
+    "label": "Vero Beach Regional Airport (United States) (KVRB / VRB)"
+  },
+  {
+    "id": "IPL",
+    "british": false,
+    "label": "Imperial County Airport (United States) (KIPL / IPL)"
+  },
+  {
+    "id": "BNA",
+    "british": false,
+    "label": "Nashville International Airport (United States) (KBNA / BNA)"
+  },
+  {
+    "id": "LRD",
+    "british": false,
+    "label": "Laredo International Airport (United States) (KLRD / LRD)"
+  },
+  {
+    "id": "EDF",
+    "british": false,
+    "label": "Elmendorf Air Force Base (United States) (PAED / EDF)"
+  },
+  {
+    "id": "OTZ",
+    "british": false,
+    "label": "Ralph Wien Memorial Airport (United States) (PAOT / OTZ)"
+  },
+  {
+    "id": "AOO",
+    "british": false,
+    "label": "Altoona Blair County Airport (United States) (KAOO / AOO)"
+  },
+  {
+    "id": "DYS",
+    "british": false,
+    "label": "Dyess Air Force Base (United States) (KDYS / DYS)"
+  },
+  {
+    "id": "ELD",
+    "british": false,
+    "label": "South Arkansas Regional At Goodwin Field (United States) (KELD / ELD)"
+  },
+  {
+    "id": "LGA",
+    "british": false,
+    "label": "La Guardia Airport (United States) (KLGA / LGA)"
+  },
+  {
+    "id": "TLH",
+    "british": false,
+    "label": "Tallahassee Regional Airport (United States) (KTLH / TLH)"
+  },
+  {
+    "id": "DPA",
+    "british": false,
+    "label": "Dupage Airport (United States) (KDPA / DPA)"
+  },
+  {
+    "id": "ACT",
+    "british": false,
+    "label": "Waco Regional Airport (United States) (KACT / ACT)"
+  },
+  {
+    "id": "AUG",
+    "british": false,
+    "label": "Augusta State Airport (United States) (KAUG / AUG)"
+  },
+  {
+    "id": "KINJ",
+    "british": false,
+    "label": "Hillsboro Municipal Airport (United States) (KINJ)"
+  },
+  {
+    "id": "NIP",
+    "british": false,
+    "label": "Jacksonville Naval Air Station (Towers Field) (United States) (KNIP / NIP)"
+  },
+  {
+    "id": "MKL",
+    "british": false,
+    "label": "McKellar-Sipes Regional Airport (United States) (KMKL / MKL)"
+  },
+  {
+    "id": "MKK",
+    "british": false,
+    "label": "Molokai Airport (United States) (PHMK / MKK)"
+  },
+  {
+    "id": "FTK",
+    "british": false,
+    "label": "Godman Army Air Field (United States) (KFTK / FTK)"
+  },
+  {
+    "id": "KNCA",
+    "british": false,
+    "label": "New River MCAS /H/ /Mccutcheon Fld/ Airport (United States) (KNCA)"
+  },
+  {
+    "id": "SJT",
+    "british": false,
+    "label": "San Angelo Regional Mathis Field (United States) (KSJT / SJT)"
+  },
+  {
+    "id": "CXL",
+    "british": false,
+    "label": "Calexico International Airport (United States) (KCXL / CXL)"
+  },
+  {
+    "id": "CIC",
+    "british": false,
+    "label": "Chico Municipal Airport (United States) (KCIC / CIC)"
+  },
+  {
+    "id": "BTV",
+    "british": false,
+    "label": "Burlington International Airport (United States) (KBTV / BTV)"
+  },
+  {
+    "id": "JAX",
+    "british": false,
+    "label": "Jacksonville International Airport (United States) (KJAX / JAX)"
+  },
+  {
+    "id": "DRO",
+    "british": false,
+    "label": "Durango La Plata County Airport (United States) (KDRO / DRO)"
+  },
+  {
+    "id": "IAD",
+    "british": false,
+    "label": "Washington Dulles International Airport (United States) (KIAD / IAD)"
+  },
+  {
+    "id": "CLL",
+    "british": false,
+    "label": "Easterwood Field (United States) (KCLL / CLL)"
+  },
+  {
+    "id": "SFF",
+    "british": false,
+    "label": "Felts Field (United States) (KSFF / SFF)"
+  },
+  {
+    "id": "MKE",
+    "british": false,
+    "label": "General Mitchell International Airport (United States) (KMKE / MKE)"
+  },
+  {
+    "id": "ABI",
+    "british": false,
+    "label": "Abilene Regional Airport (United States) (KABI / ABI)"
+  },
+  {
+    "id": "COU",
+    "british": false,
+    "label": "Columbia Regional Airport (United States) (KCOU / COU)"
+  },
+  {
+    "id": "PDX",
+    "british": false,
+    "label": "Portland International Airport (United States) (KPDX / PDX)"
+  },
+  {
+    "id": "TNT",
+    "british": false,
+    "label": "Dade Collier Training and Transition Airport (United States) (KTNT / TNT)"
+  },
+  {
+    "id": "PBI",
+    "british": false,
+    "label": "Palm Beach International Airport (United States) (KPBI / PBI)"
+  },
+  {
+    "id": "FTW",
+    "british": false,
+    "label": "Fort Worth Meacham International Airport (United States) (KFTW / FTW)"
+  },
+  {
+    "id": "OGS",
+    "british": false,
+    "label": "Ogdensburg International Airport (United States) (KOGS / OGS)"
+  },
+  {
+    "id": "FMH",
+    "british": false,
+    "label": "Cape Cod Coast Guard Air Station (United States) (KFMH / FMH)"
+  },
+  {
+    "id": "BFI",
+    "british": false,
+    "label": "Boeing Field King County International Airport (United States) (KBFI / BFI)"
+  },
+  {
+    "id": "SKF",
+    "british": false,
+    "label": "Lackland Air Force Base (United States) (KSKF / SKF)"
+  },
+  {
+    "id": "HNL",
+    "british": false,
+    "label": "Daniel K Inouye International Airport (United States) (PHNL / HNL)"
+  },
+  {
+    "id": "DSM",
+    "british": false,
+    "label": "Des Moines International Airport (United States) (KDSM / DSM)"
+  },
+  {
+    "id": "EWN",
+    "british": false,
+    "label": "Coastal Carolina Regional Airport (United States) (KEWN / EWN)"
+  },
+  {
+    "id": "SAN",
+    "british": false,
+    "label": "San Diego International Airport (United States) (KSAN / SAN)"
+  },
+  {
+    "id": "MLU",
+    "british": false,
+    "label": "Monroe Regional Airport (United States) (KMLU / MLU)"
+  },
+  {
+    "id": "SSC",
+    "british": false,
+    "label": "Shaw Air Force Base (United States) (KSSC / SSC)"
+  },
+  {
+    "id": "ONT",
+    "british": false,
+    "label": "Ontario International Airport (United States) (KONT / ONT)"
+  },
+  {
+    "id": "GVT",
+    "british": false,
+    "label": "Majors Airport (United States) (KGVT / GVT)"
+  },
+  {
+    "id": "ROW",
+    "british": false,
+    "label": "Roswell International Air Center Airport (United States) (KROW / ROW)"
+  },
+  {
+    "id": "DET",
+    "british": false,
+    "label": "Coleman A. Young Municipal Airport (United States) (KDET / DET)"
+  },
+  {
+    "id": "BRO",
+    "british": false,
+    "label": "Brownsville South Padre Island International Airport (United States) (KBRO / BRO)"
+  },
+  {
+    "id": "DHN",
+    "british": false,
+    "label": "Dothan Regional Airport (United States) (KDHN / DHN)"
+  },
+  {
+    "id": "WWD",
+    "british": false,
+    "label": "Cape May County Airport (United States) (KWWD / WWD)"
+  },
+  {
+    "id": "NFL",
+    "british": false,
+    "label": "Fallon Naval Air Station (United States) (KNFL / NFL)"
+  },
+  {
+    "id": "MTC",
+    "british": false,
+    "label": "Selfridge Air National Guard Base Airport (United States) (KMTC / MTC)"
+  },
+  {
+    "id": "FMN",
+    "british": false,
+    "label": "Four Corners Regional Airport (United States) (KFMN / FMN)"
+  },
+  {
+    "id": "CRP",
+    "british": false,
+    "label": "Corpus Christi International Airport (United States) (KCRP / CRP)"
+  },
+  {
+    "id": "SYR",
+    "british": false,
+    "label": "Syracuse Hancock International Airport (United States) (KSYR / SYR)"
+  },
+  {
+    "id": "NQX",
+    "british": false,
+    "label": "Naval Air Station Key West/Boca Chica Field (United States) (KNQX / NQX)"
+  },
+  {
+    "id": "MDW",
+    "british": false,
+    "label": "Chicago Midway International Airport (United States) (KMDW / MDW)"
+  },
+  {
+    "id": "SJC",
+    "british": false,
+    "label": "Norman Y. Mineta San Jose International Airport (United States) (KSJC / SJC)"
+  },
+  {
+    "id": "HOB",
+    "british": false,
+    "label": "Lea County Regional Airport (United States) (KHOB / HOB)"
+  },
+  {
+    "id": "PNE",
+    "british": false,
+    "label": "Northeast Philadelphia Airport (United States) (KPNE / PNE)"
+  },
+  {
+    "id": "DEN",
+    "british": false,
+    "label": "Denver International Airport (United States) (KDEN / DEN)"
+  },
+  {
+    "id": "PHL",
+    "british": false,
+    "label": "Philadelphia International Airport (United States) (KPHL / PHL)"
+  },
+  {
+    "id": "SUX",
+    "british": false,
+    "label": "Sioux Gateway Col. Bud Day Field (United States) (KSUX / SUX)"
+  },
+  {
+    "id": "MCN",
+    "british": false,
+    "label": "Middle Georgia Regional Airport (United States) (KMCN / MCN)"
+  },
+  {
+    "id": "TCS",
+    "british": false,
+    "label": "Truth Or Consequences Municipal Airport (United States) (KTCS / TCS)"
+  },
+  {
+    "id": "PMD",
+    "british": false,
+    "label": "Palmdale Regional/USAF Plant 42 Airport (United States) (KPMD / PMD)"
+  },
+  {
+    "id": "RND",
+    "british": false,
+    "label": "Randolph Air Force Base (United States) (KRND / RND)"
+  },
+  {
+    "id": "NJK",
+    "british": false,
+    "label": "El Centro NAF Airport (Vraciu Field) (United States) (KNJK / NJK)"
+  },
+  {
+    "id": "CMH",
+    "british": false,
+    "label": "John Glenn Columbus International Airport (United States) (KCMH / CMH)"
+  },
+  {
+    "id": "FYV",
+    "british": false,
+    "label": "Drake Field (United States) (KFYV / FYV)"
+  },
+  {
+    "id": "FSI",
+    "british": false,
+    "label": "Henry Post Army Air Field (Fort Sill) (United States) (KFSI / FSI)"
+  },
+  {
+    "id": "KPNM",
+    "british": false,
+    "label": "Princeton Municipal Airport (United States) (KPNM)"
+  },
+  {
+    "id": "FFO",
+    "british": false,
+    "label": "Wright-Patterson Air Force Base (United States) (KFFO / FFO)"
+  },
+  {
+    "id": "GAL",
+    "british": false,
+    "label": "Edward G. Pitka Sr Airport (United States) (PAGA / GAL)"
+  },
+  {
+    "id": "KCHD",
+    "british": false,
+    "label": "Chandler Municipal Airport (United States) (KCHD)"
+  },
+  {
+    "id": "MWL",
+    "british": false,
+    "label": "Mineral Wells Airport (United States) (KMWL / MWL)"
+  },
+  {
+    "id": "IAB",
+    "british": false,
+    "label": "Mc Connell Air Force Base (United States) (KIAB / IAB)"
+  },
+  {
+    "id": "NBG",
+    "british": false,
+    "label": "New Orleans NAS JRB/Alvin Callender Field (United States) (KNBG / NBG)"
+  },
+  {
+    "id": "BFT",
+    "british": false,
+    "label": "Beaufort County Airport (United States) (KARW / BFT)"
+  },
+  {
+    "id": "TXK",
+    "british": false,
+    "label": "Texarkana Regional Webb Field (United States) (KTXK / TXK)"
+  },
+  {
+    "id": "PBG",
+    "british": false,
+    "label": "Plattsburgh International Airport (United States) (KPBG / PBG)"
+  },
+  {
+    "id": "APG",
+    "british": false,
+    "label": "Phillips Army Air Field (United States) (KAPG / APG)"
+  },
+  {
+    "id": "TCC",
+    "british": false,
+    "label": "Tucumcari Municipal Airport (United States) (KTCC / TCC)"
+  },
+  {
+    "id": "ANC",
+    "british": false,
+    "label": "Ted Stevens Anchorage International Airport (United States) (PANC / ANC)"
+  },
+  {
+    "id": "GRK",
+    "british": false,
+    "label": "Robert Gray  Army Air Field Airport (United States) (KGRK / GRK)"
+  },
+  {
+    "id": "KZUN",
+    "british": false,
+    "label": "Black Rock Airport (United States) (KZUN)"
+  },
+  {
+    "id": "BLI",
+    "british": false,
+    "label": "Bellingham International Airport (United States) (KBLI / BLI)"
+  },
+  {
+    "id": "NQA",
+    "british": false,
+    "label": "Millington-Memphis Airport (United States) (KNQA / NQA)"
+  },
+  {
+    "id": "EKN",
+    "british": false,
+    "label": "Elkins-Randolph Co-Jennings Randolph Field (United States) (KEKN / EKN)"
+  },
+  {
+    "id": "HFD",
+    "british": false,
+    "label": "Hartford Brainard Airport (United States) (KHFD / HFD)"
+  },
+  {
+    "id": "SFZ",
+    "british": false,
+    "label": "North Central State Airport (United States) (KSFZ / SFZ)"
+  },
+  {
+    "id": "MOB",
+    "british": false,
+    "label": "Mobile Regional Airport (United States) (KMOB / MOB)"
+  },
+  {
+    "id": "NUQ",
+    "british": false,
+    "label": "Moffett Federal Airfield (United States) (KNUQ / NUQ)"
+  },
+  {
+    "id": "SAF",
+    "british": false,
+    "label": "Santa Fe Municipal Airport (United States) (KSAF / SAF)"
+  },
+  {
+    "id": "BKH",
+    "british": false,
+    "label": "Barking Sands Airport (United States) (PHBK / BKH)"
+  },
+  {
+    "id": "DRI",
+    "british": false,
+    "label": "Beauregard Regional Airport (United States) (KDRI / DRI)"
+  },
+  {
+    "id": "BSF",
+    "british": false,
+    "label": "Bradshaw Army Airfield (United States) (PHSF / BSF)"
+  },
+  {
+    "id": "OLS",
+    "british": false,
+    "label": "Nogales International Airport (United States) (KOLS / OLS)"
+  },
+  {
+    "id": "MCF",
+    "british": false,
+    "label": "Mac Dill Air Force Base (United States) (KMCF / MCF)"
+  },
+  {
+    "id": "BLV",
+    "british": false,
+    "label": "Scott AFB/Midamerica Airport (United States) (KBLV / BLV)"
+  },
+  {
+    "id": "OPF",
+    "british": false,
+    "label": "Opa-locka Executive Airport (United States) (KOPF / OPF)"
+  },
+  {
+    "id": "DRT",
+    "british": false,
+    "label": "Del Rio International Airport (United States) (KDRT / DRT)"
+  },
+  {
+    "id": "RSW",
+    "british": false,
+    "label": "Southwest Florida International Airport (United States) (KRSW / RSW)"
+  },
+  {
+    "id": "AKN",
+    "british": false,
+    "label": "King Salmon Airport (United States) (PAKN / AKN)"
+  },
+  {
+    "id": "MUI",
+    "british": false,
+    "label": "Muir Army Air Field (Fort Indiantown Gap) Airport (United States) (KMUI / MUI)"
+  },
+  {
+    "id": "JHM",
+    "british": false,
+    "label": "Kapalua Airport (United States) (PHJH / JHM)"
+  },
+  {
+    "id": "JFK",
+    "british": false,
+    "label": "John F Kennedy International Airport (United States) (KJFK / JFK)"
+  },
+  {
+    "id": "HST",
+    "british": false,
+    "label": "Homestead ARB Airport (United States) (KHST / HST)"
+  },
+  {
+    "id": "RAL",
+    "british": false,
+    "label": "Riverside Municipal Airport (United States) (KRAL / RAL)"
+  },
+  {
+    "id": "FLV",
+    "british": false,
+    "label": "Sherman Army Air Field (United States) (KFLV / FLV)"
+  },
+  {
+    "id": "WAL",
+    "british": false,
+    "label": "Wallops Flight Facility Airport (United States) (KWAL / WAL)"
+  },
+  {
+    "id": "HMN",
+    "british": false,
+    "label": "Holloman Air Force Base (United States) (KHMN / HMN)"
+  },
+  {
+    "id": "NXX",
+    "british": false,
+    "label": "Willow Grove Naval Air Station/Joint Reserve Base (United States) (KNXX / NXX)"
+  },
+  {
+    "id": "CYS",
+    "british": false,
+    "label": "Cheyenne Regional Jerry Olson Field (United States) (KCYS / CYS)"
+  },
+  {
+    "id": "SCK",
+    "british": false,
+    "label": "Stockton Metropolitan Airport (United States) (KSCK / SCK)"
+  },
+  {
+    "id": "CHS",
+    "british": false,
+    "label": "Charleston Air Force Base-International Airport (United States) (KCHS / CHS)"
+  },
+  {
+    "id": "RNO",
+    "british": false,
+    "label": "Reno Tahoe International Airport (United States) (KRNO / RNO)"
+  },
+  {
+    "id": "KTN",
+    "british": false,
+    "label": "Ketchikan International Airport (United States) (PAKT / KTN)"
+  },
+  {
+    "id": "YIP",
+    "british": false,
+    "label": "Willow Run Airport (United States) (KYIP / YIP)"
+  },
+  {
+    "id": "VBG",
+    "british": false,
+    "label": "Vandenberg Air Force Base (United States) (KVBG / VBG)"
+  },
+  {
+    "id": "BHM",
+    "british": false,
+    "label": "Birmingham-Shuttlesworth International Airport (United States) (KBHM / BHM)"
+  },
+  {
+    "id": "NEL",
+    "british": false,
+    "label": "Lakehurst Maxfield Field Airport (United States) (KNEL / NEL)"
+  },
+  {
+    "id": "SYA",
+    "british": false,
+    "label": "Eareckson Air Station (United States) (PASY / SYA)"
+  },
+  {
+    "id": "LSV",
+    "british": false,
+    "label": "Nellis Air Force Base (United States) (KLSV / LSV)"
+  },
+  {
+    "id": "RIV",
+    "british": false,
+    "label": "March ARB Airport (United States) (KRIV / RIV)"
+  },
+  {
+    "id": "MOD",
+    "british": false,
+    "label": "Modesto City Co-Harry Sham Field (United States) (KMOD / MOD)"
+  },
+  {
+    "id": "SMF",
+    "british": false,
+    "label": "Sacramento International Airport (United States) (KSMF / SMF)"
+  },
+  {
+    "id": "UGN",
+    "british": false,
+    "label": "Waukegan National Airport (United States) (KUGN / UGN)"
+  },
+  {
+    "id": "COS",
+    "british": false,
+    "label": "City of Colorado Springs Municipal Airport (United States) (KCOS / COS)"
+  },
+  {
+    "id": "BUF",
+    "british": false,
+    "label": "Buffalo Niagara International Airport (United States) (KBUF / BUF)"
+  },
+  {
+    "id": "SKY",
+    "british": false,
+    "label": "Griffing Sandusky Airport (United States) (KSKY / SKY)"
+  },
+  {
+    "id": "PAE",
+    "british": false,
+    "label": "Snohomish County (Paine Field) Airport (United States) (KPAE / PAE)"
+  },
+  {
+    "id": "MUO",
+    "british": false,
+    "label": "Mountain Home Air Force Base (United States) (KMUO / MUO)"
+  },
+  {
+    "id": "CDC",
+    "british": false,
+    "label": "Cedar City Regional Airport (United States) (KCDC / CDC)"
+  },
+  {
+    "id": "BDL",
+    "british": false,
+    "label": "Bradley International Airport (United States) (KBDL / BDL)"
+  },
+  {
+    "id": "MFE",
+    "british": false,
+    "label": "Mc Allen Miller International Airport (United States) (KMFE / MFE)"
+  },
+  {
+    "id": "NGU",
+    "british": false,
+    "label": "Norfolk Naval Station (Chambers Field) (United States) (KNGU / NGU)"
+  },
+  {
+    "id": "CEF",
+    "british": false,
+    "label": "Westover ARB/Metropolitan Airport (United States) (KCEF / CEF)"
+  },
+  {
+    "id": "LBB",
+    "british": false,
+    "label": "Lubbock Preston Smith International Airport (United States) (KLBB / LBB)"
+  },
+  {
+    "id": "ORD",
+    "british": false,
+    "label": "Chicago O'Hare International Airport (United States) (KORD / ORD)"
+  },
+  {
+    "id": "BCT",
+    "british": false,
+    "label": "Boca Raton Airport (United States) (KBCT / BCT)"
+  },
+  {
+    "id": "FAI",
+    "british": false,
+    "label": "Fairbanks International Airport (United States) (PAFA / FAI)"
+  },
+  {
+    "id": "KNYG",
+    "british": false,
+    "label": "Quantico MCAF /Turner field (United States) (KNYG)"
+  },
+  {
+    "id": "CVS",
+    "british": false,
+    "label": "Cannon Air Force Base (United States) (KCVS / CVS)"
+  },
+  {
+    "id": "NGF",
+    "british": false,
+    "label": "Kaneohe Bay MCAS (Marion E. Carl Field) Airport (United States) (PHNG / NGF)"
+  },
+  {
+    "id": "OFF",
+    "british": false,
+    "label": "Offutt Air Force Base (United States) (KOFF / OFF)"
+  },
+  {
+    "id": "GKN",
+    "british": false,
+    "label": "Gulkana Airport (United States) (PAGK / GKN)"
+  },
+  {
+    "id": "ART",
+    "british": false,
+    "label": "Watertown International Airport (United States) (KART / ART)"
+  },
+  {
+    "id": "PSP",
+    "british": false,
+    "label": "Palm Springs International Airport (United States) (KPSP / PSP)"
+  },
+  {
+    "id": "AMA",
+    "british": false,
+    "label": "Rick Husband Amarillo International Airport (United States) (KAMA / AMA)"
+  },
+  {
+    "id": "FOD",
+    "british": false,
+    "label": "Fort Dodge Regional Airport (United States) (KFOD / FOD)"
+  },
+  {
+    "id": "BAD",
+    "british": false,
+    "label": "Barksdale Air Force Base (United States) (KBAD / BAD)"
+  },
+  {
+    "id": "FOE",
+    "british": false,
+    "label": "Topeka Regional Airport - Forbes Field (United States) (KFOE / FOE)"
+  },
+  {
+    "id": "COT",
+    "british": false,
+    "label": "Cotulla-La Salle County Airport (United States) (KCOT / COT)"
+  },
+  {
+    "id": "ILM",
+    "british": false,
+    "label": "Wilmington International Airport (United States) (KILM / ILM)"
+  },
+  {
+    "id": "BTR",
+    "british": false,
+    "label": "Baton Rouge Metropolitan Airport (United States) (KBTR / BTR)"
+  },
+  {
+    "id": "KNMM",
+    "british": false,
+    "label": "Meridian Naval Air Station (United States) (KNMM)"
+  },
+  {
+    "id": "TYR",
+    "british": false,
+    "label": "Tyler Pounds Regional Airport (United States) (KTYR / TYR)"
+  },
+  {
+    "id": "BWI",
+    "british": false,
+    "label": "Baltimore/Washington International Thurgood Marshall Airport (United States) (KBWI / BWI)"
+  },
+  {
+    "id": "HBR",
+    "british": false,
+    "label": "Hobart Regional Airport (United States) (KHBR / HBR)"
+  },
+  {
+    "id": "LNY",
+    "british": false,
+    "label": "Lanai Airport (United States) (PHNY / LNY)"
+  },
+  {
+    "id": "AEX",
+    "british": false,
+    "label": "Alexandria International Airport (United States) (KAEX / AEX)"
+  },
+  {
+    "id": "WSD",
+    "british": false,
+    "label": "Condron Army Air Field (United States) (KWSD / WSD)"
+  },
+  {
+    "id": "CDB",
+    "british": false,
+    "label": "Cold Bay Airport (United States) (PACD / CDB)"
+  },
+  {
+    "id": "TUL",
+    "british": false,
+    "label": "Tulsa International Airport (United States) (KTUL / TUL)"
+  },
+  {
+    "id": "SIT",
+    "british": false,
+    "label": "Sitka Rocky Gutierrez Airport (United States) (PASI / SIT)"
+  },
+  {
+    "id": "ISP",
+    "british": false,
+    "label": "Long Island Mac Arthur Airport (United States) (KISP / ISP)"
+  },
+  {
+    "id": "MSP",
+    "british": false,
+    "label": "Minneapolis-St Paul International/Wold-Chamberlain Airport (United States) (KMSP / MSP)"
+  },
+  {
+    "id": "ILG",
+    "british": false,
+    "label": "New Castle Airport (United States) (KILG / ILG)"
+  },
+  {
+    "id": "DUT",
+    "british": false,
+    "label": "Unalaska Airport (United States) (PADU / DUT)"
+  },
+  {
+    "id": "MSY",
+    "british": false,
+    "label": "Louis Armstrong New Orleans International Airport (United States) (KMSY / MSY)"
+  },
+  {
+    "id": "PWM",
+    "british": false,
+    "label": "Portland International Jetport Airport (United States) (KPWM / PWM)"
+  },
+  {
+    "id": "OKC",
+    "british": false,
+    "label": "Will Rogers World Airport (United States) (KOKC / OKC)"
+  },
+  {
+    "id": "ALB",
+    "british": false,
+    "label": "Albany International Airport (United States) (KALB / ALB)"
+  },
+  {
+    "id": "VDZ",
+    "british": false,
+    "label": "Valdez Pioneer Field (United States) (PAVD / VDZ)"
+  },
+  {
+    "id": "LFI",
+    "british": false,
+    "label": "Langley Air Force Base (United States) (KLFI / LFI)"
+  },
+  {
+    "id": "SNA",
+    "british": false,
+    "label": "John Wayne Airport-Orange County Airport (United States) (KSNA / SNA)"
+  },
+  {
+    "id": "CBM",
+    "british": false,
+    "label": "Columbus Air Force Base (United States) (KCBM / CBM)"
+  },
+  {
+    "id": "TMB",
+    "british": false,
+    "label": "Kendall-Tamiami Executive Airport (United States) (KTMB / TMB)"
+  },
+  {
+    "id": "NTU",
+    "british": false,
+    "label": "Oceana Naval Air Station (United States) (KNTU / NTU)"
+  },
+  {
+    "id": "GUS",
+    "british": false,
+    "label": "Grissom Air Reserve Base (United States) (KGUS / GUS)"
+  },
+  {
+    "id": "CPR",
+    "british": false,
+    "label": "Casper-Natrona County International Airport (United States) (KCPR / CPR)"
+  },
+  {
+    "id": "VPS",
+    "british": false,
+    "label": "Destin-Ft Walton Beach Airport (United States) (KVPS / VPS)"
+  },
+  {
+    "id": "SEM",
+    "british": false,
+    "label": "Craig Field (United States) (KSEM / SEM)"
+  },
+  {
+    "id": "EYW",
+    "british": false,
+    "label": "Key West International Airport (United States) (KEYW / EYW)"
+  },
+  {
+    "id": "CLT",
+    "british": false,
+    "label": "Charlotte Douglas International Airport (United States) (KCLT / CLT)"
+  },
+  {
+    "id": "LAS",
+    "british": false,
+    "label": "McCarran International Airport (United States) (KLAS / LAS)"
+  },
+  {
+    "id": "MCO",
+    "british": false,
+    "label": "Orlando International Airport (United States) (KMCO / MCO)"
+  },
+  {
+    "id": "FLO",
+    "british": false,
+    "label": "Florence Regional Airport (United States) (KFLO / FLO)"
+  },
+  {
+    "id": "GTF",
+    "british": false,
+    "label": "Great Falls International Airport (United States) (KGTF / GTF)"
+  },
+  {
+    "id": "YNG",
+    "british": false,
+    "label": "Youngstown Warren Regional Airport (United States) (KYNG / YNG)"
+  },
+  {
+    "id": "FBK",
+    "british": false,
+    "label": "Ladd AAF Airfield (United States) (PAFB / FBK)"
+  },
+  {
+    "id": "KMMV",
+    "british": false,
+    "label": "Mc Minnville Municipal Airport (United States) (KMMV)"
+  },
+  {
+    "id": "WRB",
+    "british": false,
+    "label": "Robins Air Force Base (United States) (KWRB / WRB)"
+  },
+  {
+    "id": "BKK",
+    "british": false,
+    "label": "Suvarnabhumi Airport (Thailand) (VTBS / BKK)"
+  },
+  {
+    "id": "NAH",
+    "british": false,
+    "label": "Naha Airport (Indonesia) (WAMH / NAH)"
+  },
+  {
+    "id": "MXB",
+    "british": false,
+    "label": "Andi Jemma Airport (Indonesia) (WAWM / MXB)"
+  },
+  {
+    "id": "SQR",
+    "british": false,
+    "label": "Soroako Airport (Indonesia) (WAWS / SQR)"
+  },
+  {
+    "id": "TTR",
+    "british": false,
+    "label": "Pongtiku Airport (Indonesia) (WAWT / TTR)"
+  },
+  {
+    "id": "KDI",
+    "british": false,
+    "label": "Wolter Monginsidi Airport (Indonesia) (WAWW / KDI)"
+  },
+  {
+    "id": "SBG",
+    "british": false,
+    "label": "Maimun Saleh Airport (Indonesia) (WITB / SBG)"
+  },
+  {
+    "id": "TSY",
+    "british": false,
+    "label": "Cibeureum Airport (Indonesia) (WICM / TSY)"
+  },
+  {
+    "id": "WARI",
+    "british": false,
+    "label": "Iswahyudi Airport (Indonesia) (WARI)"
+  },
+  {
+    "id": "MLG",
+    "british": false,
+    "label": "Abdul Rachman Saleh Airport (Indonesia) (WARA / MLG)"
+  },
+  {
+    "id": "WICB",
+    "british": false,
+    "label": "Budiarto Airport (Indonesia) (WICB)"
+  },
+  {
+    "id": "BDO",
+    "british": false,
+    "label": "Husein Sastranegara International Airport (Indonesia) (WICC / BDO)"
+  },
+  {
+    "id": "CBN",
+    "british": false,
+    "label": "Penggung Airport (Indonesia) (WICD / CBN)"
+  },
+  {
+    "id": "JOG",
+    "british": false,
+    "label": "Adi Sutjipto International Airport (Indonesia) (WARJ / JOG)"
+  },
+  {
+    "id": "CXP",
+    "british": false,
+    "label": "Tunggul Wulung Airport (Indonesia) (WIHL / CXP)"
+  },
+  {
+    "id": "PCB",
+    "british": false,
+    "label": "Pondok Cabe Air Base (Indonesia) (WIHP / PCB)"
+  },
+  {
+    "id": "SRG",
+    "british": false,
+    "label": "Achmad Yani Airport (Indonesia) (WARS / SRG)"
+  },
+  {
+    "id": "BTH",
+    "british": false,
+    "label": "Hang Nadim International Airport (Indonesia) (WIDD / BTH)"
+  },
+  {
+    "id": "TJQ",
+    "british": false,
+    "label": "Buluh Tumbang (H A S Hanandjoeddin) Airport (Indonesia) (WIOD / TJQ)"
+  },
+  {
+    "id": "PGK",
+    "british": false,
+    "label": "Pangkal Pinang (Depati Amir) Airport (Indonesia) (WIPK / PGK)"
+  },
+  {
+    "id": "TNJ",
+    "british": false,
+    "label": "Raja Haji Fisabilillah International Airport (Indonesia) (WIDN / TNJ)"
+  },
+  {
+    "id": "SIQ",
+    "british": false,
+    "label": "Dabo Airport (Indonesia) (WIDS / SIQ)"
+  },
+  {
+    "id": "BDJ",
+    "british": false,
+    "label": "Syamsudin Noor Airport (Indonesia) (WAOO / BDJ)"
+  },
+  {
+    "id": "BTW",
+    "british": false,
+    "label": "Batu Licin Airport (Indonesia) (WAOC / BTW)"
+  },
+  {
+    "id": "PKN",
+    "british": false,
+    "label": "Iskandar Airport (Indonesia) (WAOI / PKN)"
+  },
+  {
+    "id": "PKY",
+    "british": false,
+    "label": "Tjilik Riwut Airport (Indonesia) (WAOP / PKY)"
+  },
+  {
+    "id": "MOF",
+    "british": false,
+    "label": "Maumere(Wai Oti) Airport (Indonesia) (WATC / MOF)"
+  },
+  {
+    "id": "ENE",
+    "british": false,
+    "label": "Ende (H Hasan Aroeboesman) Airport (Indonesia) (WATE / ENE)"
+  },
+  {
+    "id": "RTG",
+    "british": false,
+    "label": "Frans Sales Lega Airport (Indonesia) (WATG / RTG)"
+  },
+  {
+    "id": "KOE",
+    "british": false,
+    "label": "El Tari Airport (Indonesia) (WATT / KOE)"
+  },
+  {
+    "id": "LBJ",
+    "british": false,
+    "label": "Komodo Airport (Indonesia) (WATO / LBJ)"
+  },
+  {
+    "id": "BPN",
+    "british": false,
+    "label": "Sultan Aji Muhamad Sulaiman Airport (Indonesia) (WALL / BPN)"
+  },
+  {
+    "id": "TRK",
+    "british": false,
+    "label": "Juwata Airport (Indonesia) (WALR / TRK)"
+  },
+  {
+    "id": "SRI",
+    "british": false,
+    "label": "Temindung Airport (Indonesia) (WALS / SRI)"
+  },
+  {
+    "id": "TSX",
+    "british": false,
+    "label": "Tanjung Santan Airport (Indonesia) (WALT / TSX)"
+  },
+  {
+    "id": "AMI",
+    "british": false,
+    "label": "Selaparang Airport (Indonesia) (WADA / AMI)"
+  },
+  {
+    "id": "BMU",
+    "british": false,
+    "label": "Muhammad Salahuddin Airport (Indonesia) (WADB / BMU)"
+  },
+  {
+    "id": "WGP",
+    "british": false,
+    "label": "Umbu Mehang Kunda Airport (Indonesia) (WADW / WGP)"
+  },
+  {
+    "id": "SUB",
+    "british": false,
+    "label": "Juanda International Airport (Indonesia) (WARR / SUB)"
+  },
+  {
+    "id": "SOC",
+    "british": false,
+    "label": "Adi Sumarmo Wiryokusumo Airport (Indonesia) (WARQ / SOC)"
+  },
+  {
+    "id": "ICN",
+    "british": false,
+    "label": "Incheon International Airport (South Korea) (RKSI / ICN)"
+  },
+  {
+    "id": "CNX",
+    "british": false,
+    "label": "Chiang Mai International Airport (Thailand) (VTCC / CNX)"
+  },
+  {
+    "id": "CEI",
+    "british": false,
+    "label": "Chiang Rai International Airport (Thailand) (VTCT / CEI)"
+  },
+  {
+    "id": "NST",
+    "british": false,
+    "label": "Nakhon Si Thammarat Airport (Thailand) (VTSF / NST)"
+  },
+  {
+    "id": "NAK",
+    "british": false,
+    "label": "Nakhon Ratchasima Airport (Thailand) (VTUQ / NAK)"
+  },
+  {
+    "id": "KOP",
+    "british": false,
+    "label": "Nakhon Phanom Airport (Thailand) (VTUW / KOP)"
+  },
+  {
+    "id": "UBP",
+    "british": false,
+    "label": "Ubon Ratchathani Airport (Thailand) (VTUU / UBP)"
+  },
+  {
+    "id": "KKC",
+    "british": false,
+    "label": "Khon Kaen Airport (Thailand) (VTUK / KKC)"
+  },
+  {
+    "id": "THS",
+    "british": false,
+    "label": "Sukhothai Airport (Thailand) (VTPO / THS)"
+  },
+  {
+    "id": "DPS",
+    "british": false,
+    "label": "Ngurah Rai (Bali) International Airport (Indonesia) (WADD / DPS)"
+  },
+  {
+    "id": "ATH",
+    "british": false,
+    "label": "Eleftherios Venizelos International Airport (Greece) (LGAV / ATH)"
+  },
+  {
+    "id": "NGO",
+    "british": false,
+    "label": "Chubu Centrair International Airport (Japan) (RJGG / NGO)"
+  },
+  {
+    "id": "UKB",
+    "british": false,
+    "label": "Kobe Airport (Japan) (RJBE / UKB)"
+  },
+  {
+    "id": "PUW",
+    "british": false,
+    "label": "Pullman Moscow Regional Airport (United States) (KPUW / PUW)"
+  },
+  {
+    "id": "LWS",
+    "british": false,
+    "label": "Lewiston Nez Perce County Airport (United States) (KLWS / LWS)"
+  },
+  {
+    "id": "ELM",
+    "british": false,
+    "label": "Elmira Corning Regional Airport (United States) (KELM / ELM)"
+  },
+  {
+    "id": "ITH",
+    "british": false,
+    "label": "Ithaca Tompkins Regional Airport (United States) (KITH / ITH)"
+  },
+  {
+    "id": "MRY",
+    "british": false,
+    "label": "Monterey Peninsula Airport (United States) (KMRY / MRY)"
+  },
+  {
+    "id": "SBA",
+    "british": false,
+    "label": "Santa Barbara Municipal Airport (United States) (KSBA / SBA)"
+  },
+  {
+    "id": "DAB",
+    "british": false,
+    "label": "Daytona Beach International Airport (United States) (KDAB / DAB)"
+  },
+  {
+    "id": "LPX",
+    "british": false,
+    "label": "Liepāja International Airport (Latvia) (EVLA / LPX)"
+  },
+  {
+    "id": "RIX",
+    "british": false,
+    "label": "Riga International Airport (Latvia) (EVRA / RIX)"
+  },
+  {
+    "id": "SQQ",
+    "british": false,
+    "label": "Šiauliai International Airport (Lithuania) (EYSA / SQQ)"
+  },
+  {
+    "id": "HLJ",
+    "british": false,
+    "label": "Barysiai Airport (Lithuania) (EYSB / HLJ)"
+  },
+  {
+    "id": "KUN",
+    "british": false,
+    "label": "Kaunas International Airport (Lithuania) (EYKA / KUN)"
+  },
+  {
+    "id": "EYKS",
+    "british": false,
+    "label": "S. Darius and S. Girėnas Airfield (Lithuania) (EYKS)"
+  },
+  {
+    "id": "PLQ",
+    "british": false,
+    "label": "Palanga International Airport (Lithuania) (EYPA / PLQ)"
+  },
+  {
+    "id": "VNO",
+    "british": false,
+    "label": "Vilnius International Airport (Lithuania) (EYVI / VNO)"
+  },
+  {
+    "id": "PNV",
+    "british": false,
+    "label": "Panevėžys Air Base (Lithuania) (EYPP / PNV)"
+  },
+  {
+    "id": "UDYE",
+    "british": false,
+    "label": "Erebuni Airport (Armenia) (UDYE)"
+  },
+  {
+    "id": "UDLS",
+    "british": false,
+    "label": "Stepanavan Airport (Armenia) (UDLS)"
+  },
+  {
+    "id": "EVN",
+    "british": false,
+    "label": "Zvartnots International Airport (Armenia) (UDYZ / EVN)"
+  },
+  {
+    "id": "LWN",
+    "british": false,
+    "label": "Gyumri Shirak Airport (Armenia) (UDSG / LWN)"
+  },
+  {
+    "id": "ASA",
+    "british": false,
+    "label": "Assab International Airport (Eritrea) (HHSB / ASA)"
+  },
+  {
+    "id": "ASM",
+    "british": false,
+    "label": "Asmara International Airport (Eritrea) (HHAS / ASM)"
+  },
+  {
+    "id": "MSW",
+    "british": false,
+    "label": "Massawa International Airport (Eritrea) (HHMS / MSW)"
+  },
+  {
+    "id": "GZA",
+    "british": false,
+    "label": "Yasser Arafat International Airport (Palestine) (LVGZ / GZA)"
+  },
+  {
+    "id": "BUS",
+    "british": false,
+    "label": "Batumi International Airport (Georgia) (UGSB / BUS)"
+  },
+  {
+    "id": "KUT",
+    "british": false,
+    "label": "Kopitnari Airport (Georgia) (UGKO / KUT)"
+  },
+  {
+    "id": "TBS",
+    "british": false,
+    "label": "Tbilisi International Airport (Georgia) (UGTB / TBS)"
+  },
+  {
+    "id": "RIY",
+    "british": false,
+    "label": "Mukalla International Airport (Yemen) (OYRN / RIY)"
+  },
+  {
+    "id": "TAI",
+    "british": false,
+    "label": "Ta'izz International Airport (Yemen) (OYTZ / TAI)"
+  },
+  {
+    "id": "HOD",
+    "british": false,
+    "label": "Hodeidah International Airport (Yemen) (OYHD / HOD)"
+  },
+  {
+    "id": "ADE",
+    "british": false,
+    "label": "Aden International Airport (Yemen) (OYAA / ADE)"
+  },
+  {
+    "id": "AXK",
+    "british": false,
+    "label": "Ataq Airport (Yemen) (OYAT / AXK)"
+  },
+  {
+    "id": "AAY",
+    "british": false,
+    "label": "Al Ghaidah International Airport (Yemen) (OYGD / AAY)"
+  },
+  {
+    "id": "SAH",
+    "british": false,
+    "label": "Sana'a International Airport (Yemen) (OYSN / SAH)"
+  },
+  {
+    "id": "BHN",
+    "british": false,
+    "label": "Beihan Airport (Yemen) (OYBN / BHN)"
+  },
+  {
+    "id": "SCT",
+    "british": false,
+    "label": "Socotra International Airport (Yemen) (OYSQ / SCT)"
+  },
+  {
+    "id": "OYBA",
+    "british": false,
+    "label": "Al Badie Airport (Yemen) (OYBA)"
+  },
+  {
+    "id": "FMM",
+    "british": false,
+    "label": "Memmingen Allgau Airport (Germany) (EDJA / FMM)"
+  },
+  {
+    "id": "NAV",
+    "british": false,
+    "label": "Nevşehir Kapadokya Airport (Turkey) (LTAZ / NAV)"
+  },
+  {
+    "id": "EZE",
+    "british": false,
+    "label": "Ministro Pistarini International Airport (Argentina) (SAEZ / EZE)"
+  },
+  {
+    "id": "EBL",
+    "british": false,
+    "label": "Erbil International Airport (Iraq) (ORER / EBL)"
+  },
+  {
+    "id": "EMD",
+    "british": false,
+    "label": "Emerald Airport (Australia) (YEML / EMD)"
+  },
+  {
+    "id": "HEW",
+    "british": false,
+    "label": "Athen Helenikon Airport (Greece) (LGAT / HEW)"
+  },
+  {
+    "id": "KIX",
+    "british": false,
+    "label": "Kansai International Airport (Japan) (RJBB / KIX)"
+  },
+  {
+    "id": "JRB",
+    "british": false,
+    "label": "Downtown-Manhattan/Wall St Heliport (United States) (KJRB / JRB)"
+  },
+  {
+    "id": "TAG",
+    "british": false,
+    "label": "Tagbilaran Airport (Philippines) (RPVT / TAG)"
+  },
+  {
+    "id": "JAV",
+    "british": false,
+    "label": "Ilulissat Airport (Greenland) (BGJN / JAV)"
+  },
+  {
+    "id": "JCH",
+    "british": false,
+    "label": "Qasigiannguit Heliport (Greenland) (BGCH / JCH)"
+  },
+  {
+    "id": "JEG",
+    "british": false,
+    "label": "Aasiaat Airport (Greenland) (BGAA / JEG)"
+  },
+  {
+    "id": "PMI",
+    "british": false,
+    "label": "Palma De Mallorca Airport (Spain) (LEPA / PMI)"
+  },
+  {
+    "id": "DRW",
+    "british": false,
+    "label": "Darwin International Airport (Australia) (YPDN / DRW)"
+  },
+  {
+    "id": "URT",
+    "british": false,
+    "label": "Surat Thani Airport (Thailand) (VTSB / URT)"
+  },
+  {
+    "id": "TKA",
+    "british": false,
+    "label": "Talkeetna Airport (United States) (PATK / TKA)"
+  },
+  {
+    "id": "GZM",
+    "british": false,
+    "label": "Xewkija Heliport (Malta) (LMMG / GZM)"
+  },
+  {
+    "id": "HVN",
+    "british": false,
+    "label": "Tweed New Haven Airport (United States) (KHVN / HVN)"
+  },
+  {
+    "id": "AVL",
+    "british": false,
+    "label": "Asheville Regional Airport (United States) (KAVL / AVL)"
+  },
+  {
+    "id": "GSO",
+    "british": false,
+    "label": "Piedmont Triad International Airport (United States) (KGSO / GSO)"
+  },
+  {
+    "id": "FSD",
+    "british": false,
+    "label": "Joe Foss Field Airport (United States) (KFSD / FSD)"
+  },
+  {
+    "id": "AYQ",
+    "british": false,
+    "label": "Ayers Rock Connellan Airport (Australia) (YAYE / AYQ)"
+  },
+  {
+    "id": "MHT",
+    "british": false,
+    "label": "Manchester-Boston Regional Airport (United States) (KMHT / MHT)"
+  },
+  {
+    "id": "APF",
+    "british": false,
+    "label": "Naples Municipal Airport (United States) (KAPF / APF)"
+  },
+  {
+    "id": "RDN",
+    "british": false,
+    "label": "LTS Pulau Redang Airport (Malaysia) (WMPR / RDN)"
+  },
+  {
+    "id": "SDF",
+    "british": false,
+    "label": "Louisville International Standiford Field (United States) (KSDF / SDF)"
+  },
+  {
+    "id": "CHO",
+    "british": false,
+    "label": "Charlottesville Albemarle Airport (United States) (KCHO / CHO)"
+  },
+  {
+    "id": "ROA",
+    "british": false,
+    "label": "Roanoke–Blacksburg Regional Airport (United States) (KROA / ROA)"
+  },
+  {
+    "id": "LEX",
+    "british": false,
+    "label": "Blue Grass Airport (United States) (KLEX / LEX)"
+  },
+  {
+    "id": "EVV",
+    "british": false,
+    "label": "Evansville Regional Airport (United States) (KEVV / EVV)"
+  },
+  {
+    "id": "ABQ",
+    "british": false,
+    "label": "Albuquerque International Sunport (United States) (KABQ / ABQ)"
+  },
+  {
+    "id": "BZN",
+    "british": false,
+    "label": "Gallatin Field (United States) (KBZN / BZN)"
+  },
+  {
+    "id": "BIL",
+    "british": false,
+    "label": "Billings Logan International Airport (United States) (KBIL / BIL)"
+  },
+  {
+    "id": "BTM",
+    "british": false,
+    "label": "Bert Mooney Airport (United States) (KBTM / BTM)"
+  },
+  {
+    "id": "TVC",
+    "british": false,
+    "label": "Cherry Capital Airport (United States) (KTVC / TVC)"
+  },
+  {
+    "id": "FRS",
+    "british": false,
+    "label": "Mundo Maya International Airport (Guatemala) (MGTK / FRS)"
+  },
+  {
+    "id": "BHB",
+    "british": false,
+    "label": "Hancock County-Bar Harbor Airport (United States) (KBHB / BHB)"
+  },
+  {
+    "id": "RKD",
+    "british": false,
+    "label": "Knox County Regional Airport (United States) (KRKD / RKD)"
+  },
+  {
+    "id": "JAC",
+    "british": false,
+    "label": "Jackson Hole Airport (United States) (KJAC / JAC)"
+  },
+  {
+    "id": "RFD",
+    "british": false,
+    "label": "Chicago Rockford International Airport (United States) (KRFD / RFD)"
+  },
+  {
+    "id": "DME",
+    "british": false,
+    "label": "Domodedovo International Airport (Russia) (UUDD / DME)"
+  },
+  {
+    "id": "SYX",
+    "british": false,
+    "label": "Sanya Phoenix International Airport (China) (ZJSY / SYX)"
+  },
+  {
+    "id": "MFN",
+    "british": false,
+    "label": "Milford Sound Airport (New Zealand) (NZMF / MFN)"
+  },
+  {
+    "id": "LJG",
+    "british": false,
+    "label": "Lijiang Airport (China) (ZPLJ / LJG)"
+  },
+  {
+    "id": "GSP",
+    "british": false,
+    "label": "Greenville Spartanburg International Airport (United States) (KGSP / GSP)"
+  },
+  {
+    "id": "BMI",
+    "british": false,
+    "label": "Central Illinois Regional Airport at Bloomington-Normal (United States) (KBMI / BMI)"
+  },
+  {
+    "id": "GPT",
+    "british": false,
+    "label": "Gulfport Biloxi International Airport (United States) (KGPT / GPT)"
+  },
+  {
+    "id": "AZO",
+    "british": false,
+    "label": "Kalamazoo Battle Creek International Airport (United States) (KAZO / AZO)"
+  },
+  {
+    "id": "TOL",
+    "british": false,
+    "label": "Toledo Express Airport (United States) (KTOL / TOL)"
+  },
+  {
+    "id": "FWA",
+    "british": false,
+    "label": "Fort Wayne International Airport (United States) (KFWA / FWA)"
+  },
+  {
+    "id": "DEC",
+    "british": false,
+    "label": "Decatur Airport (United States) (KDEC / DEC)"
+  },
+  {
+    "id": "CID",
+    "british": false,
+    "label": "The Eastern Iowa Airport (United States) (KCID / CID)"
+  },
+  {
+    "id": "LSE",
+    "british": false,
+    "label": "La Crosse Municipal Airport (United States) (KLSE / LSE)"
+  },
+  {
+    "id": "CWA",
+    "british": false,
+    "label": "Central Wisconsin Airport (United States) (KCWA / CWA)"
+  },
+  {
+    "id": "PIA",
+    "british": false,
+    "label": "General Wayne A. Downing Peoria International Airport (United States) (KPIA / PIA)"
+  },
+  {
+    "id": "ATW",
+    "british": false,
+    "label": "Appleton International Airport (United States) (KATW / ATW)"
+  },
+  {
+    "id": "RST",
+    "british": false,
+    "label": "Rochester International Airport (United States) (KRST / RST)"
+  },
+  {
+    "id": "CMI",
+    "british": false,
+    "label": "University of Illinois Willard Airport (United States) (KCMI / CMI)"
+  },
+  {
+    "id": "MHK",
+    "british": false,
+    "label": "Manhattan Regional Airport (United States) (KMHK / MHK)"
+  },
+  {
+    "id": "KGC",
+    "british": false,
+    "label": "Kingscote Airport (Australia) (YKSC / KGC)"
+  },
+  {
+    "id": "HVB",
+    "british": false,
+    "label": "Hervey Bay Airport (Australia) (YHBA / HVB)"
+  },
+  {
+    "id": "DLU",
+    "british": false,
+    "label": "Dali Airport (China) (ZPDL / DLU)"
+  },
+  {
+    "id": "MZV",
+    "british": false,
+    "label": "Mulu Airport (Malaysia) (WBMU / MZV)"
+  },
+  {
+    "id": "SSH",
+    "british": false,
+    "label": "Sharm El Sheikh International Airport (Egypt) (HESH / SSH)"
+  },
+  {
+    "id": "FKL",
+    "british": false,
+    "label": "Venango Regional Airport (United States) (KFKL / FKL)"
+  },
+  {
+    "id": "NBO",
+    "british": false,
+    "label": "Jomo Kenyatta International Airport (Kenya) (HKJK / NBO)"
+  },
+  {
+    "id": "SEU",
+    "british": false,
+    "label": "Seronera Airport (Tanzania) (HTSN / SEU)"
+  },
+  {
+    "id": "FTE",
+    "british": false,
+    "label": "El Calafate Airport (Argentina) (SAWC / FTE)"
+  },
+  {
+    "id": "ARM",
+    "british": false,
+    "label": "Armidale Airport (Australia) (YARM / ARM)"
+  },
+  {
+    "id": "GJT",
+    "british": false,
+    "label": "Grand Junction Regional Airport (United States) (KGJT / GJT)"
+  },
+  {
+    "id": "SGU",
+    "british": false,
+    "label": "St George Municipal Airport (United States) (KSGU / SGU)"
+  },
+  {
+    "id": "DWH",
+    "british": false,
+    "label": "David Wayne Hooks Memorial Airport (United States) (KDWH / DWH)"
+  },
+  {
+    "id": "XS46",
+    "british": false,
+    "label": "Port O'Connor Private Heliport (United States) (XS46)"
+  },
+  {
+    "id": "SRQ",
+    "british": false,
+    "label": "Sarasota Bradenton International Airport (United States) (KSRQ / SRQ)"
+  },
+  {
+    "id": "BDA",
+    "british": false,
+    "label": "L.F. Wade International International Airport (Bermuda) (TXKF / BDA)"
+  },
+  {
+    "id": "VNY",
+    "british": false,
+    "label": "Van Nuys Airport (United States) (KVNY / VNY)"
+  },
+  {
+    "id": "MLI",
+    "british": false,
+    "label": "Quad City International Airport (United States) (KMLI / MLI)"
+  },
+  {
+    "id": "PFN",
+    "british": false,
+    "label": "Panama City-Bay Co International Airport (United States) (KPFN / PFN)"
+  },
+  {
+    "id": "HIR",
+    "british": false,
+    "label": "Honiara International Airport (Solomon Islands) (AGGH / HIR)"
+  },
+  {
+    "id": "PPT",
+    "british": false,
+    "label": "Faa'a International Airport (French Polynesia) (NTAA / PPT)"
+  },
+  {
+    "id": "INU",
+    "british": false,
+    "label": "Nauru International Airport (Nauru) (ANYN / INU)"
+  },
+  {
+    "id": "FUN",
+    "british": false,
+    "label": "Funafuti International Airport (Tuvalu) (NGFU / FUN)"
+  },
+  {
+    "id": "OVB",
+    "british": false,
+    "label": "Tolmachevo Airport (Russia) (UNNT / OVB)"
+  },
+  {
+    "id": "EKSS",
+    "british": false,
+    "label": "Samsø Airport (Denmark) (EKSS)"
+  },
+  {
+    "id": "XKH",
+    "british": false,
+    "label": "Xieng Khouang Airport (Laos) (VLXK / XKH)"
+  },
+  {
+    "id": "BIS",
+    "british": false,
+    "label": "Bismarck Municipal Airport (United States) (KBIS / BIS)"
+  },
+  {
+    "id": "TEX",
+    "british": false,
+    "label": "Telluride Regional Airport (United States) (KTEX / TEX)"
+  },
+  {
+    "id": "ZLIC",
+    "british": false,
+    "label": "Yinchuan Airport (China) (ZLIC)"
+  },
+  {
+    "id": "HGN",
+    "british": false,
+    "label": "Mae Hong Son Airport (Thailand) (VTCH / HGN)"
+  },
+  {
+    "id": "RAP",
+    "british": false,
+    "label": "Rapid City Regional Airport (United States) (KRAP / RAP)"
+  },
+  {
+    "id": "CLD",
+    "british": false,
+    "label": "Mc Clellan-Palomar Airport (United States) (KCRQ / CLD)"
+  },
+  {
+    "id": "FNT",
+    "british": false,
+    "label": "Bishop International Airport (United States) (KFNT / FNT)"
+  },
+  {
+    "id": "DVO",
+    "british": false,
+    "label": "Francisco Bangoy International Airport (Philippines) (RPMD / DVO)"
+  },
+  {
+    "id": "FNC",
+    "british": false,
+    "label": "Madeira Airport (Portugal) (LPMA / FNC)"
+  },
+  {
+    "id": "STM",
+    "british": false,
+    "label": "Maestro Wilson Fonseca Airport (Brazil) (SBSN / STM)"
+  },
+  {
+    "id": "KOS",
+    "british": false,
+    "label": "Sihanoukville International Airport (Cambodia) (VDSV / KOS)"
+  },
+  {
+    "id": "YOA",
+    "british": false,
+    "label": "Ekati Airport (Canada) (CYOA / YOA)"
+  },
+  {
+    "id": "NPE",
+    "british": false,
+    "label": "Hawke's Bay Airport (New Zealand) (NZNR / NPE)"
+  },
+  {
+    "id": "LEV",
+    "british": false,
+    "label": "Levuka Airfield (Fiji) (NFNB / LEV)"
+  },
+  {
+    "id": "LXA",
+    "british": false,
+    "label": "Lhasa Gonggar Airport (China) (ZULS / LXA)"
+  },
+  {
+    "id": "RDD",
+    "british": false,
+    "label": "Redding Municipal Airport (United States) (KRDD / RDD)"
+  },
+  {
+    "id": "EUG",
+    "british": false,
+    "label": "Mahlon Sweet Field (United States) (KEUG / EUG)"
+  },
+  {
+    "id": "IDA",
+    "british": false,
+    "label": "Idaho Falls Regional Airport (United States) (KIDA / IDA)"
+  },
+  {
+    "id": "MFR",
+    "british": false,
+    "label": "Rogue Valley International Medford Airport (United States) (KMFR / MFR)"
+  },
+  {
+    "id": "KBZ",
+    "british": false,
+    "label": "Kaikoura Airport (New Zealand) (NZKI / KBZ)"
+  },
+  {
+    "id": "RDM",
+    "british": false,
+    "label": "Roberts Field (United States) (KRDM / RDM)"
+  },
+  {
+    "id": "PCN",
+    "british": false,
+    "label": "Picton Aerodrome (New Zealand) (NZPN / PCN)"
+  },
+  {
+    "id": "WDH",
+    "british": false,
+    "label": "Hosea Kutako International Airport (Namibia) (FYWH / WDH)"
+  },
+  {
+    "id": "YWH",
+    "british": false,
+    "label": "Victoria Harbour Seaplane Base (Canada) (CYWH / YWH)"
+  },
+  {
+    "id": "CAQ3",
+    "british": false,
+    "label": "Coal Harbour Seaplane Base (Canada) (CAQ3)"
+  },
+  {
+    "id": "TNA",
+    "british": false,
+    "label": "Yaoqiang Airport (China) (ZSJN / TNA)"
+  },
+  {
+    "id": "CZX",
+    "british": false,
+    "label": "Changzhou Benniu Airport (China) (ZSCG / CZX)"
+  },
+  {
+    "id": "YBP",
+    "british": false,
+    "label": "Yibin Caiba Airport (China) (ZUYB / YBP)"
+  },
+  {
+    "id": "TJM",
+    "british": false,
+    "label": "Roshchino International Airport (Russia) (USTR / TJM)"
+  },
+  {
+    "id": "CAK",
+    "british": false,
+    "label": "Akron Canton Regional Airport (United States) (KCAK / CAK)"
+  },
+  {
+    "id": "HSV",
+    "british": false,
+    "label": "Huntsville International Carl T Jones Field (United States) (KHSV / HSV)"
+  },
+  {
+    "id": "PKB",
+    "british": false,
+    "label": "Mid Ohio Valley Regional Airport (United States) (KPKB / PKB)"
+  },
+  {
+    "id": "MGM",
+    "british": false,
+    "label": "Montgomery Regional (Dannelly Field) Airport (United States) (KMGM / MGM)"
+  },
+  {
+    "id": "TRI",
+    "british": false,
+    "label": "Tri-Cities Regional TN/VA Airport (United States) (KTRI / TRI)"
+  },
+  {
+    "id": "PAH",
+    "british": false,
+    "label": "Barkley Regional Airport (United States) (KPAH / PAH)"
+  },
+  {
+    "id": "JIB",
+    "british": false,
+    "label": "Djibouti-Ambouli Airport (Djibouti) (HDAM / JIB)"
+  },
+  {
+    "id": "HAK",
+    "british": false,
+    "label": "Haikou Meilan International Airport (China) (ZJHK / HAK)"
+  },
+  {
+    "id": "MFA",
+    "british": false,
+    "label": "Mafia Island Airport (Tanzania) (HTMA / MFA)"
+  },
+  {
+    "id": "PGA",
+    "british": false,
+    "label": "Page Municipal Airport (United States) (KPGA / PGA)"
+  },
+  {
+    "id": "UII",
+    "british": false,
+    "label": "Utila Airport (Honduras) (MHUT / UII)"
+  },
+  {
+    "id": "FCA",
+    "british": false,
+    "label": "Glacier Park International Airport (United States) (KGPI / FCA)"
+  },
+  {
+    "id": "MBS",
+    "british": false,
+    "label": "MBS International Airport (United States) (KMBS / MBS)"
+  },
+  {
+    "id": "BGM",
+    "british": false,
+    "label": "Greater Binghamton/Edwin A Link field (United States) (KBGM / BGM)"
+  },
+  {
+    "id": "BGW",
+    "british": false,
+    "label": "Baghdad International Airport (Iraq) (ORBI / BGW)"
+  },
+  {
+    "id": "NNT",
+    "british": false,
+    "label": "Nan Airport (Thailand) (VTCN / NNT)"
+  },
+  {
+    "id": "ROI",
+    "british": false,
+    "label": "Roi Et Airport (Thailand) (VTUV / ROI)"
+  },
+  {
+    "id": "BFV",
+    "british": false,
+    "label": "Buri Ram Airport (Thailand) (VTUO / BFV)"
+  },
+  {
+    "id": "TDX",
+    "british": false,
+    "label": "Trat Airport (Thailand) (VTBO / TDX)"
+  },
+  {
+    "id": "BLH",
+    "british": false,
+    "label": "Blythe Airport (United States) (KBLH / BLH)"
+  },
+  {
+    "id": "IQA",
+    "british": false,
+    "label": "Al Asad Air Base (Iraq) (ORAA / IQA)"
+  },
+  {
+    "id": "TQD",
+    "british": false,
+    "label": "Al Taqaddum Air Base (Iraq) (ORAT / TQD)"
+  },
+  {
+    "id": "XQC",
+    "british": false,
+    "label": "Joint Base Balad (Iraq) (ORBD / XQC)"
+  },
+  {
+    "id": "CRK",
+    "british": false,
+    "label": "Diosdado Macapagal International Airport (Philippines) (RPLC / CRK)"
+  },
+  {
+    "id": "SDK",
+    "british": false,
+    "label": "Sandakan Airport (Malaysia) (WBKS / SDK)"
+  },
+  {
+    "id": "LXG",
+    "british": false,
+    "label": "Luang Namtha Airport (Laos) (VLLN / LXG)"
+  },
+  {
+    "id": "ODY",
+    "british": false,
+    "label": "Oudomsay Airport (Laos) (VLOS / ODY)"
+  },
+  {
+    "id": "SHE",
+    "british": false,
+    "label": "Taoxian Airport (China) (ZYTX / SHE)"
+  },
+  {
+    "id": "DOY",
+    "british": false,
+    "label": "Dongying Shengli Airport (China) (ZSDY / DOY)"
+  },
+  {
+    "id": "MNI",
+    "british": false,
+    "label": "John A. Osborne Airport (Montserrat) (TRPG / MNI)"
+  },
+  {
+    "id": "PSG",
+    "british": false,
+    "label": "Petersburg James A Johnson Airport (United States) (PAPG / PSG)"
+  },
+  {
+    "id": "LYA",
+    "british": false,
+    "label": "Luoyang Airport (China) (ZHLY / LYA)"
+  },
+  {
+    "id": "XUZ",
+    "british": false,
+    "label": "Xuzhou Guanyin Airport (China) (ZSXZ / XUZ)"
+  },
+  {
+    "id": "MWQ",
+    "british": false,
+    "label": "Magway Airport (Burma) (VYMW / MWQ)"
+  },
+  {
+    "id": "KHM",
+    "british": false,
+    "label": "Kanti Airport (Burma) (VYKI / KHM)"
+  },
+  {
+    "id": "DLI",
+    "british": false,
+    "label": "Lien Khuong Airport (Vietnam) (VVDL / DLI)"
+  },
+  {
+    "id": "VDH",
+    "british": false,
+    "label": "Dong Hoi Airport (Vietnam) (VVDH / VDH)"
+  },
+  {
+    "id": "VKG",
+    "british": false,
+    "label": "Rach Gia Airport (Vietnam) (VVRG / VKG)"
+  },
+  {
+    "id": "CAH",
+    "british": false,
+    "label": "Cà Mau Airport (Vietnam) (VVCM / CAH)"
+  },
+  {
+    "id": "VCL",
+    "british": false,
+    "label": "Chu Lai International Airport (Vietnam) (VVCA / VCL)"
+  },
+  {
+    "id": "TBB",
+    "british": false,
+    "label": "Dong Tac Airport (Vietnam) (VVTH / TBB)"
+  },
+  {
+    "id": "PYY",
+    "british": false,
+    "label": "Mae Hong Son Airport (Thailand) (VTCI / PYY)"
+  },
+  {
+    "id": "BWK",
+    "british": false,
+    "label": "Bol Airport (Croatia) (LDSB / BWK)"
+  },
+  {
+    "id": "NSI",
+    "british": false,
+    "label": "Yaoundé Nsimalen International Airport (Cameroon) (FKYS / NSI)"
+  },
+  {
+    "id": "CKY",
+    "british": false,
+    "label": "Conakry International Airport (Guinea) (GUCY / CKY)"
+  },
+  {
+    "id": "AAH",
+    "british": false,
+    "label": "Aachen-Merzbrück Airport (Germany) (EDKA / AAH)"
+  },
+  {
+    "id": "FKB",
+    "british": false,
+    "label": "Karlsruhe Baden-Baden Airport (Germany) (EDSB / FKB)"
+  },
+  {
+    "id": "SFB",
+    "british": false,
+    "label": "Orlando Sanford International Airport (United States) (KSFB / SFB)"
+  },
+  {
+    "id": "JST",
+    "british": false,
+    "label": "John Murtha Johnstown Cambria County Airport (United States) (KJST / JST)"
+  },
+  {
+    "id": "LUA",
+    "british": false,
+    "label": "Lukla Airport (Nepal) (VNLK / LUA)"
+  },
+  {
+    "id": "BHP",
+    "british": false,
+    "label": "Bhojpur Airport (Nepal) (VNBJ / BHP)"
+  },
+  {
+    "id": "LDN",
+    "british": false,
+    "label": "Lamidanda Airport (Nepal) (VNLD / LDN)"
+  },
+  {
+    "id": "JMO",
+    "british": false,
+    "label": "Jomsom Airport (Nepal) (VNJS / JMO)"
+  },
+  {
+    "id": "NGX",
+    "british": false,
+    "label": "Manang Airport (Nepal) (VNMA / NGX)"
+  },
+  {
+    "id": "PPL",
+    "british": false,
+    "label": "Phaplu Airport (Nepal) (VNPL / PPL)"
+  },
+  {
+    "id": "RUM",
+    "british": false,
+    "label": "Rumjatar Airport (Nepal) (VNRT / RUM)"
+  },
+  {
+    "id": "DNP",
+    "british": false,
+    "label": "Tulsipur Airport (Nepal) (VNDG / DNP)"
+  },
+  {
+    "id": "RUK",
+    "british": false,
+    "label": "Rukum Chaurjahari Airport (Nepal) (VNRK / RUK)"
+  },
+  {
+    "id": "JUM",
+    "british": false,
+    "label": "Jumla Airport (Nepal) (VNJL / JUM)"
+  },
+  {
+    "id": "TPJ",
+    "british": false,
+    "label": "Taplejung Airport (Nepal) (VNTJ / TPJ)"
+  },
+  {
+    "id": "TMI",
+    "british": false,
+    "label": "Tumling Tar Airport (Nepal) (VNTR / TMI)"
+  },
+  {
+    "id": "SKH",
+    "british": false,
+    "label": "Surkhet Airport (Nepal) (VNSK / SKH)"
+  },
+  {
+    "id": "IMK",
+    "british": false,
+    "label": "Simikot Airport (Nepal) (VNST / IMK)"
+  },
+  {
+    "id": "DOP",
+    "british": false,
+    "label": "Dolpa Airport (Nepal) (VNDP / DOP)"
+  },
+  {
+    "id": "BJH",
+    "british": false,
+    "label": "Bajhang Airport (Nepal) (VNBG / BJH)"
+  },
+  {
+    "id": "DHI",
+    "british": false,
+    "label": "Dhangarhi Airport (Nepal) (VNDH / DHI)"
+  },
+  {
+    "id": "MWX",
+    "british": false,
+    "label": "Muan International Airport (South Korea) (RKJB / MWX)"
+  },
+  {
+    "id": "JTY",
+    "british": false,
+    "label": "Astypalaia Airport (Greece) (LGPL / JTY)"
+  },
+  {
+    "id": "JIK",
+    "british": false,
+    "label": "Ikaria Airport (Greece) (LGIK / JIK)"
+  },
+  {
+    "id": "JKL",
+    "british": false,
+    "label": "Kalymnos Airport (Greece) (LGKY / JKL)"
+  },
+  {
+    "id": "MLO",
+    "british": false,
+    "label": "Milos Airport (Greece) (LGML / MLO)"
+  },
+  {
+    "id": "JNX",
+    "british": false,
+    "label": "Naxos Airport (Greece) (LGNX / JNX)"
+  },
+  {
+    "id": "PAS",
+    "british": false,
+    "label": "Paros National Airport (Greece) (LGPA / PAS)"
+  },
+  {
+    "id": "KZS",
+    "british": false,
+    "label": "Kastelorizo Airport (Greece) (LGKJ / KZS)"
+  },
+  {
+    "id": "RMF",
+    "british": false,
+    "label": "Marsa Alam International Airport (Egypt) (HEMA / RMF)"
+  },
+  {
+    "id": "NRN",
+    "british": false,
+    "label": "Weeze Airport (Germany) (EDLV / NRN)"
+  },
+  {
+    "id": "USU",
+    "british": false,
+    "label": "Francisco B. Reyes Airport (Philippines) (RPVV / USU)"
+  },
+  {
+    "id": "BXU",
+    "british": false,
+    "label": "Bancasi Airport (Philippines) (RPME / BXU)"
+  },
+  {
+    "id": "DPL",
+    "british": false,
+    "label": "Dipolog Airport (Philippines) (RPMG / DPL)"
+  },
+  {
+    "id": "LAO",
+    "british": false,
+    "label": "Laoag International Airport (Philippines) (RPLI / LAO)"
+  },
+  {
+    "id": "LGP",
+    "british": false,
+    "label": "Legazpi City International Airport (Philippines) (RPLP / LGP)"
+  },
+  {
+    "id": "OZC",
+    "british": false,
+    "label": "Labo Airport (Philippines) (RPMO / OZC)"
+  },
+  {
+    "id": "CEB",
+    "british": false,
+    "label": "Mactan Cebu International Airport (Philippines) (RPVM / CEB)"
+  },
+  {
+    "id": "NOD",
+    "british": false,
+    "label": "Norden-Norddeich Airport (Germany) (EDWS / NOD)"
+  },
+  {
+    "id": "JUI",
+    "british": false,
+    "label": "Juist Airport (Germany) (EDWJ / JUI)"
+  },
+  {
+    "id": "BPS",
+    "british": false,
+    "label": "Porto Seguro Airport (Brazil) (SBPS / BPS)"
+  },
+  {
+    "id": "QIG",
+    "british": false,
+    "label": "Iguatu Airport (Brazil) (SNIG / QIG)"
+  },
+  {
+    "id": "PMW",
+    "british": false,
+    "label": "Brigadeiro Lysias Rodrigues Airport (Brazil) (SBPJ / PMW)"
+  },
+  {
+    "id": "CLV",
+    "british": false,
+    "label": "Nelson Ribeiro Guimarães Airport (Brazil) (SBCN / CLV)"
+  },
+  {
+    "id": "MSO",
+    "british": false,
+    "label": "Missoula International Airport (United States) (KMSO / MSO)"
+  },
+  {
+    "id": "BKQ",
+    "british": false,
+    "label": "Blackall Airport (Australia) (YBCK / BKQ)"
+  },
+  {
+    "id": "BDB",
+    "british": false,
+    "label": "Bundaberg Airport (Australia) (YBUD / BDB)"
+  },
+  {
+    "id": "GCN",
+    "british": false,
+    "label": "Grand Canyon National Park Airport (United States) (KGCN / GCN)"
+  },
+  {
+    "id": "SGR",
+    "british": false,
+    "label": "Sugar Land Regional Airport (United States) (KSGR / SGR)"
+  },
+  {
+    "id": "YHYN",
+    "british": false,
+    "label": "Hayman Island Heliport (Australia) (YHYN)"
+  },
+  {
+    "id": "APA",
+    "british": false,
+    "label": "Centennial Airport (United States) (KAPA / APA)"
+  },
+  {
+    "id": "CVN",
+    "british": false,
+    "label": "Clovis Municipal Airport (United States) (KCVN / CVN)"
+  },
+  {
+    "id": "FST",
+    "british": false,
+    "label": "Fort Stockton Pecos County Airport (United States) (KFST / FST)"
+  },
+  {
+    "id": "LVS",
+    "british": false,
+    "label": "Las Vegas Municipal Airport (United States) (KLVS / LVS)"
+  },
+  {
+    "id": "IWS",
+    "british": false,
+    "label": "West Houston Airport (United States) (KIWS / IWS)"
+  },
+  {
+    "id": "KLHX",
+    "british": false,
+    "label": "La Junta Municipal Airport (United States) (KLHX)"
+  },
+  {
+    "id": "LRU",
+    "british": false,
+    "label": "Las Cruces International Airport (United States) (KLRU / LRU)"
+  },
+  {
+    "id": "BKD",
+    "british": false,
+    "label": "Stephens County Airport (United States) (KBKD / BKD)"
+  },
+  {
+    "id": "TPL",
+    "british": false,
+    "label": "Draughon Miller Central Texas Regional Airport (United States) (KTPL / TPL)"
+  },
+  {
+    "id": "OZA",
+    "british": false,
+    "label": "Ozona Municipal Airport (United States) (KOZA / OZA)"
+  },
+  {
+    "id": "KDM",
+    "british": false,
+    "label": "Kaadedhdhoo Airport (Maldives) (VRMT / KDM)"
+  },
+  {
+    "id": "LAK",
+    "british": false,
+    "label": "Aklavik/Freddie Carmichael Airport (Canada) (CYKD / LAK)"
+  },
+  {
+    "id": "YWJ",
+    "british": false,
+    "label": "Déline Airport (Canada) (CYWJ / YWJ)"
+  },
+  {
+    "id": "ZFN",
+    "british": false,
+    "label": "Tulita Airport (Canada) (CZFN / ZFN)"
+  },
+  {
+    "id": "YGH",
+    "british": false,
+    "label": "Fort Good Hope Airport (Canada) (CYGH / YGH)"
+  },
+  {
+    "id": "TAH",
+    "british": false,
+    "label": "Tanna Airport (Vanuatu) (NVVW / TAH)"
+  },
+  {
+    "id": "YPC",
+    "british": false,
+    "label": "Paulatuk (Nora Aliqatchialuk Ruben) Airport (Canada) (CYPC / YPC)"
+  },
+  {
+    "id": "SRZ",
+    "british": false,
+    "label": "El Trompillo Airport (Bolivia) (SLET / SRZ)"
+  },
+  {
+    "id": "SAB",
+    "british": false,
+    "label": "Juancho E. Yrausquin Airport (Netherlands Antilles) (TNCS / SAB)"
+  },
+  {
+    "id": "EGE",
+    "british": false,
+    "label": "Eagle County Regional Airport (United States) (KEGE / EGE)"
+  },
+  {
+    "id": "SKN",
+    "british": false,
+    "label": "Stokmarknes Skagen Airport (Norway) (ENSK / SKN)"
+  },
+  {
+    "id": "CGF",
+    "british": false,
+    "label": "Cuyahoga County Airport (United States) (KCGF / CGF)"
+  },
+  {
+    "id": "MFD",
+    "british": false,
+    "label": "Mansfield Lahm Regional Airport (United States) (KMFD / MFD)"
+  },
+  {
+    "id": "CSG",
+    "british": false,
+    "label": "Columbus Metropolitan Airport (United States) (KCSG / CSG)"
+  },
+  {
+    "id": "LAW",
+    "british": false,
+    "label": "Lawton Fort Sill Regional Airport (United States) (KLAW / LAW)"
+  },
+  {
+    "id": "FNL",
+    "british": false,
+    "label": "Northern Colorado Regional Airport (United States) (KFNL / FNL)"
+  },
+  {
+    "id": "FLG",
+    "british": false,
+    "label": "Flagstaff Pulliam Airport (United States) (KFLG / FLG)"
+  },
+  {
+    "id": "TVL",
+    "british": false,
+    "label": "Lake Tahoe Airport (United States) (KTVL / TVL)"
+  },
+  {
+    "id": "TWF",
+    "british": false,
+    "label": "Joslin Field Magic Valley Regional Airport (United States) (KTWF / TWF)"
+  },
+  {
+    "id": "MVY",
+    "british": false,
+    "label": "Martha's Vineyard Airport (United States) (KMVY / MVY)"
+  },
+  {
+    "id": "CON",
+    "british": false,
+    "label": "Concord Municipal Airport (United States) (KCON / CON)"
+  },
+  {
+    "id": "GON",
+    "british": false,
+    "label": "Groton New London Airport (United States) (KGON / GON)"
+  },
+  {
+    "id": "STC",
+    "british": false,
+    "label": "St Cloud Regional Airport (United States) (KSTC / STC)"
+  },
+  {
+    "id": "BPE",
+    "british": false,
+    "label": "Qinhuangdao Beidaihe Airport (Burma) (ZBDH / BPE)"
+  },
+  {
+    "id": "GTR",
+    "british": false,
+    "label": "Golden Triangle Regional Airport (United States) (KGTR / GTR)"
+  },
+  {
+    "id": "GOJ",
+    "british": false,
+    "label": "Nizhny Novgorod Strigino International Airport (Russia) (UWGG / GOJ)"
+  },
+  {
+    "id": "HQM",
+    "british": false,
+    "label": "Bowerman Airport (United States) (KHQM / HQM)"
+  },
+  {
+    "id": "ERI",
+    "british": false,
+    "label": "Erie International Tom Ridge Field (United States) (KERI / ERI)"
+  },
+  {
+    "id": "HYA",
+    "british": false,
+    "label": "Barnstable Municipal Boardman Polando Field (United States) (KHYA / HYA)"
+  },
+  {
+    "id": "SPR",
+    "british": false,
+    "label": "San Pedro Airport (Belize) (MZSP / SPR)"
+  },
+  {
+    "id": "SDX",
+    "british": false,
+    "label": "Sedona Airport (United States) (KSEZ / SDX)"
+  },
+  {
+    "id": "MGW",
+    "british": false,
+    "label": "Morgantown Municipal Walter L. Bill Hart Field (United States) (KMGW / MGW)"
+  },
+  {
+    "id": "CRW",
+    "british": false,
+    "label": "Yeager Airport (United States) (KCRW / CRW)"
+  },
+  {
+    "id": "AVP",
+    "british": false,
+    "label": "Wilkes Barre Scranton International Airport (United States) (KAVP / AVP)"
+  },
+  {
+    "id": "BJI",
+    "british": false,
+    "label": "Bemidji Regional Airport (United States) (KBJI / BJI)"
+  },
+  {
+    "id": "THG",
+    "british": false,
+    "label": "Thangool Airport (Australia) (YTNG / THG)"
+  },
+  {
+    "id": "FGI",
+    "british": false,
+    "label": "Fagali'i Airport (Samoa) (NSFI / FGI)"
+  },
+  {
+    "id": "BNK",
+    "british": false,
+    "label": "Ballina Byron Gateway Airport (Australia) (YBNA / BNK)"
+  },
+  {
+    "id": "FAR",
+    "british": false,
+    "label": "Hector International Airport (United States) (KFAR / FAR)"
+  },
+  {
+    "id": "MKC",
+    "british": false,
+    "label": "Charles B. Wheeler Downtown Airport (United States) (KMKC / MKC)"
+  },
+  {
+    "id": "RBE",
+    "british": false,
+    "label": "Ratanakiri Airport (Cambodia) (VDRK / RBE)"
+  },
+  {
+    "id": "GCC",
+    "british": false,
+    "label": "Gillette Campbell County Airport (United States) (KGCC / GCC)"
+  },
+  {
+    "id": "TOF",
+    "british": false,
+    "label": "Bogashevo Airport (Russia) (UNTT / TOF)"
+  },
+  {
+    "id": "NZJ",
+    "british": false,
+    "label": "El Toro Marine Corps Air Station (United States) (KNZJ / NZJ)"
+  },
+  {
+    "id": "PHY",
+    "british": false,
+    "label": "Phetchabun Airport (Thailand) (VTPB / PHY)"
+  },
+  {
+    "id": "CJM",
+    "british": false,
+    "label": "Chumphon Airport (Thailand) (VTSE / CJM)"
+  },
+  {
+    "id": "JZH",
+    "british": false,
+    "label": "Jiuzhai Huanglong Airport (China) (ZUJZ / JZH)"
+  },
+  {
+    "id": "SWA",
+    "british": false,
+    "label": "Jieyang Chaoshan International Airport (China) (ZGOW / SWA)"
+  },
+  {
+    "id": "LFFE",
+    "british": false,
+    "label": "Enghien Moisselles Airfield (France) (LFFE)"
+  },
+  {
+    "id": "GEO",
+    "british": false,
+    "label": "Cheddi Jagan International Airport (Guyana) (SYCJ / GEO)"
+  },
+  {
+    "id": "AGT",
+    "british": false,
+    "label": "Guarani International Airport (Paraguay) (SGES / AGT)"
+  },
+  {
+    "id": "OGL",
+    "british": false,
+    "label": "Eugene F. Correira International Airport (Guyana) (SYGO / OGL)"
+  },
+  {
+    "id": "KAI",
+    "british": false,
+    "label": "Kaieteur International Airport (Guyana) (PKSA / KAI)"
+  },
+  {
+    "id": "DNH",
+    "british": false,
+    "label": "Dunhuang Airport (China) (ZLDH / DNH)"
+  },
+  {
+    "id": "AOI",
+    "british": false,
+    "label": "Ancona Falconara Airport (Italy) (LIPY / AOI)"
+  },
+  {
+    "id": "SCHA",
+    "british": false,
+    "label": "Chamonate Airport (Chile) (SCHA)"
+  },
+  {
+    "id": "TCP",
+    "british": false,
+    "label": "Taba International Airport (Egypt) (HETB / TCP)"
+  },
+  {
+    "id": "LYB",
+    "british": false,
+    "label": "Edward Bodden Airfield (Cayman Islands) (MWCL / LYB)"
+  },
+  {
+    "id": "BJV",
+    "british": false,
+    "label": "Milas Bodrum International Airport (Turkey) (LTFE / BJV)"
+  },
+  {
+    "id": "TBJ",
+    "british": false,
+    "label": "Tabarka 7 Novembre Airport (Tunisia) (DTKA / TBJ)"
+  },
+  {
+    "id": "SAW",
+    "british": false,
+    "label": "Sabiha Gökçen International Airport (Turkey) (LTFJ / SAW)"
+  },
+  {
+    "id": "SCE",
+    "british": false,
+    "label": "University Park Airport (United States) (KUNV / SCE)"
+  },
+  {
+    "id": "BME",
+    "british": false,
+    "label": "Broome International Airport (Australia) (YBRM / BME)"
+  },
+  {
+    "id": "NTL",
+    "british": false,
+    "label": "Newcastle Airport (Australia) (YWLM / NTL)"
+  },
+  {
+    "id": "BIBA",
+    "british": false,
+    "label": "Bakki Airport (Iceland) (BIBA)"
+  },
+  {
+    "id": "KLU",
+    "british": false,
+    "label": "Klagenfurt Airport (Austria) (LOWK / KLU)"
+  },
+  {
+    "id": "HFT",
+    "british": false,
+    "label": "Hammerfest Airport (Norway) (ENHF / HFT)"
+  },
+  {
+    "id": "HVG",
+    "british": false,
+    "label": "Valan Airport (Norway) (ENHV / HVG)"
+  },
+  {
+    "id": "MEH",
+    "british": false,
+    "label": "Mehamn Airport (Norway) (ENMH / MEH)"
+  },
+  {
+    "id": "VDS",
+    "british": false,
+    "label": "Vadsø Airport (Norway) (ENVD / VDS)"
+  },
+  {
+    "id": "IKA",
+    "british": false,
+    "label": "Imam Khomeini International Airport (Iran) (OIIE / IKA)"
+  },
+  {
+    "id": "MHD",
+    "british": false,
+    "label": "Mashhad International Airport (Iran) (OIMM / MHD)"
+  },
+  {
+    "id": "UIK",
+    "british": false,
+    "label": "Ust-Ilimsk Airport (Russia) (UIBS / UIK)"
+  },
+  {
+    "id": "MEI",
+    "british": false,
+    "label": "Key Field (United States) (KMEI / MEI)"
+  },
+  {
+    "id": "SPI",
+    "british": false,
+    "label": "Abraham Lincoln Capital Airport (United States) (KSPI / SPI)"
+  },
+  {
+    "id": "CEZ",
+    "british": false,
+    "label": "Cortez Municipal Airport (United States) (KCEZ / CEZ)"
+  },
+  {
+    "id": "HDN",
+    "british": false,
+    "label": "Yampa Valley Airport (United States) (KHDN / HDN)"
+  },
+  {
+    "id": "GUP",
+    "british": false,
+    "label": "Gallup Municipal Airport (United States) (KGUP / GUP)"
+  },
+  {
+    "id": "LBL",
+    "british": false,
+    "label": "Liberal Mid-America Regional Airport (United States) (KLBL / LBL)"
+  },
+  {
+    "id": "LAA",
+    "british": false,
+    "label": "Lamar Municipal Airport (United States) (KLAA / LAA)"
+  },
+  {
+    "id": "GLD",
+    "british": false,
+    "label": "Renner Field-Goodland Municipal Airport (United States) (KGLD / GLD)"
+  },
+  {
+    "id": "COD",
+    "british": false,
+    "label": "Yellowstone Regional Airport (United States) (KCOD / COD)"
+  },
+  {
+    "id": "HOV",
+    "british": false,
+    "label": "Ørsta-Volda Airport, Hovden (Norway) (ENOV / HOV)"
+  },
+  {
+    "id": "ISC",
+    "british": true,
+    "label": "St. Mary's Airport (United Kingdom) (EGHE / ISC)"
+  },
+  {
+    "id": "SGF",
+    "british": false,
+    "label": "Springfield Branson National Airport (United States) (KSGF / SGF)"
+  },
+  {
+    "id": "NVK",
+    "british": false,
+    "label": "Narvik Framnes Airport (Norway) (ENNK / NVK)"
+  },
+  {
+    "id": "BVG",
+    "british": false,
+    "label": "Berlevåg Airport (Norway) (ENBV / BVG)"
+  },
+  {
+    "id": "FBU",
+    "british": false,
+    "label": "Oslo, Fornebu Airport (Norway) (ENFB / FBU)"
+  },
+  {
+    "id": "NSK",
+    "british": false,
+    "label": "Norilsk-Alykel Airport (Russia) (UOOO / NSK)"
+  },
+  {
+    "id": "AAQ",
+    "british": false,
+    "label": "Anapa Vityazevo Airport (Russia) (URKA / AAQ)"
+  },
+  {
+    "id": "JLN",
+    "british": false,
+    "label": "Joplin Regional Airport (United States) (KJLN / JLN)"
+  },
+  {
+    "id": "ABE",
+    "british": false,
+    "label": "Lehigh Valley International Airport (United States) (KABE / ABE)"
+  },
+  {
+    "id": "XNA",
+    "british": false,
+    "label": "Northwest Arkansas Regional Airport (United States) (KXNA / XNA)"
+  },
+  {
+    "id": "GUW",
+    "british": false,
+    "label": "Atyrau Airport (Kazakhstan) (UATG / GUW)"
+  },
+  {
+    "id": "KZO",
+    "british": false,
+    "label": "Kzyl-Orda Southwest Airport (Kazakhstan) (UAOO / KZO)"
+  },
+  {
+    "id": "SBN",
+    "british": false,
+    "label": "South Bend Regional Airport (United States) (KSBN / SBN)"
+  },
+  {
+    "id": "BKA",
+    "british": false,
+    "label": "Bykovo Airport (Russia) (UUBB / BKA)"
+  },
+  {
+    "id": "ARH",
+    "british": false,
+    "label": "Talagi Airport (Russia) (ULAA / ARH)"
+  },
+  {
+    "id": "RTW",
+    "british": false,
+    "label": "Saratov Central Airport (Russia) (UWSS / RTW)"
+  },
+  {
+    "id": "NUX",
+    "british": false,
+    "label": "Novy Urengoy Airport (Russia) (USMU / NUX)"
+  },
+  {
+    "id": "NOJ",
+    "british": false,
+    "label": "Noyabrsk Airport (Russia) (USRO / NOJ)"
+  },
+  {
+    "id": "SCO",
+    "british": false,
+    "label": "Aktau Airport (Kazakhstan) (UATE / SCO)"
+  },
+  {
+    "id": "UCT",
+    "british": false,
+    "label": "Ukhta Airport (Russia) (UUYH / UCT)"
+  },
+  {
+    "id": "USK",
+    "british": false,
+    "label": "Usinsk Airport (Russia) (UUYS / USK)"
+  },
+  {
+    "id": "PEX",
+    "british": false,
+    "label": "Pechora Airport (Russia) (UUYP / PEX)"
+  },
+  {
+    "id": "NNM",
+    "british": false,
+    "label": "Naryan Mar Airport (Russia) (ULAM / NNM)"
+  },
+  {
+    "id": "PKV",
+    "british": false,
+    "label": "Pskov Airport (Russia) (ULOO / PKV)"
+  },
+  {
+    "id": "KGP",
+    "british": false,
+    "label": "Kogalym International Airport (Russia) (USRK / KGP)"
+  },
+  {
+    "id": "KJA",
+    "british": false,
+    "label": "Yemelyanovo Airport (Russia) (UNKL / KJA)"
+  },
+  {
+    "id": "KGF",
+    "british": false,
+    "label": "Sary-Arka Airport (Kazakhstan) (UAKK / KGF)"
+  },
+  {
+    "id": "UNCC",
+    "british": false,
+    "label": "Novosibirsk North Airport (Russia) (UNCC)"
+  },
+  {
+    "id": "URJ",
+    "british": false,
+    "label": "Uray Airport (Russia) (USHU / URJ)"
+  },
+  {
+    "id": "IWA",
+    "british": false,
+    "label": "Ivanovo South Airport (Russia) (UUBI / IWA)"
+  },
+  {
+    "id": "CGQ",
+    "british": false,
+    "label": "Longjia Airport (China) (ZYCC / CGQ)"
+  },
+  {
+    "id": "KIJ",
+    "british": false,
+    "label": "Niigata Airport (Japan) (RJSN / KIJ)"
+  },
+  {
+    "id": "JON",
+    "british": false,
+    "label": "Johnston Atoll Airport (Johnston Atoll) (PJON / JON)"
+  },
+  {
+    "id": "SMD",
+    "british": false,
+    "label": "Smith Field (United States) (KSMD / SMD)"
+  },
+  {
+    "id": "ACV",
+    "british": false,
+    "label": "California Redwood Coast-Humboldt County Airport (United States) (KACV / ACV)"
+  },
+  {
+    "id": "OAJ",
+    "british": false,
+    "label": "Albert J Ellis Airport (United States) (KOAJ / OAJ)"
+  },
+  {
+    "id": "TCL",
+    "british": false,
+    "label": "Tuscaloosa Regional Airport (United States) (KTCL / TCL)"
+  },
+  {
+    "id": "DBQ",
+    "british": false,
+    "label": "Dubuque Regional Airport (United States) (KDBQ / DBQ)"
+  },
+  {
+    "id": "HHP",
+    "british": false,
+    "label": "Shun Tak Heliport (Hong Kong) (VHST / HHP)"
+  },
+  {
+    "id": "ATD",
+    "british": false,
+    "label": "Uru Harbour Airport (Solomon Islands) (AGAT / ATD)"
+  },
+  {
+    "id": "AKS",
+    "british": false,
+    "label": "Gwaunaru'u Airport (Solomon Islands) (AGGA / AKS)"
+  },
+  {
+    "id": "BAS",
+    "british": false,
+    "label": "Ballalae Airport (Solomon Islands) (AGGE / BAS)"
+  },
+  {
+    "id": "FRE",
+    "british": false,
+    "label": "Fera/Maringe Airport (Solomon Islands) (AGGF / FRE)"
+  },
+  {
+    "id": "MBU",
+    "british": false,
+    "label": "Babanakira Airport (Solomon Islands) (AGGI / MBU)"
+  },
+  {
+    "id": "IRA",
+    "british": false,
+    "label": "Ngorangora Airport (Solomon Islands) (AGGK / IRA)"
+  },
+  {
+    "id": "SCZ",
+    "british": false,
+    "label": "Santa Cruz/Graciosa Bay/Luova Airport (Solomon Islands) (AGGL / SCZ)"
+  },
+  {
+    "id": "MUA",
+    "british": false,
+    "label": "Munda Airport (Solomon Islands) (AGGM / MUA)"
+  },
+  {
+    "id": "GZO",
+    "british": false,
+    "label": "Nusatupe Airport (Solomon Islands) (AGGN / GZO)"
+  },
+  {
+    "id": "MNY",
+    "british": false,
+    "label": "Mono Airport (Solomon Islands) (AGGO / MNY)"
+  },
+  {
+    "id": "RNL",
+    "british": false,
+    "label": "Rennell/Tingoa Airport (Solomon Islands) (AGGR / RNL)"
+  },
+  {
+    "id": "RUS",
+    "british": false,
+    "label": "Marau Airport (Solomon Islands) (AGGU / RUS)"
+  },
+  {
+    "id": "VAO",
+    "british": false,
+    "label": "Suavanao Airport (Solomon Islands) (AGGV / VAO)"
+  },
+  {
+    "id": "KGE",
+    "british": false,
+    "label": "Kaghau Airport (Solomon Islands) (AGKG / KGE)"
+  },
+  {
+    "id": "RBV",
+    "british": false,
+    "label": "Ramata Airport (Solomon Islands) (AGRM / RBV)"
+  },
+  {
+    "id": "BUA",
+    "british": false,
+    "label": "Buka Airport (Papua New Guinea) (AYBK / BUA)"
+  },
+  {
+    "id": "CMU",
+    "british": false,
+    "label": "Chimbu Airport (Papua New Guinea) (AYCH / CMU)"
+  },
+  {
+    "id": "DAU",
+    "british": false,
+    "label": "Daru Airport (Papua New Guinea) (AYDU / DAU)"
+  },
+  {
+    "id": "GUR",
+    "british": false,
+    "label": "Gurney Airport (Papua New Guinea) (AYGN / GUR)"
+  },
+  {
+    "id": "PNP",
+    "british": false,
+    "label": "Girua Airport (Papua New Guinea) (AYGR / PNP)"
+  },
+  {
+    "id": "HKN",
+    "british": false,
+    "label": "Kimbe Airport (Papua New Guinea) (AYHK / HKN)"
+  },
+  {
+    "id": "UNG",
+    "british": false,
+    "label": "Kiunga Airport (Papua New Guinea) (AYKI / UNG)"
+  },
+  {
+    "id": "KRI",
+    "british": false,
+    "label": "Kikori Airport (Papua New Guinea) (AYKK / KRI)"
+  },
+  {
+    "id": "KMA",
+    "british": false,
+    "label": "Kerema Airport (Papua New Guinea) (AYKM / KMA)"
+  },
+  {
+    "id": "KVG",
+    "british": false,
+    "label": "Kavieng Airport (Papua New Guinea) (AYKV / KVG)"
+  },
+  {
+    "id": "MDU",
+    "british": false,
+    "label": "Mendi Airport (Papua New Guinea) (AYMN / MDU)"
+  },
+  {
+    "id": "MAS",
+    "british": false,
+    "label": "Momote Airport (Papua New Guinea) (AYMO / MAS)"
+  },
+  {
+    "id": "MXH",
+    "british": false,
+    "label": "Moro Airport (Papua New Guinea) (AYMR / MXH)"
+  },
+  {
+    "id": "MIS",
+    "british": false,
+    "label": "Misima Island Airport (Papua New Guinea) (AYMS / MIS)"
+  },
+  {
+    "id": "TIZ",
+    "british": false,
+    "label": "Tari Airport (Papua New Guinea) (AYTA / TIZ)"
+  },
+  {
+    "id": "TBG",
+    "british": false,
+    "label": "Tabubil Airport (Papua New Guinea) (AYTB / TBG)"
+  },
+  {
+    "id": "RAB",
+    "british": false,
+    "label": "Tokua Airport (Papua New Guinea) (AYTK / RAB)"
+  },
+  {
+    "id": "VAI",
+    "british": false,
+    "label": "Vanimo Airport (Papua New Guinea) (AYVN / VAI)"
+  },
+  {
+    "id": "WBM",
+    "british": false,
+    "label": "Wapenamanda Airport (Papua New Guinea) (AYWD / WBM)"
+  },
+  {
+    "id": "LLU",
+    "british": false,
+    "label": "Alluitsup Paa Heliport (Greenland) (BGAP / LLU)"
+  },
+  {
+    "id": "CNP",
+    "british": false,
+    "label": "Neerlerit Inaat Airport (Greenland) (BGCO / CNP)"
+  },
+  {
+    "id": "JFR",
+    "british": false,
+    "label": "Paamiut Heliport (Greenland) (BGFH / JFR)"
+  },
+  {
+    "id": "JGO",
+    "british": false,
+    "label": "Qeqertarsuaq Heliport (Greenland) (BGGN / JGO)"
+  },
+  {
+    "id": "JJU",
+    "british": false,
+    "label": "Qaqortoq Heliport (Greenland) (BGJH / JJU)"
+  },
+  {
+    "id": "JSU",
+    "british": false,
+    "label": "Maniitsoq Airport (Greenland) (BGMQ / JSU)"
+  },
+  {
+    "id": "JNN",
+    "british": false,
+    "label": "Nanortalik Heliport (Greenland) (BGNN / JNN)"
+  },
+  {
+    "id": "JNS",
+    "british": false,
+    "label": "Narsaq Heliport (Greenland) (BGNS / JNS)"
+  },
+  {
+    "id": "NAQ",
+    "british": false,
+    "label": "Qaanaaq Airport (Greenland) (BGQQ / NAQ)"
+  },
+  {
+    "id": "JHS",
+    "british": false,
+    "label": "Sisimiut Airport (Greenland) (BGSS / JHS)"
+  },
+  {
+    "id": "JUV",
+    "british": false,
+    "label": "Upernavik Airport (Greenland) (BGUK / JUV)"
+  },
+  {
+    "id": "JQA",
+    "british": false,
+    "label": "Qaarsut Airport (Greenland) (BGUQ / JQA)"
+  },
+  {
+    "id": "GRY",
+    "british": false,
+    "label": "Grímsey Airport (Iceland) (BIGR / GRY)"
+  },
+  {
+    "id": "THO",
+    "british": false,
+    "label": "Thorshofn Airport (Iceland) (BITN / THO)"
+  },
+  {
+    "id": "VPN",
+    "british": false,
+    "label": "Vopnafjörður Airport (Iceland) (BIVO / VPN)"
+  },
+  {
+    "id": "YWS",
+    "british": false,
+    "label": "Whistler/Green Lake Water Aerodrome (Canada) (CAE5 / YWS)"
+  },
+  {
+    "id": "YAA",
+    "british": false,
+    "label": "Anahim Lake Airport (Canada) (CAJ4 / YAA)"
+  },
+  {
+    "id": "YWM",
+    "british": false,
+    "label": "Williams Harbour Airport (Canada) (CCA6 / YWM)"
+  },
+  {
+    "id": "YFX",
+    "british": false,
+    "label": "St. Lewis (Fox Harbour) Airport (Canada) (CCK4 / YFX)"
+  },
+  {
+    "id": "YHA",
+    "british": false,
+    "label": "Port Hope Simpson Airport (Canada) (CCP4 / YHA)"
+  },
+  {
+    "id": "YRG",
+    "british": false,
+    "label": "Rigolet Airport (Canada) (CCZ2 / YRG)"
+  },
+  {
+    "id": "YCK",
+    "british": false,
+    "label": "Colville Lake Airport (Canada) (CEB3 / YCK)"
+  },
+  {
+    "id": "YLE",
+    "british": false,
+    "label": "Whatì Airport (Canada) (CEM3 / YLE)"
+  },
+  {
+    "id": "SUR",
+    "british": false,
+    "label": "Summer Beaver Airport (Canada) (CJV7 / SUR)"
+  },
+  {
+    "id": "YAX",
+    "british": false,
+    "label": "Wapekeka Airport (Canada) (CKB6 / YAX)"
+  },
+  {
+    "id": "WNN",
+    "british": false,
+    "label": "Wunnumin Lake Airport (Canada) (CKL3 / WNN)"
+  },
+  {
+    "id": "YNO",
+    "british": false,
+    "label": "North Spirit Lake Airport (Canada) (CKQ3 / YNO)"
+  },
+  {
+    "id": "XBE",
+    "british": false,
+    "label": "Bearskin Lake Airport (Canada) (CNE3 / XBE)"
+  },
+  {
+    "id": "KIF",
+    "british": false,
+    "label": "Kingfisher Lake Airport (Canada) (CNM5 / KIF)"
+  },
+  {
+    "id": "YOG",
+    "british": false,
+    "label": "Ogoki Post Airport (Canada) (CNT3 / YOG)"
+  },
+  {
+    "id": "YHP",
+    "british": false,
+    "label": "Poplar Hill Airport (Canada) (CPV7 / YHP)"
+  },
+  {
+    "id": "YKU",
+    "british": false,
+    "label": "Chisasibi Airport (Canada) (CSU2 / YKU)"
+  },
+  {
+    "id": "ZTB",
+    "british": false,
+    "label": "Tête-à-la-Baleine Airport (Canada) (CTB6 / ZTB)"
+  },
+  {
+    "id": "ZLT",
+    "british": false,
+    "label": "La Tabatière Airport (Canada) (CTU5 / ZLT)"
+  },
+  {
+    "id": "YAC",
+    "british": false,
+    "label": "Cat Lake Airport (Canada) (CYAC / YAC)"
+  },
+  {
+    "id": "YAG",
+    "british": false,
+    "label": "Fort Frances Municipal Airport (Canada) (CYAG / YAG)"
+  },
+  {
+    "id": "XKS",
+    "british": false,
+    "label": "Kasabonika Airport (Canada) (CYAQ / XKS)"
+  },
+  {
+    "id": "YKG",
+    "british": false,
+    "label": "Kangirsuk Airport (Canada) (CYAS / YKG)"
+  },
+  {
+    "id": "YAT",
+    "british": false,
+    "label": "Attawapiskat Airport (Canada) (CYAT / YAT)"
+  },
+  {
+    "id": "CYAX",
+    "british": false,
+    "label": "Lac Du Bonnet Airport (Canada) (CYAX)"
+  },
+  {
+    "id": "YBE",
+    "british": false,
+    "label": "Uranium City Airport (Canada) (CYBE / YBE)"
+  },
+  {
+    "id": "YBX",
+    "british": false,
+    "label": "Lourdes de Blanc Sablon Airport (Canada) (CYBX / YBX)"
+  },
+  {
+    "id": "YRF",
+    "british": false,
+    "label": "Cartwright Airport (Canada) (CYCA / YRF)"
+  },
+  {
+    "id": "YCS",
+    "british": false,
+    "label": "Chesterfield Inlet Airport (Canada) (CYCS / YCS)"
+  },
+  {
+    "id": "YDP",
+    "british": false,
+    "label": "Nain Airport (Canada) (CYDP / YDP)"
+  },
+  {
+    "id": "YER",
+    "british": false,
+    "label": "Fort Severn Airport (Canada) (CYER / YER)"
+  },
+  {
+    "id": "YFA",
+    "british": false,
+    "label": "Fort Albany Airport (Canada) (CYFA / YFA)"
+  },
+  {
+    "id": "YFH",
+    "british": false,
+    "label": "Fort Hope Airport (Canada) (CYFH / YFH)"
+  },
+  {
+    "id": "YMN",
+    "british": false,
+    "label": "Makkovik Airport (Canada) (CYFT / YMN)"
+  },
+  {
+    "id": "YGB",
+    "british": false,
+    "label": "Texada Gillies Bay Airport (Canada) (CYGB / YGB)"
+  },
+  {
+    "id": "YGO",
+    "british": false,
+    "label": "Gods Lake Narrows Airport (Canada) (CYGO / YGO)"
+  },
+  {
+    "id": "YGT",
+    "british": false,
+    "label": "Igloolik Airport (Canada) (CYGT / YGT)"
+  },
+  {
+    "id": "YGW",
+    "british": false,
+    "label": "Kuujjuarapik Airport (Canada) (CYGW / YGW)"
+  },
+  {
+    "id": "YGX",
+    "british": false,
+    "label": "Gillam Airport (Canada) (CYGX / YGX)"
+  },
+  {
+    "id": "YGZ",
+    "british": false,
+    "label": "Grise Fiord Airport (Canada) (CYGZ / YGZ)"
+  },
+  {
+    "id": "YQC",
+    "british": false,
+    "label": "Quaqtaq Airport (Canada) (CYHA / YQC)"
+  },
+  {
+    "id": "CXH",
+    "british": false,
+    "label": "Vancouver Harbour Water Aerodrome (Canada) (CYHC / CXH)"
+  },
+  {
+    "id": "YNS",
+    "british": false,
+    "label": "Nemiscau Airport (Canada) (CYHH / YNS)"
+  },
+  {
+    "id": "YHO",
+    "british": false,
+    "label": "Hopedale Airport (Canada) (CYHO / YHO)"
+  },
+  {
+    "id": "YHR",
+    "british": false,
+    "label": "Chevery Airport (Canada) (CYHR / YHR)"
+  },
+  {
+    "id": "YIK",
+    "british": false,
+    "label": "Ivujivik Airport (Canada) (CYIK / YIK)"
+  },
+  {
+    "id": "YIV",
+    "british": false,
+    "label": "Island Lake Airport (Canada) (CYIV / YIV)"
+  },
+  {
+    "id": "AKV",
+    "british": false,
+    "label": "Akulivik Airport (Canada) (CYKO / AKV)"
+  },
+  {
+    "id": "YKQ",
+    "british": false,
+    "label": "Waskaganish Airport (Canada) (CYKQ / YKQ)"
+  },
+  {
+    "id": "YPJ",
+    "british": false,
+    "label": "Aupaluk Airport (Canada) (CYLA / YPJ)"
+  },
+  {
+    "id": "YLC",
+    "british": false,
+    "label": "Kimmirut Airport (Canada) (CYLC / YLC)"
+  },
+  {
+    "id": "YLH",
+    "british": false,
+    "label": "Lansdowne House Airport (Canada) (CYLH / YLH)"
+  },
+  {
+    "id": "CYSG",
+    "british": false,
+    "label": "St Georges Airport (Canada) (CYSG)"
+  },
+  {
+    "id": "XGR",
+    "british": false,
+    "label": "Kangiqsualujjuaq (Georges River) Airport (Canada) (CYLU / XGR)"
+  },
+  {
+    "id": "YMH",
+    "british": false,
+    "label": "Mary's Harbour Airport (Canada) (CYMH / YMH)"
+  },
+  {
+    "id": "YMT",
+    "british": false,
+    "label": "Chapais Airport (Canada) (CYMT / YMT)"
+  },
+  {
+    "id": "YUD",
+    "british": false,
+    "label": "Umiujaq Airport (Canada) (CYMU / YUD)"
+  },
+  {
+    "id": "YNC",
+    "british": false,
+    "label": "Wemindji Airport (Canada) (CYNC / YNC)"
+  },
+  {
+    "id": "YNE",
+    "british": false,
+    "label": "Norway House Airport (Canada) (CYNE / YNE)"
+  },
+  {
+    "id": "YNL",
+    "british": false,
+    "label": "Points North Landing Airport (Canada) (CYNL / YNL)"
+  },
+  {
+    "id": "YOH",
+    "british": false,
+    "label": "Oxford House Airport (Canada) (CYOH / YOH)"
+  },
+  {
+    "id": "YPH",
+    "british": false,
+    "label": "Inukjuak Airport (Canada) (CYPH / YPH)"
+  },
+  {
+    "id": "YPM",
+    "british": false,
+    "label": "Pikangikum Airport (Canada) (CYPM / YPM)"
+  },
+  {
+    "id": "YPO",
+    "british": false,
+    "label": "Peawanuck Airport (Canada) (CYPO / YPO)"
+  },
+  {
+    "id": "YPW",
+    "british": false,
+    "label": "Powell River Airport (Canada) (CYPW / YPW)"
+  },
+  {
+    "id": "YQD",
+    "british": false,
+    "label": "The Pas Airport (Canada) (CYQD / YQD)"
+  },
+  {
+    "id": "YQN",
+    "british": false,
+    "label": "Nakina Airport (Canada) (CYQN / YQN)"
+  },
+  {
+    "id": "YRA",
+    "british": false,
+    "label": "Rae Lakes Airport (Canada) (CYRA / YRA)"
+  },
+  {
+    "id": "YRL",
+    "british": false,
+    "label": "Red Lake Airport (Canada) (CYRL / YRL)"
+  },
+  {
+    "id": "YSF",
+    "british": false,
+    "label": "Stony Rapids Airport (Canada) (CYSF / YSF)"
+  },
+  {
+    "id": "YSK",
+    "british": false,
+    "label": "Sanikiluaq Airport (Canada) (CYSK / YSK)"
+  },
+  {
+    "id": "YST",
+    "british": false,
+    "label": "St. Theresa Point Airport (Canada) (CYST / YST)"
+  },
+  {
+    "id": "YTL",
+    "british": false,
+    "label": "Big Trout Lake Airport (Canada) (CYTL / YTL)"
+  },
+  {
+    "id": "YVZ",
+    "british": false,
+    "label": "Deer Lake Airport (Canada) (CYVZ / YVZ)"
+  },
+  {
+    "id": "YWP",
+    "british": false,
+    "label": "Webequie Airport (Canada) (CYWP / YWP)"
+  },
+  {
+    "id": "YXN",
+    "british": false,
+    "label": "Whale Cove Airport (Canada) (CYXN / YXN)"
+  },
+  {
+    "id": "YZG",
+    "british": false,
+    "label": "Salluit Airport (Canada) (CYZG / YZG)"
+  },
+  {
+    "id": "ZAC",
+    "british": false,
+    "label": "York Landing Airport (Canada) (CZAC / ZAC)"
+  },
+  {
+    "id": "ILF",
+    "british": false,
+    "label": "Ilford Airport (Canada) (CZBD / ILF)"
+  },
+  {
+    "id": "ZBF",
+    "british": false,
+    "label": "Bathurst Airport (Canada) (CZBF / ZBF)"
+  },
+  {
+    "id": "ZEM",
+    "british": false,
+    "label": "Eastmain River Airport (Canada) (CZEM / ZEM)"
+  },
+  {
+    "id": "ZFD",
+    "british": false,
+    "label": "Fond-Du-Lac Airport (Canada) (CZFD / ZFD)"
+  },
+  {
+    "id": "ZGI",
+    "british": false,
+    "label": "Gods River Airport (Canada) (CZGI / ZGI)"
+  },
+  {
+    "id": "ZJN",
+    "british": false,
+    "label": "Swan River Airport (Canada) (CZJN / ZJN)"
+  },
+  {
+    "id": "ZKE",
+    "british": false,
+    "label": "Kashechewan Airport (Canada) (CZKE / ZKE)"
+  },
+  {
+    "id": "MSA",
+    "british": false,
+    "label": "Muskrat Dam Airport (Canada) (CZMD / MSA)"
+  },
+  {
+    "id": "ZMT",
+    "british": false,
+    "label": "Masset Airport (Canada) (CZMT / ZMT)"
+  },
+  {
+    "id": "ZPB",
+    "british": false,
+    "label": "Sachigo Lake Airport (Canada) (CZPB / ZPB)"
+  },
+  {
+    "id": "ZRJ",
+    "british": false,
+    "label": "Round Lake (Weagamow Lake) Airport (Canada) (CZRJ / ZRJ)"
+  },
+  {
+    "id": "ZSJ",
+    "british": false,
+    "label": "Sandy Lake Airport (Canada) (CZSJ / ZSJ)"
+  },
+  {
+    "id": "ZTM",
+    "british": false,
+    "label": "Shamattawa Airport (Canada) (CZTM / ZTM)"
+  },
+  {
+    "id": "ZUM",
+    "british": false,
+    "label": "Churchill Falls Airport (Canada) (CZUM / ZUM)"
+  },
+  {
+    "id": "ZWL",
+    "british": false,
+    "label": "Wollaston Lake Airport (Canada) (CZWL / ZWL)"
+  },
+  {
+    "id": "BLJ",
+    "british": false,
+    "label": "Batna Airport (Algeria) (DABT / BLJ)"
+  },
+  {
+    "id": "CBH",
+    "british": false,
+    "label": "Béchar Boudghene Ben Ali Lotfi Airport (Algeria) (DAOR / CBH)"
+  },
+  {
+    "id": "BMW",
+    "british": false,
+    "label": "Bordj Badji Mokhtar Airport (Algeria) (DATM / BMW)"
+  },
+  {
+    "id": "ELU",
+    "british": false,
+    "label": "Guemar Airport (Algeria) (DAUO / ELU)"
+  },
+  {
+    "id": "KMS",
+    "british": false,
+    "label": "Kumasi Airport (Ghana) (DGSI / KMS)"
+  },
+  {
+    "id": "HDF",
+    "british": false,
+    "label": "Heringsdorf Airport (Germany) (EDAH / HDF)"
+  },
+  {
+    "id": "HEI",
+    "british": false,
+    "label": "Heide-Büsum Airport (Germany) (EDXB / HEI)"
+  },
+  {
+    "id": "HGL",
+    "british": false,
+    "label": "Helgoland-Düne Airport (Germany) (EDXH / HGL)"
+  },
+  {
+    "id": "SJY",
+    "british": false,
+    "label": "Seinäjoki Airport (Finland) (EFSI / SJY)"
+  },
+  {
+    "id": "NQT",
+    "british": true,
+    "label": "Nottingham Airport (United Kingdom) (EGBN / NQT)"
+  },
+  {
+    "id": "DSA",
+    "british": true,
+    "label": "Robin Hood Doncaster Sheffield Airport (United Kingdom) (EGCN / DSA)"
+  },
+  {
+    "id": "CAL",
+    "british": true,
+    "label": "Campbeltown Airport (United Kingdom) (EGEC / CAL)"
+  },
+  {
+    "id": "EOI",
+    "british": true,
+    "label": "Eday Airport (United Kingdom) (EGED / EOI)"
+  },
+  {
+    "id": "FIE",
+    "british": true,
+    "label": "Fair Isle Airport (United Kingdom) (EGEF / FIE)"
+  },
+  {
+    "id": "NRL",
+    "british": true,
+    "label": "North Ronaldsay Airport (United Kingdom) (EGEN / NRL)"
+  },
+  {
+    "id": "PPW",
+    "british": true,
+    "label": "Papa Westray Airport (United Kingdom) (EGEP / PPW)"
+  },
+  {
+    "id": "SOY",
+    "british": true,
+    "label": "Stronsay Airport (United Kingdom) (EGER / SOY)"
+  },
+  {
+    "id": "NDY",
+    "british": true,
+    "label": "Sanday Airport (United Kingdom) (EGES / NDY)"
+  },
+  {
+    "id": "LWK",
+    "british": true,
+    "label": "Lerwick / Tingwall Airport (United Kingdom) (EGET / LWK)"
+  },
+  {
+    "id": "WRY",
+    "british": true,
+    "label": "Westray Airport (United Kingdom) (EGEW / WRY)"
+  },
+  {
+    "id": "LEQ",
+    "british": true,
+    "label": "Land's End Airport (United Kingdom) (EGHC / LEQ)"
+  },
+  {
+    "id": "PZE",
+    "british": true,
+    "label": "Penzance Heliport (United Kingdom) (EGHK / PZE)"
+  },
+  {
+    "id": "VLY",
+    "british": true,
+    "label": "Anglesey Airport (United Kingdom) (EGOV / VLY)"
+  },
+  {
+    "id": "BRR",
+    "british": true,
+    "label": "Barra Airport (United Kingdom) (EGPR / BRR)"
+  },
+  {
+    "id": "CFN",
+    "british": false,
+    "label": "Donegal Airport (Ireland) (EIDL / CFN)"
+  },
+  {
+    "id": "EIWT",
+    "british": false,
+    "label": "Weston Airport (Ireland) (EIWT)"
+  },
+  {
+    "id": "CNL",
+    "british": false,
+    "label": "Sindal Airport (Denmark) (EKSN / CNL)"
+  },
+  {
+    "id": "LKN",
+    "british": false,
+    "label": "Leknes Airport (Norway) (ENLK / LKN)"
+  },
+  {
+    "id": "OSY",
+    "british": false,
+    "label": "Namsos Høknesøra Airport (Norway) (ENNM / OSY)"
+  },
+  {
+    "id": "MQN",
+    "british": false,
+    "label": "Mo i Rana Airport, Røssvoll (Norway) (ENRA / MQN)"
+  },
+  {
+    "id": "RVK",
+    "british": false,
+    "label": "Rørvik Airport, Ryum (Norway) (ENRM / RVK)"
+  },
+  {
+    "id": "RET",
+    "british": false,
+    "label": "Røst Airport (Norway) (ENRS / RET)"
+  },
+  {
+    "id": "SDN",
+    "british": false,
+    "label": "Sandane Airport (Anda) (Norway) (ENSD / SDN)"
+  },
+  {
+    "id": "SOG",
+    "british": false,
+    "label": "Sogndal Airport (Norway) (ENSG / SOG)"
+  },
+  {
+    "id": "SVJ",
+    "british": false,
+    "label": "Svolvær Helle Airport (Norway) (ENSH / SVJ)"
+  },
+  {
+    "id": "SOJ",
+    "british": false,
+    "label": "Sørkjosen Airport (Norway) (ENSR / SOJ)"
+  },
+  {
+    "id": "VAW",
+    "british": false,
+    "label": "Vardø Airport, Svartnes (Norway) (ENSS / VAW)"
+  },
+  {
+    "id": "VRY",
+    "british": false,
+    "label": "Værøy Heliport (Norway) (ENVR / VRY)"
+  },
+  {
+    "id": "BZG",
+    "british": false,
+    "label": "Bydgoszcz Ignacy Jan Paderewski Airport (Poland) (EPBY / BZG)"
+  },
+  {
+    "id": "LCJ",
+    "british": false,
+    "label": "Łódź Władysław Reymont Airport (Poland) (EPLL / LCJ)"
+  },
+  {
+    "id": "OSD",
+    "british": false,
+    "label": "Åre Östersund Airport (Sweden) (ESNZ / OSD)"
+  },
+  {
+    "id": "HFS",
+    "british": false,
+    "label": "Hagfors Airport (Sweden) (ESOH / HFS)"
+  },
+  {
+    "id": "KSD",
+    "british": false,
+    "label": "Karlstad Airport (Sweden) (ESOK / KSD)"
+  },
+  {
+    "id": "TYF",
+    "british": false,
+    "label": "Torsby Airport (Sweden) (ESST / TYF)"
+  },
+  {
+    "id": "AGH",
+    "british": false,
+    "label": "Ängelholm-Helsingborg Airport (Sweden) (ESTA / AGH)"
+  },
+  {
+    "id": "SQO",
+    "british": false,
+    "label": "Storuman Airport (Sweden) (ESUD / SQO)"
+  },
+  {
+    "id": "HMV",
+    "british": false,
+    "label": "Hemavan Airport (Sweden) (ESUT / HMV)"
+  },
+  {
+    "id": "VNT",
+    "british": false,
+    "label": "Ventspils International Airport (Latvia) (EVVA / VNT)"
+  },
+  {
+    "id": "QRA",
+    "british": false,
+    "label": "Rand Airport (South Africa) (FAGM / QRA)"
+  },
+  {
+    "id": "MQP",
+    "british": false,
+    "label": "Kruger Mpumalanga International Airport (South Africa) (FAKN / MQP)"
+  },
+  {
+    "id": "AAM",
+    "british": false,
+    "label": "Malamala Airport (South Africa) (FAMD / AAM)"
+  },
+  {
+    "id": "MBD",
+    "british": false,
+    "label": "Mmabatho International Airport (South Africa) (FAMM / MBD)"
+  },
+  {
+    "id": "GNZ",
+    "british": false,
+    "label": "Ghanzi Airport (Botswana) (FBGZ / GNZ)"
+  },
+  {
+    "id": "ORP",
+    "british": false,
+    "label": "Orapa Airport (Botswana) (FBOR / ORP)"
+  },
+  {
+    "id": "SWX",
+    "british": false,
+    "label": "Shakawe Airport (Botswana) (FBSW / SWX)"
+  },
+  {
+    "id": "TLD",
+    "british": false,
+    "label": "Limpopo Valley Airport (Botswana) (FBTL / TLD)"
+  },
+  {
+    "id": "DIS",
+    "british": false,
+    "label": "Ngot Nzoungou Airport (Congo (Brazzaville)) (FCPL / DIS)"
+  },
+  {
+    "id": "CIP",
+    "british": false,
+    "label": "Chipata Airport (Zambia) (FLCP / CIP)"
+  },
+  {
+    "id": "KSLI",
+    "british": false,
+    "label": "Los Alamitos Army Air Field (Zambia) (KSLI)"
+  },
+  {
+    "id": "YVA",
+    "british": false,
+    "label": "Iconi Airport (Comoros) (FMCN / YVA)"
+  },
+  {
+    "id": "WAQ",
+    "british": false,
+    "label": "Antsalova Airport (Madagascar) (FMMG / WAQ)"
+  },
+  {
+    "id": "JVA",
+    "british": false,
+    "label": "Ankavandra Airport (Madagascar) (FMMK / JVA)"
+  },
+  {
+    "id": "BMD",
+    "british": false,
+    "label": "Belo sur Tsiribihina Airport (Madagascar) (FMML / BMD)"
+  },
+  {
+    "id": "MXT",
+    "british": false,
+    "label": "Maintirano Airport (Madagascar) (FMMO / MXT)"
+  },
+  {
+    "id": "TVA",
+    "british": false,
+    "label": "Morafenobe Airport (Madagascar) (FMMR / TVA)"
+  },
+  {
+    "id": "WTA",
+    "british": false,
+    "label": "Tambohorano Airport (Madagascar) (FMMU / WTA)"
+  },
+  {
+    "id": "WTS",
+    "british": false,
+    "label": "Tsiroanomandidy Airport (Madagascar) (FMMX / WTS)"
+  },
+  {
+    "id": "WAM",
+    "british": false,
+    "label": "Ambatondrazaka Airport (Madagascar) (FMMZ / WAM)"
+  },
+  {
+    "id": "WPB",
+    "british": false,
+    "label": "Port Bergé Airport (Madagascar) (FMNG / WPB)"
+  },
+  {
+    "id": "FMNJ",
+    "british": false,
+    "label": "Ambanja Airport (Madagascar) (FMNJ)"
+  },
+  {
+    "id": "DWB",
+    "british": false,
+    "label": "Soalala Airport (Madagascar) (FMNO / DWB)"
+  },
+  {
+    "id": "WMP",
+    "british": false,
+    "label": "Mampikony Airport (Madagascar) (FMNP / WMP)"
+  },
+  {
+    "id": "KTTS",
+    "british": false,
+    "label": "Nasa Shuttle Landing Facility Airport (Madagascar) (KTTS)"
+  },
+  {
+    "id": "WMA",
+    "british": false,
+    "label": "Mandritsara Airport (Madagascar) (FMNX / WMA)"
+  },
+  {
+    "id": "MJA",
+    "british": false,
+    "label": "Manja Airport (Madagascar) (FMSJ / MJA)"
+  },
+  {
+    "id": "CBT",
+    "british": false,
+    "label": "Catumbela Airport (Angola) (FNCT / CBT)"
+  },
+  {
+    "id": "DUE",
+    "british": false,
+    "label": "Dundo Airport (Angola) (FNDU / DUE)"
+  },
+  {
+    "id": "VPE",
+    "british": false,
+    "label": "Ngjiva Pereira Airport (Angola) (FNGI / VPE)"
+  },
+  {
+    "id": "MSZ",
+    "british": false,
+    "label": "Namibe Airport (Angola) (FNMO / MSZ)"
+  },
+  {
+    "id": "KOU",
+    "british": false,
+    "label": "Koulamoutou Mabimbi Airport (Gabon) (FOGK / KOU)"
+  },
+  {
+    "id": "MJL",
+    "british": false,
+    "label": "Mouilla Ville Airport (Gabon) (FOGM / MJL)"
+  },
+  {
+    "id": "TCH",
+    "british": false,
+    "label": "Tchibanga Airport (Gabon) (FOOT / TCH)"
+  },
+  {
+    "id": "VPY",
+    "british": false,
+    "label": "Chimoio Airport (Mozambique) (FQCH / VPY)"
+  },
+  {
+    "id": "SRH",
+    "british": false,
+    "label": "Sarh Airport (Chad) (FTTA / SRH)"
+  },
+  {
+    "id": "CMK",
+    "british": false,
+    "label": "Club Makokola Airport (Malawi) (FWCM / CMK)"
+  },
+  {
+    "id": "LUD",
+    "british": false,
+    "label": "Luderitz Airport (Namibia) (FYLZ / LUD)"
+  },
+  {
+    "id": "OND",
+    "british": false,
+    "label": "Ondangwa Airport (Namibia) (FYOA / OND)"
+  },
+  {
+    "id": "OMD",
+    "british": false,
+    "label": "Oranjemund Airport (Namibia) (FYOG / OMD)"
+  },
+  {
+    "id": "SWP",
+    "british": false,
+    "label": "Swakopmund Airport (Namibia) (FYSM / SWP)"
+  },
+  {
+    "id": "ERS",
+    "british": false,
+    "label": "Eros Airport (Namibia) (FYWE / ERS)"
+  },
+  {
+    "id": "BOA",
+    "british": false,
+    "label": "Boma Airport (Congo (Kinshasa)) (FZAJ / BOA)"
+  },
+  {
+    "id": "MAT",
+    "british": false,
+    "label": "Tshimpi Airport (Congo (Kinshasa)) (FZAM / MAT)"
+  },
+  {
+    "id": "INO",
+    "british": false,
+    "label": "Inongo Airport (Congo (Kinshasa)) (FZBA / INO)"
+  },
+  {
+    "id": "NIO",
+    "british": false,
+    "label": "Nioki Airport (Congo (Kinshasa)) (FZBI / NIO)"
+  },
+  {
+    "id": "KRZ",
+    "british": false,
+    "label": "Basango Mboliasa Airport (Congo (Kinshasa)) (FZBT / KRZ)"
+  },
+  {
+    "id": "BSU",
+    "british": false,
+    "label": "Basankusu Airport (Congo (Kinshasa)) (FZEN / BSU)"
+  },
+  {
+    "id": "TSH",
+    "british": false,
+    "label": "Tshikapa Airport (Congo (Kinshasa)) (FZUK / TSH)"
+  },
+  {
+    "id": "LJA",
+    "british": false,
+    "label": "Lodja Airport (Congo (Kinshasa)) (FZVA / LJA)"
+  },
+  {
+    "id": "PFR",
+    "british": false,
+    "label": "Ilebo Airport (Congo (Kinshasa)) (FZVS / PFR)"
+  },
+  {
+    "id": "OUK",
+    "british": true,
+    "label": "Outer Skerries Airport (United Kingdom) (EGOU / OUK)"
+  },
+  {
+    "id": "GMZ",
+    "british": false,
+    "label": "La Gomera Airport (Spain) (GCGM / GMZ)"
+  },
+  {
+    "id": "BTE",
+    "british": false,
+    "label": "Sherbro International Airport (Sierra Leone) (GFBN / BTE)"
+  },
+  {
+    "id": "KBS",
+    "british": false,
+    "label": "Bo Airport (Sierra Leone) (GFBO / KBS)"
+  },
+  {
+    "id": "KEN",
+    "british": false,
+    "label": "Kenema Airport (Sierra Leone) (GFKE / KEN)"
+  },
+  {
+    "id": "OXB",
+    "british": false,
+    "label": "Osvaldo Vieira International Airport (Guinea-Bissau) (GGOV / OXB)"
+  },
+  {
+    "id": "SMW",
+    "british": false,
+    "label": "Smara Airport (Western Sahara) (GMMA / SMW)"
+  },
+  {
+    "id": "VIL",
+    "british": false,
+    "label": "Dakhla Airport (Western Sahara) (GMMH / VIL)"
+  },
+  {
+    "id": "ESU",
+    "british": false,
+    "label": "Mogador Airport (Morocco) (GMMI / ESU)"
+  },
+  {
+    "id": "EUN",
+    "british": false,
+    "label": "Hassan I Airport (Western Sahara) (GMML / EUN)"
+  },
+  {
+    "id": "NDR",
+    "british": false,
+    "label": "Nador International Airport (Morocco) (GMMW / NDR)"
+  },
+  {
+    "id": "RAI",
+    "british": false,
+    "label": "Praia International Airport (Cape Verde) (GVNP / RAI)"
+  },
+  {
+    "id": "SFL",
+    "british": false,
+    "label": "São Filipe Airport (Cape Verde) (GVSF / SFL)"
+  },
+  {
+    "id": "BCO",
+    "british": false,
+    "label": "Baco Airport (Ethiopia) (HABC / BCO)"
+  },
+  {
+    "id": "BEI",
+    "british": false,
+    "label": "Beica Airport (Ethiopia) (HABE / BEI)"
+  },
+  {
+    "id": "DSE",
+    "british": false,
+    "label": "Combolcha Airport (Ethiopia) (HADC / DSE)"
+  },
+  {
+    "id": "DEM",
+    "british": false,
+    "label": "Dembidollo Airport (Ethiopia) (HADD / DEM)"
+  },
+  {
+    "id": "GDE",
+    "british": false,
+    "label": "Gode Airport (Ethiopia) (HAGO / GDE)"
+  },
+  {
+    "id": "GOR",
+    "british": false,
+    "label": "Gore Airport (Ethiopia) (HAGR / GOR)"
+  },
+  {
+    "id": "ABK",
+    "british": false,
+    "label": "Kabri Dehar Airport (Ethiopia) (HAKD / ABK)"
+  },
+  {
+    "id": "MTF",
+    "british": false,
+    "label": "Mizan Teferi Airport (Ethiopia) (HAMT / MTF)"
+  },
+  {
+    "id": "TIE",
+    "british": false,
+    "label": "Tippi Airport (Ethiopia) (HATP / TIE)"
+  },
+  {
+    "id": "ALU",
+    "british": false,
+    "label": "Alula Airport (Somalia) (HCMA / ALU)"
+  },
+  {
+    "id": "BSA",
+    "british": false,
+    "label": "Bosaso Airport (Somalia) (HCMF / BSA)"
+  },
+  {
+    "id": "MGQ",
+    "british": false,
+    "label": "Aden Adde International Airport (Somalia) (HCMM / MGQ)"
+  },
+  {
+    "id": "GLK",
+    "british": false,
+    "label": "Galcaio Airport (Somalia) (HCMR / GLK)"
+  },
+  {
+    "id": "BUO",
+    "british": false,
+    "label": "Burao Airport (Somalia) (HCMV / BUO)"
+  },
+  {
+    "id": "AAC",
+    "british": false,
+    "label": "El Arish International Airport (Egypt) (HEAR / AAC)"
+  },
+  {
+    "id": "ATZ",
+    "british": false,
+    "label": "Assiut International Airport (Egypt) (HEAT / ATZ)"
+  },
+  {
+    "id": "ASV",
+    "british": false,
+    "label": "Amboseli Airport (Kenya) (HKAM / ASV)"
+  },
+  {
+    "id": "LKG",
+    "british": false,
+    "label": "Lokichoggio Airport (Kenya) (HKLK / LKG)"
+  },
+  {
+    "id": "MYD",
+    "british": false,
+    "label": "Malindi Airport (Kenya) (HKML / MYD)"
+  },
+  {
+    "id": "NYK",
+    "british": false,
+    "label": "Nanyuki Airport (Kenya) (HKNY / NYK)"
+  },
+  {
+    "id": "SRX",
+    "british": false,
+    "label": "Gardabya Airport (Libya) (HLGD / SRX)"
+  },
+  {
+    "id": "TOB",
+    "british": false,
+    "label": "Gamal Abdel Nasser Airport (Libya) (HLGN / TOB)"
+  },
+  {
+    "id": "MJI",
+    "british": false,
+    "label": "Mitiga Airport (Libya) (HLLM / MJI)"
+  },
+  {
+    "id": "LAQ",
+    "british": false,
+    "label": "La Abraq Airport (Libya) (HLLQ / LAQ)"
+  },
+  {
+    "id": "ATB",
+    "british": false,
+    "label": "Atbara Airport (Sudan) (HSAT / ATB)"
+  },
+  {
+    "id": "UYL",
+    "british": false,
+    "label": "Nyala Airport (Sudan) (HSNN / UYL)"
+  },
+  {
+    "id": "PZU",
+    "british": false,
+    "label": "Port Sudan New International Airport (Sudan) (HSPN / PZU)"
+  },
+  {
+    "id": "BKZ",
+    "british": false,
+    "label": "Bukoba Airport (Tanzania) (HTBU / BKZ)"
+  },
+  {
+    "id": "TKQ",
+    "british": false,
+    "label": "Kigoma Airport (Tanzania) (HTKA / TKQ)"
+  },
+  {
+    "id": "LDI",
+    "british": false,
+    "label": "Lindi Airport (Tanzania) (HTLI / LDI)"
+  },
+  {
+    "id": "MUZ",
+    "british": false,
+    "label": "Musoma Airport (Tanzania) (HTMU / MUZ)"
+  },
+  {
+    "id": "SHY",
+    "british": false,
+    "label": "Shinyanga Airport (Tanzania) (HTSY / SHY)"
+  },
+  {
+    "id": "TBO",
+    "british": false,
+    "label": "Tabora Airport (Tanzania) (HTTB / TBO)"
+  },
+  {
+    "id": "RUA",
+    "british": false,
+    "label": "Arua Airport (Uganda) (HUAR / RUA)"
+  },
+  {
+    "id": "ULU",
+    "british": false,
+    "label": "Gulu Airport (Uganda) (HUGU / ULU)"
+  },
+  {
+    "id": "DIU",
+    "british": false,
+    "label": "Diu Airport (India) (VA1P / DIU)"
+  },
+  {
+    "id": "ABR",
+    "british": false,
+    "label": "Aberdeen Regional Airport (United States) (KABR / ABR)"
+  },
+  {
+    "id": "ABY",
+    "british": false,
+    "label": "Southwest Georgia Regional Airport (United States) (KABY / ABY)"
+  },
+  {
+    "id": "AHN",
+    "british": false,
+    "label": "Athens Ben Epps Airport (United States) (KAHN / AHN)"
+  },
+  {
+    "id": "ALM",
+    "british": false,
+    "label": "Alamogordo White Sands Regional Airport (United States) (KALM / ALM)"
+  },
+  {
+    "id": "ALO",
+    "british": false,
+    "label": "Waterloo Regional Airport (United States) (KALO / ALO)"
+  },
+  {
+    "id": "ALW",
+    "british": false,
+    "label": "Walla Walla Regional Airport (United States) (KALW / ALW)"
+  },
+  {
+    "id": "APN",
+    "british": false,
+    "label": "Alpena County Regional Airport (United States) (KAPN / APN)"
+  },
+  {
+    "id": "ATY",
+    "british": false,
+    "label": "Watertown Regional Airport (United States) (KATY / ATY)"
+  },
+  {
+    "id": "BFD",
+    "british": false,
+    "label": "Bradford Regional Airport (United States) (KBFD / BFD)"
+  },
+  {
+    "id": "BFF",
+    "british": false,
+    "label": "Western Neb. Rgnl/William B. Heilig Airport (United States) (KBFF / BFF)"
+  },
+  {
+    "id": "BKW",
+    "british": false,
+    "label": "Raleigh County Memorial Airport (United States) (KBKW / BKW)"
+  },
+  {
+    "id": "BQK",
+    "british": false,
+    "label": "Brunswick Golden Isles Airport (United States) (KBQK / BQK)"
+  },
+  {
+    "id": "BRL",
+    "british": false,
+    "label": "Southeast Iowa Regional Airport (United States) (KBRL / BRL)"
+  },
+  {
+    "id": "CEC",
+    "british": false,
+    "label": "Jack Mc Namara Field Airport (United States) (KCEC / CEC)"
+  },
+  {
+    "id": "CGI",
+    "british": false,
+    "label": "Cape Girardeau Regional Airport (United States) (KCGI / CGI)"
+  },
+  {
+    "id": "CIU",
+    "british": false,
+    "label": "Chippewa County International Airport (United States) (KCIU / CIU)"
+  },
+  {
+    "id": "CKB",
+    "british": false,
+    "label": "North Central West Virginia Airport (United States) (KCKB / CKB)"
+  },
+  {
+    "id": "CLM",
+    "british": false,
+    "label": "William R Fairchild International Airport (United States) (KCLM / CLM)"
+  },
+  {
+    "id": "CMX",
+    "british": false,
+    "label": "Houghton County Memorial Airport (United States) (KCMX / CMX)"
+  },
+  {
+    "id": "DDC",
+    "british": false,
+    "label": "Dodge City Regional Airport (United States) (KDDC / DDC)"
+  },
+  {
+    "id": "DUJ",
+    "british": false,
+    "label": "DuBois Regional Airport (United States) (KDUJ / DUJ)"
+  },
+  {
+    "id": "EAU",
+    "british": false,
+    "label": "Chippewa Valley Regional Airport (United States) (KEAU / EAU)"
+  },
+  {
+    "id": "EKO",
+    "british": false,
+    "label": "Elko Regional Airport (United States) (KEKO / EKO)"
+  },
+  {
+    "id": "EWB",
+    "british": false,
+    "label": "New Bedford Regional Airport (United States) (KEWB / EWB)"
+  },
+  {
+    "id": "FAY",
+    "british": false,
+    "label": "Fayetteville Regional Grannis Field (United States) (KFAY / FAY)"
+  },
+  {
+    "id": "GGW",
+    "british": false,
+    "label": "Wokal Field Glasgow International Airport (United States) (KGGW / GGW)"
+  },
+  {
+    "id": "GRI",
+    "british": false,
+    "label": "Central Nebraska Regional Airport (United States) (KGRI / GRI)"
+  },
+  {
+    "id": "HOT",
+    "british": false,
+    "label": "Memorial Field (United States) (KHOT / HOT)"
+  },
+  {
+    "id": "HTS",
+    "british": false,
+    "label": "Tri-State/Milton J. Ferguson Field (United States) (KHTS / HTS)"
+  },
+  {
+    "id": "KIO",
+    "british": false,
+    "label": "Kili Airport (Marshall Islands) (Q51 / KIO)"
+  },
+  {
+    "id": "IRK",
+    "british": false,
+    "label": "Kirksville Regional Airport (United States) (KIRK / IRK)"
+  },
+  {
+    "id": "JMS",
+    "british": false,
+    "label": "Jamestown Regional Airport (United States) (KJMS / JMS)"
+  },
+  {
+    "id": "LAR",
+    "british": false,
+    "label": "Laramie Regional Airport (United States) (KLAR / LAR)"
+  },
+  {
+    "id": "LBE",
+    "british": false,
+    "label": "Arnold Palmer Regional Airport (United States) (KLBE / LBE)"
+  },
+  {
+    "id": "LBF",
+    "british": false,
+    "label": "North Platte Regional Airport Lee Bird Field (United States) (KLBF / LBF)"
+  },
+  {
+    "id": "LEB",
+    "british": false,
+    "label": "Lebanon Municipal Airport (United States) (KLEB / LEB)"
+  },
+  {
+    "id": "LMT",
+    "british": false,
+    "label": "Crater Lake-Klamath Regional Airport (United States) (KLMT / LMT)"
+  },
+  {
+    "id": "LNS",
+    "british": false,
+    "label": "Lancaster Airport (United States) (KLNS / LNS)"
+  },
+  {
+    "id": "LWT",
+    "british": false,
+    "label": "Lewistown Municipal Airport (United States) (KLWT / LWT)"
+  },
+  {
+    "id": "LYH",
+    "british": false,
+    "label": "Lynchburg Regional Preston Glenn Field (United States) (KLYH / LYH)"
+  },
+  {
+    "id": "MKG",
+    "british": false,
+    "label": "Muskegon County Airport (United States) (KMKG / MKG)"
+  },
+  {
+    "id": "MLS",
+    "british": false,
+    "label": "Frank Wiley Field (United States) (KMLS / MLS)"
+  },
+  {
+    "id": "MSL",
+    "british": false,
+    "label": "Northwest Alabama Regional Airport (United States) (KMSL / MSL)"
+  },
+  {
+    "id": "OTH",
+    "british": false,
+    "label": "Southwest Oregon Regional Airport (United States) (KOTH / OTH)"
+  },
+  {
+    "id": "OWB",
+    "british": false,
+    "label": "Owensboro Daviess County Airport (United States) (KOWB / OWB)"
+  },
+  {
+    "id": "PIB",
+    "british": false,
+    "label": "Hattiesburg Laurel Regional Airport (United States) (KPIB / PIB)"
+  },
+  {
+    "id": "PIH",
+    "british": false,
+    "label": "Pocatello Regional Airport (United States) (KPIH / PIH)"
+  },
+  {
+    "id": "PIR",
+    "british": false,
+    "label": "Pierre Regional Airport (United States) (KPIR / PIR)"
+  },
+  {
+    "id": "PLN",
+    "british": false,
+    "label": "Pellston Regional Airport of Emmet County Airport (United States) (KPLN / PLN)"
+  },
+  {
+    "id": "PSM",
+    "british": false,
+    "label": "Portsmouth International at Pease Airport (United States) (KPSM / PSM)"
+  },
+  {
+    "id": "RDG",
+    "british": false,
+    "label": "Reading Regional Carl A Spaatz Field (United States) (KRDG / RDG)"
+  },
+  {
+    "id": "RHI",
+    "british": false,
+    "label": "Rhinelander Oneida County Airport (United States) (KRHI / RHI)"
+  },
+  {
+    "id": "RKS",
+    "british": false,
+    "label": "Southwest Wyoming Regional Airport (United States) (KRKS / RKS)"
+  },
+  {
+    "id": "RUT",
+    "british": false,
+    "label": "Rutland - Southern Vermont Regional Airport (United States) (KRUT / RUT)"
+  },
+  {
+    "id": "SBP",
+    "british": false,
+    "label": "San Luis County Regional Airport (United States) (KSBP / SBP)"
+  },
+  {
+    "id": "SHR",
+    "british": false,
+    "label": "Sheridan County Airport (United States) (KSHR / SHR)"
+  },
+  {
+    "id": "SLK",
+    "british": false,
+    "label": "Adirondack Regional Airport (United States) (KSLK / SLK)"
+  },
+  {
+    "id": "SLN",
+    "british": false,
+    "label": "Salina Municipal Airport (United States) (KSLN / SLN)"
+  },
+  {
+    "id": "SMX",
+    "british": false,
+    "label": "Santa Maria Pub/Capt G Allan Hancock Field (United States) (KSMX / SMX)"
+  },
+  {
+    "id": "TUP",
+    "british": false,
+    "label": "Tupelo Regional Airport (United States) (KTUP / TUP)"
+  },
+  {
+    "id": "UIN",
+    "british": false,
+    "label": "Quincy Regional Baldwin Field (United States) (KUIN / UIN)"
+  },
+  {
+    "id": "VCT",
+    "british": false,
+    "label": "Victoria Regional Airport (United States) (KVCT / VCT)"
+  },
+  {
+    "id": "VLD",
+    "british": false,
+    "label": "Valdosta Regional Airport (United States) (KVLD / VLD)"
+  },
+  {
+    "id": "WRL",
+    "british": false,
+    "label": "Worland Municipal Airport (United States) (KWRL / WRL)"
+  },
+  {
+    "id": "YKM",
+    "british": false,
+    "label": "Yakima Air Terminal McAllister Field (United States) (KYKM / YKM)"
+  },
+  {
+    "id": "ECN",
+    "british": false,
+    "label": "Ercan International Airport (Cyprus) (LCEN / ECN)"
+  },
+  {
+    "id": "RJL",
+    "british": false,
+    "label": "Logroño-Agoncillo Airport (Spain) (LELO / RJL)"
+  },
+  {
+    "id": "IDY",
+    "british": false,
+    "label": "Île d'Yeu Airport (France) (LFEY / IDY)"
+  },
+  {
+    "id": "ANE",
+    "british": false,
+    "label": "Angers-Loire Airport (France) (LFJR / ANE)"
+  },
+  {
+    "id": "LTT",
+    "british": false,
+    "label": "La Môle Airport (France) (LFTZ / LTT)"
+  },
+  {
+    "id": "JSY",
+    "british": false,
+    "label": "Syros Airport (Greece) (LGSO / JSY)"
+  },
+  {
+    "id": "PEV",
+    "british": false,
+    "label": "Pécs-Pogány Airport (Hungary) (LHPP / PEV)"
+  },
+  {
+    "id": "LHPR",
+    "british": false,
+    "label": "Győr-Pér International Airport (Hungary) (LHPR)"
+  },
+  {
+    "id": "SOB",
+    "british": false,
+    "label": "Sármellék International Airport (Hungary) (LHSM / SOB)"
+  },
+  {
+    "id": "AOT",
+    "british": false,
+    "label": "Aosta Airport (Italy) (LIMW / AOT)"
+  },
+  {
+    "id": "QSR",
+    "british": false,
+    "label": "Salerno Costa d'Amalfi Airport (Italy) (LIRI / QSR)"
+  },
+  {
+    "id": "CVU",
+    "british": false,
+    "label": "Corvo Airport (Portugal) (LPCR / CVU)"
+  },
+  {
+    "id": "BNX",
+    "british": false,
+    "label": "Banja Luka International Airport (Bosnia and Herzegovina) (LQBK / BNX)"
+  },
+  {
+    "id": "USQ",
+    "british": false,
+    "label": "Uşak Airport (Turkey) (LTBO / USQ)"
+  },
+  {
+    "id": "KSY",
+    "british": false,
+    "label": "Kars Airport (Turkey) (LTCF / KSY)"
+  },
+  {
+    "id": "SFQ",
+    "british": false,
+    "label": "Şanlıurfa Airport (Turkey) (LTCH / SFQ)"
+  },
+  {
+    "id": "KCM",
+    "british": false,
+    "label": "Kahramanmaraş Airport (Turkey) (LTCN / KCM)"
+  },
+  {
+    "id": "AJI",
+    "british": false,
+    "label": "Ağrı Airport (Turkey) (LTCO / AJI)"
+  },
+  {
+    "id": "ADF",
+    "british": false,
+    "label": "Adıyaman Airport (Turkey) (LTCP / ADF)"
+  },
+  {
+    "id": "ISE",
+    "british": false,
+    "label": "Süleyman Demirel International Airport (Turkey) (LTFC / ISE)"
+  },
+  {
+    "id": "EDO",
+    "british": false,
+    "label": "Balıkesir Körfez Airport (Turkey) (LTFD / EDO)"
+  },
+  {
+    "id": "SZF",
+    "british": false,
+    "label": "Samsun Çarşamba Airport (Turkey) (LTFH / SZF)"
+  },
+  {
+    "id": "ILZ",
+    "british": false,
+    "label": "Žilina Airport (Slovakia) (LZZI / ILZ)"
+  },
+  {
+    "id": "GDT",
+    "british": false,
+    "label": "JAGS McCartney International Airport (Turks and Caicos Islands) (MBGT / GDT)"
+  },
+  {
+    "id": "MDS",
+    "british": false,
+    "label": "Middle Caicos Airport (Turks and Caicos Islands) (MBMC / MDS)"
+  },
+  {
+    "id": "SLX",
+    "british": false,
+    "label": "Salt Cay Airport (Turks and Caicos Islands) (MBSY / SLX)"
+  },
+  {
+    "id": "AZS",
+    "british": false,
+    "label": "Samaná El Catey International Airport (Dominican Republic) (MDCY / AZS)"
+  },
+  {
+    "id": "JBQ",
+    "british": false,
+    "label": "La Isabela International Airport (Dominican Republic) (MDJB / JBQ)"
+  },
+  {
+    "id": "PBR",
+    "british": false,
+    "label": "Puerto Barrios Airport (Guatemala) (MGPB / PBR)"
+  },
+  {
+    "id": "AAZ",
+    "british": false,
+    "label": "Quezaltenango Airport (Guatemala) (MGQZ / AAZ)"
+  },
+  {
+    "id": "UTK",
+    "british": false,
+    "label": "Utirik Airport (Marshall Islands) (03N / UTK)"
+  },
+  {
+    "id": "AHS",
+    "british": false,
+    "label": "Ahuas Airport (Honduras) (MHAH / AHS)"
+  },
+  {
+    "id": "PEU",
+    "british": false,
+    "label": "Puerto Lempira Airport (Honduras) (MHPL / PEU)"
+  },
+  {
+    "id": "MIJ",
+    "british": false,
+    "label": "Mili Island Airport (Marshall Islands) (MLIP / MIJ)"
+  },
+  {
+    "id": "CYW",
+    "british": false,
+    "label": "Captain Rogelio Castillo National Airport (Mexico) (MMCY / CYW)"
+  },
+  {
+    "id": "CUA",
+    "british": false,
+    "label": "Ciudad Constitución Airport (Mexico) (MMDA / CUA)"
+  },
+  {
+    "id": "GUB",
+    "british": false,
+    "label": "Guerrero Negro Airport (Mexico) (MMGR / GUB)"
+  },
+  {
+    "id": "JAL",
+    "british": false,
+    "label": "El Lencero Airport (Mexico) (MMJA / JAL)"
+  },
+  {
+    "id": "CTD",
+    "british": false,
+    "label": "Alonso Valderrama Airport (Panama) (MPCE / CTD)"
+  },
+  {
+    "id": "ONX",
+    "british": false,
+    "label": "Enrique Adolfo Jimenez Airport (Panama) (MPEJ / ONX)"
+  },
+  {
+    "id": "JQE",
+    "british": false,
+    "label": "Jaqué Airport (Panama) (MPJE / JQE)"
+  },
+  {
+    "id": "PLP",
+    "british": false,
+    "label": "Captain Ramon Xatruch Airport (Panama) (MPLP / PLP)"
+  },
+  {
+    "id": "TTQ",
+    "british": false,
+    "label": "Aerotortuguero Airport (Costa Rica) (MRAO / TTQ)"
+  },
+  {
+    "id": "BCL",
+    "british": false,
+    "label": "Barra del Colorado Airport (Costa Rica) (MRBC / BCL)"
+  },
+  {
+    "id": "MRCV",
+    "british": false,
+    "label": "Cabo Velas Airport (Costa Rica) (MRCV)"
+  },
+  {
+    "id": "PBP",
+    "british": false,
+    "label": "Islita Airport (Costa Rica) (MRIA / PBP)"
+  },
+  {
+    "id": "PJM",
+    "british": false,
+    "label": "Puerto Jimenez Airport (Costa Rica) (MRPJ / PJM)"
+  },
+  {
+    "id": "SYQ",
+    "british": false,
+    "label": "Tobias Bolanos International Airport (Costa Rica) (MRPV / SYQ)"
+  },
+  {
+    "id": "MRSR",
+    "british": false,
+    "label": "(Duplicate) Playa Samara Airport (Costa Rica) (MRSR)"
+  },
+  {
+    "id": "JEE",
+    "british": false,
+    "label": "Jérémie Airport (Haiti) (MTJE / JEE)"
+  },
+  {
+    "id": "PAX",
+    "british": false,
+    "label": "Port-de-Paix Airport (Haiti) (MTPX / PAX)"
+  },
+  {
+    "id": "MUOC",
+    "british": false,
+    "label": "Cayo Coco Airport (Cuba) (MUOC)"
+  },
+  {
+    "id": "TND",
+    "british": false,
+    "label": "Alberto Delgado Airport (Cuba) (MUTD / TND)"
+  },
+  {
+    "id": "COX",
+    "british": false,
+    "label": "Congo Town Airport (Bahamas) (MYAK / COX)"
+  },
+  {
+    "id": "ATC",
+    "british": false,
+    "label": "Arthur's Town Airport (Bahamas) (MYCA / ATC)"
+  },
+  {
+    "id": "TBI",
+    "british": false,
+    "label": "New Bight Airport (Bahamas) (MYCB / TBI)"
+  },
+  {
+    "id": "CRI",
+    "british": false,
+    "label": "Colonel Hill Airport (Bahamas) (MYCI / CRI)"
+  },
+  {
+    "id": "PID",
+    "british": false,
+    "label": "Nassau Paradise Island Airport (Bahamas) (MYPI / PID)"
+  },
+  {
+    "id": "AIU",
+    "british": false,
+    "label": "Enua Airport (Cook Islands) (NCAT / AIU)"
+  },
+  {
+    "id": "MGS",
+    "british": false,
+    "label": "Mangaia Island Airport (Cook Islands) (NCMG / MGS)"
+  },
+  {
+    "id": "MHX",
+    "british": false,
+    "label": "Manihiki Island Airport (Cook Islands) (NCMH / MHX)"
+  },
+  {
+    "id": "MUK",
+    "british": false,
+    "label": "Mauke Airport (Cook Islands) (NCMK / MUK)"
+  },
+  {
+    "id": "MOI",
+    "british": false,
+    "label": "Mitiaro Island Airport (Cook Islands) (NCMR / MOI)"
+  },
+  {
+    "id": "PYE",
+    "british": false,
+    "label": "Tongareva Airport (Cook Islands) (NCPY / PYE)"
+  },
+  {
+    "id": "ICI",
+    "british": false,
+    "label": "Cicia Airport (Fiji) (NFCI / ICI)"
+  },
+  {
+    "id": "PTF",
+    "british": false,
+    "label": "Malolo Lailai Island Airport (Fiji) (NFFO / PTF)"
+  },
+  {
+    "id": "KDV",
+    "british": false,
+    "label": "Vunisea Airport (Fiji) (NFKD / KDV)"
+  },
+  {
+    "id": "MNF",
+    "british": false,
+    "label": "Mana Island Airport (Fiji) (NFMA / MNF)"
+  },
+  {
+    "id": "MFJ",
+    "british": false,
+    "label": "Moala Airport (Fiji) (NFMO / MFJ)"
+  },
+  {
+    "id": "NGI",
+    "british": false,
+    "label": "Ngau Airport (Fiji) (NFNG / NGI)"
+  },
+  {
+    "id": "LKB",
+    "british": false,
+    "label": "Lakeba Island Airport (Fiji) (NFNK / LKB)"
+  },
+  {
+    "id": "LBS",
+    "british": false,
+    "label": "Labasa Airport (Fiji) (NFNL / LBS)"
+  },
+  {
+    "id": "TVU",
+    "british": false,
+    "label": "Matei Airport (Fiji) (NFNM / TVU)"
+  },
+  {
+    "id": "KXF",
+    "british": false,
+    "label": "Koro Island Airport (Fiji) (NFNO / KXF)"
+  },
+  {
+    "id": "RTA",
+    "british": false,
+    "label": "Rotuma Airport (Fiji) (NFNR / RTA)"
+  },
+  {
+    "id": "SVU",
+    "british": false,
+    "label": "Savusavu Airport (Fiji) (NFNS / SVU)"
+  },
+  {
+    "id": "EUA",
+    "british": false,
+    "label": "Kaufana Airport (Tonga) (NFTE / EUA)"
+  },
+  {
+    "id": "HPA",
+    "british": false,
+    "label": "Lifuka Island Airport (Tonga) (NFTL / HPA)"
+  },
+  {
+    "id": "NFO",
+    "british": false,
+    "label": "Mata'aho Airport (Tonga) (NFTO / NFO)"
+  },
+  {
+    "id": "NTT",
+    "british": false,
+    "label": "Kuini Lavenia Airport (Tonga) (NFTP / NTT)"
+  },
+  {
+    "id": "VBV",
+    "british": false,
+    "label": "Vanua Balavu Airport (Fiji) (NFVB / VBV)"
+  },
+  {
+    "id": "IUE",
+    "british": false,
+    "label": "Niue International Airport (Niue) (NIUE / IUE)"
+  },
+  {
+    "id": "FUT",
+    "british": false,
+    "label": "Pointe Vele Airport (Wallis and Futuna) (NLWF / FUT)"
+  },
+  {
+    "id": "MXS",
+    "british": false,
+    "label": "Maota Airport (Samoa) (NSMA / MXS)"
+  },
+  {
+    "id": "APK",
+    "british": false,
+    "label": "Apataki Airport (French Polynesia) (NTGD / APK)"
+  },
+  {
+    "id": "AHE",
+    "british": false,
+    "label": "Ahe Airport (French Polynesia) (NTHE / AHE)"
+  },
+  {
+    "id": "AUQ",
+    "british": false,
+    "label": "Hiva Oa-Atuona Airport (French Polynesia) (NTMN / AUQ)"
+  },
+  {
+    "id": "UAP",
+    "british": false,
+    "label": "Ua Pou Airport (French Polynesia) (NTMP / UAP)"
+  },
+  {
+    "id": "UAH",
+    "british": false,
+    "label": "Ua Huka Airport (French Polynesia) (NTMU / UAH)"
+  },
+  {
+    "id": "MTV",
+    "british": false,
+    "label": "Mota Lava Airport (Vanuatu) (NVSA / MTV)"
+  },
+  {
+    "id": "SLH",
+    "british": false,
+    "label": "Sola Airport (Vanuatu) (NVSC / SLH)"
+  },
+  {
+    "id": "TOH",
+    "british": false,
+    "label": "Torres Airstrip (Vanuatu) (NVSD / TOH)"
+  },
+  {
+    "id": "EAE",
+    "british": false,
+    "label": "Siwo Airport (Vanuatu) (NVSE / EAE)"
+  },
+  {
+    "id": "CCV",
+    "british": false,
+    "label": "Craig Cove Airport (Vanuatu) (NVSF / CCV)"
+  },
+  {
+    "id": "LOD",
+    "british": false,
+    "label": "Longana Airport (Vanuatu) (NVSG / LOD)"
+  },
+  {
+    "id": "SSR",
+    "british": false,
+    "label": "Sara Airport (Vanuatu) (NVSH / SSR)"
+  },
+  {
+    "id": "PBJ",
+    "british": false,
+    "label": "Tavie Airport (Vanuatu) (NVSI / PBJ)"
+  },
+  {
+    "id": "LPM",
+    "british": false,
+    "label": "Lamap Airport (Vanuatu) (NVSL / LPM)"
+  },
+  {
+    "id": "LNB",
+    "british": false,
+    "label": "Lamen Bay Airport (Vanuatu) (NVSM / LNB)"
+  },
+  {
+    "id": "MWF",
+    "british": false,
+    "label": "Maewo-Naone Airport (Vanuatu) (NVSN / MWF)"
+  },
+  {
+    "id": "LNE",
+    "british": false,
+    "label": "Lonorore Airport (Vanuatu) (NVSO / LNE)"
+  },
+  {
+    "id": "NUS",
+    "british": false,
+    "label": "Norsup Airport (Vanuatu) (NVSP / NUS)"
+  },
+  {
+    "id": "ZGU",
+    "british": false,
+    "label": "Gaua Island Airport (Vanuatu) (NVSQ / ZGU)"
+  },
+  {
+    "id": "RCL",
+    "british": false,
+    "label": "Redcliffe Airport (Vanuatu) (NVSR / RCL)"
+  },
+  {
+    "id": "SON",
+    "british": false,
+    "label": "Santo Pekoa International Airport (Vanuatu) (NVSS / SON)"
+  },
+  {
+    "id": "TGH",
+    "british": false,
+    "label": "Tongoa Airport (Vanuatu) (NVST / TGH)"
+  },
+  {
+    "id": "ULB",
+    "british": false,
+    "label": "Uléi Airport (Vanuatu) (NVSU / ULB)"
+  },
+  {
+    "id": "VLS",
+    "british": false,
+    "label": "Valesdir Airport (Vanuatu) (NVSV / VLS)"
+  },
+  {
+    "id": "SWJ",
+    "british": false,
+    "label": "Southwest Bay Airport (Vanuatu) (NVSX / SWJ)"
+  },
+  {
+    "id": "OLJ",
+    "british": false,
+    "label": "North West Santo Airport (Vanuatu) (NVSZ / OLJ)"
+  },
+  {
+    "id": "AUY",
+    "british": false,
+    "label": "Aneityum Airport (Vanuatu) (NVVA / AUY)"
+  },
+  {
+    "id": "AWD",
+    "british": false,
+    "label": "Aniwa Airport (Vanuatu) (NVVB / AWD)"
+  },
+  {
+    "id": "DLY",
+    "british": false,
+    "label": "Dillon's Bay Airport (Vanuatu) (NVVD / DLY)"
+  },
+  {
+    "id": "FTA",
+    "british": false,
+    "label": "Futuna Airport (Vanuatu) (NVVF / FTA)"
+  },
+  {
+    "id": "IPA",
+    "british": false,
+    "label": "Ipota Airport (Vanuatu) (NVVI / IPA)"
+  },
+  {
+    "id": "TGJ",
+    "british": false,
+    "label": "Tiga Airport (New Caledonia) (NWWA / TGJ)"
+  },
+  {
+    "id": "BMY",
+    "british": false,
+    "label": "Île Art - Waala Airport (New Caledonia) (NWWC / BMY)"
+  },
+  {
+    "id": "ILP",
+    "british": false,
+    "label": "Île des Pins Airport (New Caledonia) (NWWE / ILP)"
+  },
+  {
+    "id": "FBD",
+    "british": false,
+    "label": "Fayzabad Airport (Afghanistan) (OAFZ / FBD)"
+  },
+  {
+    "id": "OEDW",
+    "british": false,
+    "label": "Dawadmi Domestic Airport (Saudi Arabia) (OEDW)"
+  },
+  {
+    "id": "AJF",
+    "british": false,
+    "label": "Al-Jawf Domestic Airport (Saudi Arabia) (OESK / AJF)"
+  },
+  {
+    "id": "WAE",
+    "british": false,
+    "label": "Wadi Al Dawasir Airport (Saudi Arabia) (OEWD / WAE)"
+  },
+  {
+    "id": "KHD",
+    "british": false,
+    "label": "Khoram Abad Airport (Iran) (OICK / KHD)"
+  },
+  {
+    "id": "BXR",
+    "british": false,
+    "label": "Bam Airport (Iran) (OIKM / BXR)"
+  },
+  {
+    "id": "RJN",
+    "british": false,
+    "label": "Rafsanjan Airport (Iran) (OIKR / RJN)"
+  },
+  {
+    "id": "BJB",
+    "british": false,
+    "label": "Bojnord Airport (Iran) (OIMN / BJB)"
+  },
+  {
+    "id": "AFZ",
+    "british": false,
+    "label": "Sabzevar National Airport (Iran) (OIMS / AFZ)"
+  },
+  {
+    "id": "NSH",
+    "british": false,
+    "label": "Noshahr Airport (Iran) (OINN / NSH)"
+  },
+  {
+    "id": "SRY",
+    "british": false,
+    "label": "Dasht-e Naz Airport (Iran) (OINZ / SRY)"
+  },
+  {
+    "id": "LRR",
+    "british": false,
+    "label": "Lar Airport (Iran) (OISL / LRR)"
+  },
+  {
+    "id": "ADU",
+    "british": false,
+    "label": "Ardabil Airport (Iran) (OITL / ADU)"
+  },
+  {
+    "id": "OMH",
+    "british": false,
+    "label": "Urmia Airport (Iran) (OITR / OMH)"
+  },
+  {
+    "id": "AAN",
+    "british": false,
+    "label": "Al Ain International Airport (United Arab Emirates) (OMAL / AAN)"
+  },
+  {
+    "id": "BNP",
+    "british": false,
+    "label": "Bannu Airport (Pakistan) (OPBN / BNP)"
+  },
+  {
+    "id": "BHV",
+    "british": false,
+    "label": "Bahawalpur Airport (Pakistan) (OPBW / BHV)"
+  },
+  {
+    "id": "CJL",
+    "british": false,
+    "label": "Chitral Airport (Pakistan) (OPCH / CJL)"
+  },
+  {
+    "id": "DBA",
+    "british": false,
+    "label": "Dalbandin Airport (Pakistan) (OPDB / DBA)"
+  },
+  {
+    "id": "DEA",
+    "british": false,
+    "label": "Dera Ghazi Khan Airport (Pakistan) (OPDG / DEA)"
+  },
+  {
+    "id": "DSK",
+    "british": false,
+    "label": "Dera Ismael Khan Airport (Pakistan) (OPDI / DSK)"
+  },
+  {
+    "id": "JIW",
+    "british": false,
+    "label": "Jiwani Airport (Pakistan) (OPJI / JIW)"
+  },
+  {
+    "id": "HDD",
+    "british": false,
+    "label": "Hyderabad Airport (Pakistan) (OPKD / HDD)"
+  },
+  {
+    "id": "KDD",
+    "british": false,
+    "label": "Khuzdar Airport (Pakistan) (OPKH / KDD)"
+  },
+  {
+    "id": "ORW",
+    "british": false,
+    "label": "Ormara Airport (Pakistan) (OPOR / ORW)"
+  },
+  {
+    "id": "PAJ",
+    "british": false,
+    "label": "Parachinar Airport (Pakistan) (OPPC / PAJ)"
+  },
+  {
+    "id": "KDU",
+    "british": false,
+    "label": "Skardu Airport (Pakistan) (OPSD / KDU)"
+  },
+  {
+    "id": "SYW",
+    "british": false,
+    "label": "Sehwan Sharif Airport (Pakistan) (OPSN / SYW)"
+  },
+  {
+    "id": "TUK",
+    "british": false,
+    "label": "Turbat International Airport (Pakistan) (OPTU / TUK)"
+  },
+  {
+    "id": "ISU",
+    "british": false,
+    "label": "Sulaymaniyah International Airport (Iraq) (ORSU / ISU)"
+  },
+  {
+    "id": "KAC",
+    "british": false,
+    "label": "Kamishly Airport (Syria) (OSKL / KAC)"
+  },
+  {
+    "id": "GXF",
+    "british": false,
+    "label": "Sayun International Airport (Yemen) (OYSY / GXF)"
+  },
+  {
+    "id": "ADK",
+    "british": false,
+    "label": "Adak Airport (United States) (PADK / ADK)"
+  },
+  {
+    "id": "GST",
+    "british": false,
+    "label": "Gustavus Airport (United States) (PAGS / GST)"
+  },
+  {
+    "id": "SGY",
+    "british": false,
+    "label": "Skagway Airport (United States) (PAGY / SGY)"
+  },
+  {
+    "id": "HCR",
+    "british": false,
+    "label": "Holy Cross Airport (United States) (PAHC / HCR)"
+  },
+  {
+    "id": "HNS",
+    "british": false,
+    "label": "Haines Airport (United States) (PAHN / HNS)"
+  },
+  {
+    "id": "KLG",
+    "british": false,
+    "label": "Kalskag Airport (United States) (PALG / KLG)"
+  },
+  {
+    "id": "MCG",
+    "british": false,
+    "label": "McGrath Airport (United States) (PAMC / MCG)"
+  },
+  {
+    "id": "MOU",
+    "british": false,
+    "label": "Mountain Village Airport (United States) (PAMO / MOU)"
+  },
+  {
+    "id": "ANI",
+    "british": false,
+    "label": "Aniak Airport (United States) (PANI / ANI)"
+  },
+  {
+    "id": "VAK",
+    "british": false,
+    "label": "Chevak Airport (United States) (PAVA / VAK)"
+  },
+  {
+    "id": "WRG",
+    "british": false,
+    "label": "Wrangell Airport (United States) (PAWG / WRG)"
+  },
+  {
+    "id": "OPU",
+    "british": false,
+    "label": "Balimo Airport (Papua New Guinea) (AYBM / OPU)"
+  },
+  {
+    "id": "VMU",
+    "british": false,
+    "label": "Baimuru Airport (Papua New Guinea) (AYBA / VMU)"
+  },
+  {
+    "id": "LUP",
+    "british": false,
+    "label": "Kalaupapa Airport (United States) (PHLU / LUP)"
+  },
+  {
+    "id": "ENT",
+    "british": false,
+    "label": "Eniwetok Airport (Marshall Islands) (PKMA / ENT)"
+  },
+  {
+    "id": "LZN",
+    "british": false,
+    "label": "Matsu Nangan Airport (Taiwan) (RCFG / LZN)"
+  },
+  {
+    "id": "HCN",
+    "british": false,
+    "label": "Hengchun Airport (Taiwan) (RCKW / HCN)"
+  },
+  {
+    "id": "MFK",
+    "british": false,
+    "label": "Matsu Beigan Airport (Taiwan) (RCMT / MFK)"
+  },
+  {
+    "id": "KUH",
+    "british": false,
+    "label": "Kushiro Airport (Japan) (RJCK / KUH)"
+  },
+  {
+    "id": "OKD",
+    "british": false,
+    "label": "Okadama Airport (Japan) (RJCO / OKD)"
+  },
+  {
+    "id": "HSG",
+    "british": false,
+    "label": "Saga Airport (Japan) (RJFS / HSG)"
+  },
+  {
+    "id": "NKM",
+    "british": false,
+    "label": "Nagoya Airport (Japan) (RJNA / NKM)"
+  },
+  {
+    "id": "IWJ",
+    "british": false,
+    "label": "Iwami Airport (Japan) (RJOW / IWJ)"
+  },
+  {
+    "id": "FKS",
+    "british": false,
+    "label": "Fukushima Airport (Japan) (RJSF / FKS)"
+  },
+  {
+    "id": "ONJ",
+    "british": false,
+    "label": "Odate Noshiro Airport (Japan) (RJSR / ONJ)"
+  },
+  {
+    "id": "SYO",
+    "british": false,
+    "label": "Shonai Airport (Japan) (RJSY / SYO)"
+  },
+  {
+    "id": "MYE",
+    "british": false,
+    "label": "Miyakejima Airport (Japan) (RJTQ / MYE)"
+  },
+  {
+    "id": "KUV",
+    "british": false,
+    "label": "Kunsan Air Base (South Korea) (RKJK / KUV)"
+  },
+  {
+    "id": "MPK",
+    "british": false,
+    "label": "Mokpo Heliport (South Korea) (RKJM / MPK)"
+  },
+  {
+    "id": "WJU",
+    "british": false,
+    "label": "Wonju/Hoengseong Air Base (K-38/K-46) (South Korea) (RKNW / WJU)"
+  },
+  {
+    "id": "YNY",
+    "british": false,
+    "label": "Yangyang International Airport (South Korea) (RKNY / YNY)"
+  },
+  {
+    "id": "HIN",
+    "british": false,
+    "label": "Sacheon Air Base/Airport (South Korea) (RKPS / HIN)"
+  },
+  {
+    "id": "CJJ",
+    "british": false,
+    "label": "Cheongju International Airport/Cheongju Air Base (K-59/G-513) (South Korea) (RKTU / CJJ)"
+  },
+  {
+    "id": "SFS",
+    "british": false,
+    "label": "Subic Bay International Airport (Philippines) (RPLB / SFS)"
+  },
+  {
+    "id": "CYU",
+    "british": false,
+    "label": "Cuyo Airport (Philippines) (RPLO / CYU)"
+  },
+  {
+    "id": "RPMB",
+    "british": false,
+    "label": "Rajah Buayan Air Base (Philippines) (RPMB)"
+  },
+  {
+    "id": "CGM",
+    "british": false,
+    "label": "Camiguin Airport (Philippines) (RPMH / CGM)"
+  },
+  {
+    "id": "JOL",
+    "british": false,
+    "label": "Jolo Airport (Philippines) (RPMJ / JOL)"
+  },
+  {
+    "id": "TWT",
+    "british": false,
+    "label": "Sanga Sanga Airport (Philippines) (RPMN / TWT)"
+  },
+  {
+    "id": "SUG",
+    "british": false,
+    "label": "Surigao Airport (Philippines) (RPMS / SUG)"
+  },
+  {
+    "id": "TDG",
+    "british": false,
+    "label": "Tandag Airport (Philippines) (RPMW / TDG)"
+  },
+  {
+    "id": "WNP",
+    "british": false,
+    "label": "Naga Airport (Philippines) (RPUN / WNP)"
+  },
+  {
+    "id": "BSO",
+    "british": false,
+    "label": "Basco Airport (Philippines) (RPUO / BSO)"
+  },
+  {
+    "id": "SFE",
+    "british": false,
+    "label": "San Fernando Airport (Philippines) (RPUS / SFE)"
+  },
+  {
+    "id": "TUG",
+    "british": false,
+    "label": "Tuguegarao Airport (Philippines) (RPUT / TUG)"
+  },
+  {
+    "id": "VRC",
+    "british": false,
+    "label": "Virac Airport (Philippines) (RPUV / VRC)"
+  },
+  {
+    "id": "CYP",
+    "british": false,
+    "label": "Calbayog Airport (Philippines) (RPVC / CYP)"
+  },
+  {
+    "id": "CRM",
+    "british": false,
+    "label": "Catarman National Airport (Philippines) (RPVF / CRM)"
+  },
+  {
+    "id": "MBT",
+    "british": false,
+    "label": "Moises R. Espinosa Airport (Philippines) (RPVJ / MBT)"
+  },
+  {
+    "id": "RXS",
+    "british": false,
+    "label": "Roxas Airport (Philippines) (RPVR / RXS)"
+  },
+  {
+    "id": "TTG",
+    "british": false,
+    "label": "General Enrique Mosconi Airport (Argentina) (SAST / TTG)"
+  },
+  {
+    "id": "LHS",
+    "british": false,
+    "label": "Las Heras Airport (Argentina) (SAVH / LHS)"
+  },
+  {
+    "id": "OES",
+    "british": false,
+    "label": "Antoine de Saint Exupéry Airport (Argentina) (SAVN / OES)"
+  },
+  {
+    "id": "ING",
+    "british": false,
+    "label": "Lago Argentino Airport (Argentina) (SAWA / ING)"
+  },
+  {
+    "id": "GGS",
+    "british": false,
+    "label": "Gobernador Gregores Airport (Argentina) (SAWR / GGS)"
+  },
+  {
+    "id": "SST",
+    "british": false,
+    "label": "Santa Teresita Airport (Argentina) (SAZL / SST)"
+  },
+  {
+    "id": "NEC",
+    "british": false,
+    "label": "Necochea Airport (Argentina) (SAZO / NEC)"
+  },
+  {
+    "id": "JDO",
+    "british": false,
+    "label": "Orlando Bezerra de Menezes Airport (Brazil) (SBJU / JDO)"
+  },
+  {
+    "id": "LEC",
+    "british": false,
+    "label": "Coronel Horácio de Mattos Airport (Brazil) (SBLE / LEC)"
+  },
+  {
+    "id": "MEA",
+    "british": false,
+    "label": "Macaé Airport (Brazil) (SBME / MEA)"
+  },
+  {
+    "id": "MII",
+    "british": false,
+    "label": "Frank Miloye Milenkowichi–Marília State Airport (Brazil) (SBML / MII)"
+  },
+  {
+    "id": "VDC",
+    "british": false,
+    "label": "Vitória da Conquista Airport (Brazil) (SBQV / VDC)"
+  },
+  {
+    "id": "RIA",
+    "british": false,
+    "label": "Santa Maria Airport (Brazil) (SBSM / RIA)"
+  },
+  {
+    "id": "TOW",
+    "british": false,
+    "label": "Toledo Airport (Brazil) (SBTD / TOW)"
+  },
+  {
+    "id": "ESR",
+    "british": false,
+    "label": "Ricardo García Posada Airport (Chile) (SCES / ESR)"
+  },
+  {
+    "id": "ZPC",
+    "british": false,
+    "label": "Pucón Airport (Chile) (SCPC / ZPC)"
+  },
+  {
+    "id": "SOD",
+    "british": false,
+    "label": "Sorocaba Airport (Brazil) (SDCO / SOD)"
+  },
+  {
+    "id": "SCY",
+    "british": false,
+    "label": "San Cristóbal Airport (Ecuador) (SEST / SCY)"
+  },
+  {
+    "id": "LOH",
+    "british": false,
+    "label": "Camilo Ponce Enriquez Airport (Ecuador) (SETM / LOH)"
+  },
+  {
+    "id": "ESM",
+    "british": false,
+    "label": "General Rivadeneira Airport (Ecuador) (SETN / ESM)"
+  },
+  {
+    "id": "PSY",
+    "british": false,
+    "label": "Port Stanley Airport (Falkland Islands) (SFAL / PSY)"
+  },
+  {
+    "id": "CRC",
+    "british": false,
+    "label": "Santa Ana Airport (Colombia) (SKGO / CRC)"
+  },
+  {
+    "id": "SKGZ",
+    "british": false,
+    "label": "La Jagua Airport (Colombia) (SKGZ)"
+  },
+  {
+    "id": "LQM",
+    "british": false,
+    "label": "Caucaya Airport (Colombia) (SKLG / LQM)"
+  },
+  {
+    "id": "LPD",
+    "british": false,
+    "label": "La Pedrera Airport (Colombia) (SKLP / LPD)"
+  },
+  {
+    "id": "NQU",
+    "british": false,
+    "label": "Reyes Murillo Airport (Colombia) (SKNQ / NQU)"
+  },
+  {
+    "id": "PDA",
+    "british": false,
+    "label": "Obando Airport (Colombia) (SKPD / PDA)"
+  },
+  {
+    "id": "EYP",
+    "british": false,
+    "label": "El Yopal Airport (Colombia) (SKYP / EYP)"
+  },
+  {
+    "id": "GYA",
+    "british": false,
+    "label": "Capitán de Av. Emilio Beltrán Airport (Bolivia) (SLGY / GYA)"
+  },
+  {
+    "id": "PUR",
+    "british": false,
+    "label": "Puerto Rico Airport (Bolivia) (SLPR / PUR)"
+  },
+  {
+    "id": "RIB",
+    "british": false,
+    "label": "Capitán Av. Selin Zeitun Lopez Airport (Bolivia) (SLRI / RIB)"
+  },
+  {
+    "id": "REY",
+    "british": false,
+    "label": "Reyes Airport (Bolivia) (SLRY / REY)"
+  },
+  {
+    "id": "SRJ",
+    "british": false,
+    "label": "Capitán Av. German Quiroga G. Airport (Bolivia) (SLSB / SRJ)"
+  },
+  {
+    "id": "ORG",
+    "british": false,
+    "label": "Zorg en Hoop Airport (Suriname) (SMZO / ORG)"
+  },
+  {
+    "id": "MVS",
+    "british": false,
+    "label": "Mucuri Airport (Brazil) (SNMU / MVS)"
+  },
+  {
+    "id": "SPBC",
+    "british": false,
+    "label": "Caballococha Airport (Peru) (SPBC)"
+  },
+  {
+    "id": "CJA",
+    "british": false,
+    "label": "Mayor General FAP Armando Revoredo Iglesias Airport (Peru) (SPJR / CJA)"
+  },
+  {
+    "id": "HUU",
+    "british": false,
+    "label": "Alferez Fap David Figueroa Fernandini Airport (Peru) (SPNC / HUU)"
+  },
+  {
+    "id": "NZC",
+    "british": false,
+    "label": "Maria Reiche Neuman Airport (Peru) (SPZA / NZC)"
+  },
+  {
+    "id": "SRA",
+    "british": false,
+    "label": "Santa Rosa Airport (Brazil) (SSZR / SRA)"
+  },
+  {
+    "id": "SUPE",
+    "british": false,
+    "label": "El Jagüel / Punta del Este Airport (Uruguay) (SUPE)"
+  },
+  {
+    "id": "MYC",
+    "british": false,
+    "label": "Escuela Mariscal Sucre Airport (Venezuela) (SVBS / MYC)"
+  },
+  {
+    "id": "VIG",
+    "british": false,
+    "label": "Juan Pablo Pérez Alfonso Airport (Venezuela) (SVVG / VIG)"
+  },
+  {
+    "id": "JPR",
+    "british": false,
+    "label": "Ji-Paraná Airport (Brazil) (SWJI / JPR)"
+  },
+  {
+    "id": "BBQ",
+    "british": false,
+    "label": "Codrington Airport (Antigua and Barbuda) (TAPH / BBQ)"
+  },
+  {
+    "id": "DSD",
+    "british": false,
+    "label": "La Désirade Airport (Guadeloupe) (TFFA / DSD)"
+  },
+  {
+    "id": "BBR",
+    "british": false,
+    "label": "Baillif Airport (Guadeloupe) (TFFB / BBR)"
+  },
+  {
+    "id": "SFC",
+    "british": false,
+    "label": "St-François Airport (Guadeloupe) (TFFC / SFC)"
+  },
+  {
+    "id": "GBJ",
+    "british": false,
+    "label": "Les Bases Airport (Guadeloupe) (TFFM / GBJ)"
+  },
+  {
+    "id": "NEV",
+    "british": false,
+    "label": "Vance W. Amory International Airport (Saint Kitts and Nevis) (TKPN / NEV)"
+  },
+  {
+    "id": "VIJ",
+    "british": false,
+    "label": "Virgin Gorda Airport (British Virgin Islands) (TUPW / VIJ)"
+  },
+  {
+    "id": "BQU",
+    "british": false,
+    "label": "J F Mitchell Airport (Saint Vincent and the Grenadines) (TVSB / BQU)"
+  },
+  {
+    "id": "UNI",
+    "british": false,
+    "label": "Union Island International Airport (Saint Vincent and the Grenadines) (TVSU / UNI)"
+  },
+  {
+    "id": "KOV",
+    "british": false,
+    "label": "Kokshetau Airport (Kazakhstan) (UACK / KOV)"
+  },
+  {
+    "id": "PPK",
+    "british": false,
+    "label": "Petropavlosk South Airport (Kazakhstan) (UACP / PPK)"
+  },
+  {
+    "id": "DZN",
+    "british": false,
+    "label": "Zhezkazgan Airport (Kazakhstan) (UAKD / DZN)"
+  },
+  {
+    "id": "UKK",
+    "british": false,
+    "label": "Ust-Kamennogorsk Airport (Kazakhstan) (UASK / UKK)"
+  },
+  {
+    "id": "KSN",
+    "british": false,
+    "label": "Kostanay West Airport (Kazakhstan) (UAUU / KSN)"
+  },
+  {
+    "id": "KVD",
+    "british": false,
+    "label": "Ganja Airport (Azerbaijan) (UBBG / KVD)"
+  },
+  {
+    "id": "NAJ",
+    "british": false,
+    "label": "Nakhchivan Airport (Azerbaijan) (UBBN / NAJ)"
+  },
+  {
+    "id": "NER",
+    "british": false,
+    "label": "Chulman Airport (Russia) (UELL / NER)"
+  },
+  {
+    "id": "PYJ",
+    "british": false,
+    "label": "Polyarny Airport (Russia) (UERP / PYJ)"
+  },
+  {
+    "id": "CKH",
+    "british": false,
+    "label": "Chokurdakh Airport (Russia) (UESO / CKH)"
+  },
+  {
+    "id": "CYX",
+    "british": false,
+    "label": "Cherskiy Airport (Russia) (UESS / CYX)"
+  },
+  {
+    "id": "IKS",
+    "british": false,
+    "label": "Tiksi Airport (Russia) (UEST / IKS)"
+  },
+  {
+    "id": "KXK",
+    "british": false,
+    "label": "Komsomolsk-on-Amur Airport (Russia) (UHKK / KXK)"
+  },
+  {
+    "id": "DYR",
+    "british": false,
+    "label": "Ugolny Airport (Russia) (UHMA / DYR)"
+  },
+  {
+    "id": "OHO",
+    "british": false,
+    "label": "Okhotsk Airport (Russia) (UHOO / OHO)"
+  },
+  {
+    "id": "UJE",
+    "british": false,
+    "label": "Ujae Atoll Airport (Marshall Islands) (UJAP / UJE)"
+  },
+  {
+    "id": "MPW",
+    "british": false,
+    "label": "Mariupol International Airport (Ukraine) (UKCM / MPW)"
+  },
+  {
+    "id": "VSG",
+    "british": false,
+    "label": "Luhansk International Airport (Ukraine) (UKCW / VSG)"
+  },
+  {
+    "id": "OZH",
+    "british": false,
+    "label": "Zaporizhzhia International Airport (Ukraine) (UKDE / OZH)"
+  },
+  {
+    "id": "KWG",
+    "british": false,
+    "label": "Kryvyi Rih International Airport (Ukraine) (UKDR / KWG)"
+  },
+  {
+    "id": "HRK",
+    "british": false,
+    "label": "Kharkiv International Airport (Ukraine) (UKHH / HRK)"
+  },
+  {
+    "id": "IFO",
+    "british": false,
+    "label": "Ivano-Frankivsk International Airport (Ukraine) (UKLI / IFO)"
+  },
+  {
+    "id": "CWC",
+    "british": false,
+    "label": "Chernivtsi International Airport (Ukraine) (UKLN / CWC)"
+  },
+  {
+    "id": "RWN",
+    "british": false,
+    "label": "Rivne International Airport (Ukraine) (UKLR / RWN)"
+  },
+  {
+    "id": "UDJ",
+    "british": false,
+    "label": "Uzhhorod International Airport (Ukraine) (UKLU / UDJ)"
+  },
+  {
+    "id": "CSH",
+    "british": false,
+    "label": "Solovki Airport (Russia) (ULAS / CSH)"
+  },
+  {
+    "id": "CEE",
+    "british": false,
+    "label": "Cherepovets Airport (Russia) (ULBC / CEE)"
+  },
+  {
+    "id": "AMV",
+    "british": false,
+    "label": "Amderma Airport (Russia) (ULDD / AMV)"
+  },
+  {
+    "id": "KSZ",
+    "british": false,
+    "label": "Kotlas Airport (Russia) (ULKK / KSZ)"
+  },
+  {
+    "id": "PES",
+    "british": false,
+    "label": "Petrozavodsk Airport (Russia) (ULPB / PES)"
+  },
+  {
+    "id": "GNA",
+    "british": false,
+    "label": "Hrodna Airport (Belarus) (UMMG / GNA)"
+  },
+  {
+    "id": "MVQ",
+    "british": false,
+    "label": "Mogilev Airport (Belarus) (UMOO / MVQ)"
+  },
+  {
+    "id": "EIE",
+    "british": false,
+    "label": "Yeniseysk Airport (Russia) (UNII / EIE)"
+  },
+  {
+    "id": "KYZ",
+    "british": false,
+    "label": "Kyzyl Airport (Russia) (UNKY / KYZ)"
+  },
+  {
+    "id": "NOZ",
+    "british": false,
+    "label": "Spichenkovo Airport (Russia) (UNWW / NOZ)"
+  },
+  {
+    "id": "HTG",
+    "british": false,
+    "label": "Khatanga Airport (Russia) (UOHH / HTG)"
+  },
+  {
+    "id": "IAA",
+    "british": false,
+    "label": "Igarka Airport (Russia) (UOII / IAA)"
+  },
+  {
+    "id": "URMG",
+    "british": false,
+    "label": "Khankala Air Base (Russia) (URMG)"
+  },
+  {
+    "id": "NAL",
+    "british": false,
+    "label": "Nalchik Airport (Russia) (URMN / NAL)"
+  },
+  {
+    "id": "OGZ",
+    "british": false,
+    "label": "Beslan Airport (Russia) (URMO / OGZ)"
+  },
+  {
+    "id": "ESL",
+    "british": false,
+    "label": "Elista Airport (Russia) (URWI / ESL)"
+  },
+  {
+    "id": "WKK",
+    "british": false,
+    "label": "Aleknagik / New Airport (United States) (5A8 / WKK)"
+  },
+  {
+    "id": "BLF",
+    "british": false,
+    "label": "Mercer County Airport (United States) (KBLF / BLF)"
+  },
+  {
+    "id": "GLH",
+    "british": false,
+    "label": "Mid Delta Regional Airport (United States) (KGLH / GLH)"
+  },
+  {
+    "id": "PSC",
+    "british": false,
+    "label": "Tri Cities Airport (United States) (KPSC / PSC)"
+  },
+  {
+    "id": "KQA",
+    "british": false,
+    "label": "Akutan Seaplane Base (United States) (KQA / KQA)"
+  },
+  {
+    "id": "LPS",
+    "british": false,
+    "label": "Lopez Island Airport (United States) (S31 / LPS)"
+  },
+  {
+    "id": "SLY",
+    "british": false,
+    "label": "Salekhard Airport (Russia) (USDD / SLY)"
+  },
+  {
+    "id": "HMA",
+    "british": false,
+    "label": "Khanty Mansiysk Airport (Russia) (USHH / HMA)"
+  },
+  {
+    "id": "NYA",
+    "british": false,
+    "label": "Nyagan Airport (Russia) (USHN / NYA)"
+  },
+  {
+    "id": "OVS",
+    "british": false,
+    "label": "Sovetskiy Airport (Russia) (USHS / OVS)"
+  },
+  {
+    "id": "IJK",
+    "british": false,
+    "label": "Izhevsk Airport (Russia) (USII / IJK)"
+  },
+  {
+    "id": "KVX",
+    "british": false,
+    "label": "Pobedilovo Airport (Russia) (USKK / KVX)"
+  },
+  {
+    "id": "NYM",
+    "british": false,
+    "label": "Nadym Airport (Russia) (USMM / NYM)"
+  },
+  {
+    "id": "RAT",
+    "british": false,
+    "label": "Raduzhny Airport (Russia) (USNR / RAT)"
+  },
+  {
+    "id": "NFG",
+    "british": false,
+    "label": "Nefteyugansk Airport (Russia) (USRN / NFG)"
+  },
+  {
+    "id": "KRO",
+    "british": false,
+    "label": "Kurgan Airport (Russia) (USUU / KRO)"
+  },
+  {
+    "id": "LBD",
+    "british": false,
+    "label": "Khudzhand Airport (Tajikistan) (UTDL / LBD)"
+  },
+  {
+    "id": "AZN",
+    "british": false,
+    "label": "Andizhan Airport (Uzbekistan) (UTKA / AZN)"
+  },
+  {
+    "id": "FEG",
+    "british": false,
+    "label": "Fergana International Airport (Uzbekistan) (UTKF / FEG)"
+  },
+  {
+    "id": "NMA",
+    "british": false,
+    "label": "Namangan Airport (Uzbekistan) (UTKN / NMA)"
+  },
+  {
+    "id": "NCU",
+    "british": false,
+    "label": "Nukus Airport (Uzbekistan) (UTNN / NCU)"
+  },
+  {
+    "id": "UGC",
+    "british": false,
+    "label": "Urgench Airport (Uzbekistan) (UTNU / UGC)"
+  },
+  {
+    "id": "KSQ",
+    "british": false,
+    "label": "Karshi Khanabad Airport (Uzbekistan) (UTSL / KSQ)"
+  },
+  {
+    "id": "TMJ",
+    "british": false,
+    "label": "Termez Airport (Uzbekistan) (UTST / TMJ)"
+  },
+  {
+    "id": "RYB",
+    "british": false,
+    "label": "Staroselye Airport (Russia) (UUBK / RYB)"
+  },
+  {
+    "id": "EGO",
+    "british": false,
+    "label": "Belgorod International Airport (Russia) (UUOB / EGO)"
+  },
+  {
+    "id": "URS",
+    "british": false,
+    "label": "Kursk East Airport (Russia) (UUOK / URS)"
+  },
+  {
+    "id": "LPK",
+    "british": false,
+    "label": "Lipetsk Airport (Russia) (UUOL / LPK)"
+  },
+  {
+    "id": "VKT",
+    "british": false,
+    "label": "Vorkuta Airport (Russia) (UUYW / VKT)"
+  },
+  {
+    "id": "UUA",
+    "british": false,
+    "label": "Bugulma Airport (Russia) (UWKB / UUA)"
+  },
+  {
+    "id": "JOK",
+    "british": false,
+    "label": "Yoshkar-Ola Airport (Russia) (UWKJ / JOK)"
+  },
+  {
+    "id": "CSY",
+    "british": false,
+    "label": "Cheboksary Airport (Russia) (UWKS / CSY)"
+  },
+  {
+    "id": "ULY",
+    "british": false,
+    "label": "Ulyanovsk East Airport (Russia) (UWLW / ULY)"
+  },
+  {
+    "id": "OSW",
+    "british": false,
+    "label": "Orsk Airport (Russia) (UWOR / OSW)"
+  },
+  {
+    "id": "PEZ",
+    "british": false,
+    "label": "Penza Airport (Russia) (UWPP / PEZ)"
+  },
+  {
+    "id": "SKX",
+    "british": false,
+    "label": "Saransk Airport (Russia) (UWPS / SKX)"
+  },
+  {
+    "id": "BWO",
+    "british": false,
+    "label": "Balakovo Airport (Russia) (UWSB / BWO)"
+  },
+  {
+    "id": "HBX",
+    "british": false,
+    "label": "Hubli Airport (India) (VAHB / HBX)"
+  },
+  {
+    "id": "KCT",
+    "british": false,
+    "label": "Koggala Airport (Sri Lanka) (VCCK / KCT)"
+  },
+  {
+    "id": "WRZ",
+    "british": false,
+    "label": "Weerawila Airport (Sri Lanka) (VCCW / WRZ)"
+  },
+  {
+    "id": "BBM",
+    "british": false,
+    "label": "Battambang Airport (Cambodia) (VDBG / BBM)"
+  },
+  {
+    "id": "SHL",
+    "british": false,
+    "label": "Shillong Airport (India) (VEBI / SHL)"
+  },
+  {
+    "id": "GAU",
+    "british": false,
+    "label": "Lokpriya Gopinath Bordoloi International Airport (India) (VEGT / GAU)"
+  },
+  {
+    "id": "DMU",
+    "british": false,
+    "label": "Dimapur Airport (India) (VEMR / DMU)"
+  },
+  {
+    "id": "TEZ",
+    "british": false,
+    "label": "Tezpur Airport (India) (VETZ / TEZ)"
+  },
+  {
+    "id": "BZL",
+    "british": false,
+    "label": "Barisal Airport (Bangladesh) (VGBR / BZL)"
+  },
+  {
+    "id": "HOE",
+    "british": false,
+    "label": "Ban Huoeisay Airport (Laos) (VLHS / HOE)"
+  },
+  {
+    "id": "BHR",
+    "british": false,
+    "label": "Bharatpur Airport (Nepal) (VNBP / BHR)"
+  },
+  {
+    "id": "BDP",
+    "british": false,
+    "label": "Bhadrapur Airport (Nepal) (VNCG / BDP)"
+  },
+  {
+    "id": "MEY",
+    "british": false,
+    "label": "Meghauli Airport (Nepal) (VNMG / MEY)"
+  },
+  {
+    "id": "KEP",
+    "british": false,
+    "label": "Nepalgunj Airport (Nepal) (VNNG / KEP)"
+  },
+  {
+    "id": "GAN",
+    "british": false,
+    "label": "Gan International Airport (Maldives) (VRMG / GAN)"
+  },
+  {
+    "id": "HAQ",
+    "british": false,
+    "label": "Hanimaadhoo Airport (Maldives) (VRMH / HAQ)"
+  },
+  {
+    "id": "KDO",
+    "british": false,
+    "label": "Kadhdhoo Airport (Maldives) (VRMK / KDO)"
+  },
+  {
+    "id": "MAQ",
+    "british": false,
+    "label": "Mae Sot Airport (Thailand) (VTPM / MAQ)"
+  },
+  {
+    "id": "BMV",
+    "british": false,
+    "label": "Buon Ma Thuot Airport (Vietnam) (VVBM / BMV)"
+  },
+  {
+    "id": "HPH",
+    "british": false,
+    "label": "Cat Bi International Airport (Vietnam) (VVCI / HPH)"
+  },
+  {
+    "id": "CXR",
+    "british": false,
+    "label": "Cam Ranh Airport (Vietnam) (VVCR / CXR)"
+  },
+  {
+    "id": "VCS",
+    "british": false,
+    "label": "Co Ong Airport (Vietnam) (VVCS / VCS)"
+  },
+  {
+    "id": "VCA",
+    "british": false,
+    "label": "Can Tho International Airport (Vietnam) (VVCT / VCA)"
+  },
+  {
+    "id": "DIN",
+    "british": false,
+    "label": "Dien Bien Phu Airport (Vietnam) (VVDB / DIN)"
+  },
+  {
+    "id": "UIH",
+    "british": false,
+    "label": "Phu Cat Airport (Vietnam) (VVPC / UIH)"
+  },
+  {
+    "id": "PXU",
+    "british": false,
+    "label": "Pleiku Airport (Vietnam) (VVPK / PXU)"
+  },
+  {
+    "id": "VII",
+    "british": false,
+    "label": "Vinh Airport (Vietnam) (VVVH / VII)"
+  },
+  {
+    "id": "BMO",
+    "british": false,
+    "label": "Banmaw Airport (Burma) (VYBM / BMO)"
+  },
+  {
+    "id": "TVY",
+    "british": false,
+    "label": "Dawei Airport (Burma) (VYDW / TVY)"
+  },
+  {
+    "id": "KAW",
+    "british": false,
+    "label": "Kawthoung Airport (Burma) (VYKT / KAW)"
+  },
+  {
+    "id": "LIW",
+    "british": false,
+    "label": "Loikaw Airport (Burma) (VYLK / LIW)"
+  },
+  {
+    "id": "MNU",
+    "british": false,
+    "label": "Mawlamyine Airport (Burma) (VYMM / MNU)"
+  },
+  {
+    "id": "BSX",
+    "british": false,
+    "label": "Pathein Airport (Burma) (VYPN / BSX)"
+  },
+  {
+    "id": "PKK",
+    "british": false,
+    "label": "Pakhokku Airport (Burma) (VYPU / PKK)"
+  },
+  {
+    "id": "SWQ",
+    "british": false,
+    "label": "Sumbawa Besar Airport (Indonesia) (WADS / SWQ)"
+  },
+  {
+    "id": "TMC",
+    "british": false,
+    "label": "Tambolaka Airport (Indonesia) (WADT / TMC)"
+  },
+  {
+    "id": "BUI",
+    "british": false,
+    "label": "Bokondini Airport (Indonesia) (WAJB / BUI)"
+  },
+  {
+    "id": "SEH",
+    "british": false,
+    "label": "Senggeh Airport (Indonesia) (WAJS / SEH)"
+  },
+  {
+    "id": "TJS",
+    "british": false,
+    "label": "Tanjung Harapan Airport (Indonesia) (WALG / TJS)"
+  },
+  {
+    "id": "DTD",
+    "british": false,
+    "label": "Datadawai Airport (Indonesia) (WALJ / DTD)"
+  },
+  {
+    "id": "BEJ",
+    "british": false,
+    "label": "Kalimarau Airport (Indonesia) (WALK / BEJ)"
+  },
+  {
+    "id": "TJG",
+    "british": false,
+    "label": "Warukin Airport (Indonesia) (WAON / TJG)"
+  },
+  {
+    "id": "SMQ",
+    "british": false,
+    "label": "Sampit(Hasan) Airport (Indonesia) (WAOS / SMQ)"
+  },
+  {
+    "id": "LUV",
+    "british": false,
+    "label": "Dumatumbun Airport (Indonesia) (WAPL / LUV)"
+  },
+  {
+    "id": "ARD",
+    "british": false,
+    "label": "Mali Airport (Indonesia) (WATM / ARD)"
+  },
+  {
+    "id": "BLG",
+    "british": false,
+    "label": "Belaga Airport (Malaysia) (WBGC / BLG)"
+  },
+  {
+    "id": "LGL",
+    "british": false,
+    "label": "Long Lellang Airport (Malaysia) (WBGF / LGL)"
+  },
+  {
+    "id": "ODN",
+    "british": false,
+    "label": "Long Seridan Airport (Malaysia) (WBGI / ODN)"
+  },
+  {
+    "id": "MKM",
+    "british": false,
+    "label": "Mukah Airport (Malaysia) (WBGK / MKM)"
+  },
+  {
+    "id": "BKM",
+    "british": false,
+    "label": "Bakalalan Airport (Malaysia) (WBGQ / BKM)"
+  },
+  {
+    "id": "LWY",
+    "british": false,
+    "label": "Lawas Airport (Malaysia) (WBGW / LWY)"
+  },
+  {
+    "id": "BBN",
+    "british": false,
+    "label": "Bario Airport (Malaysia) (WBGZ / BBN)"
+  },
+  {
+    "id": "TMG",
+    "british": false,
+    "label": "Tomanggong Airport (Malaysia) (WBKM / TMG)"
+  },
+  {
+    "id": "KUD",
+    "british": false,
+    "label": "Kudat Airport (Malaysia) (WBKT / KUD)"
+  },
+  {
+    "id": "TKG",
+    "british": false,
+    "label": "Radin Inten II (Branti) Airport (Indonesia) (WIAT / TKG)"
+  },
+  {
+    "id": "HLP",
+    "british": false,
+    "label": "Halim Perdanakusuma International Airport (Indonesia) (WIHH / HLP)"
+  },
+  {
+    "id": "NTX",
+    "british": false,
+    "label": "Ranai Airport (Indonesia) (WION / NTX)"
+  },
+  {
+    "id": "PSU",
+    "british": false,
+    "label": "Pangsuma Airport (Indonesia) (WIOP / PSU)"
+  },
+  {
+    "id": "SQG",
+    "british": false,
+    "label": "Sintang(Susilo) Airport (Indonesia) (WIOS / SQG)"
+  },
+  {
+    "id": "PDO",
+    "british": false,
+    "label": "Pendopo Airport (Indonesia) (WIPQ / PDO)"
+  },
+  {
+    "id": "LSW",
+    "british": false,
+    "label": "Malikus Saleh Airport (Indonesia) (WITM / LSW)"
+  },
+  {
+    "id": "PKG",
+    "british": false,
+    "label": "Pulau Pangkor Airport (Malaysia) (WMPA / PKG)"
+  },
+  {
+    "id": "LBW",
+    "british": false,
+    "label": "Long Bawan Airport (Indonesia) (WRLB / LBW)"
+  },
+  {
+    "id": "NNX",
+    "british": false,
+    "label": "Nunukan Airport (Indonesia) (WRLF / NNX)"
+  },
+  {
+    "id": "LPU",
+    "british": false,
+    "label": "Long Apung Airport (Indonesia) (WRLP / LPU)"
+  },
+  {
+    "id": "ALH",
+    "british": false,
+    "label": "Albany Airport (Australia) (YABA / ALH)"
+  },
+  {
+    "id": "GYL",
+    "british": false,
+    "label": "Argyle Airport (Australia) (YARG / GYL)"
+  },
+  {
+    "id": "AUU",
+    "british": false,
+    "label": "Aurukun Airport (Australia) (YAUR / AUU)"
+  },
+  {
+    "id": "BCI",
+    "british": false,
+    "label": "Barcaldine Airport (Australia) (YBAR / BCI)"
+  },
+  {
+    "id": "BDD",
+    "british": false,
+    "label": "Badu Island Airport (Australia) (YBAU / BDD)"
+  },
+  {
+    "id": "BVI",
+    "british": false,
+    "label": "Birdsville Airport (Australia) (YBDV / BVI)"
+  },
+  {
+    "id": "BHQ",
+    "british": false,
+    "label": "Broken Hill Airport (Australia) (YBHI / BHQ)"
+  },
+  {
+    "id": "HTI",
+    "british": false,
+    "label": "Hamilton Island Airport (Australia) (YBHM / HTI)"
+  },
+  {
+    "id": "BEU",
+    "british": false,
+    "label": "Bedourie Airport (Australia) (YBIE / BEU)"
+  },
+  {
+    "id": "BRK",
+    "british": false,
+    "label": "Bourke Airport (Australia) (YBKE / BRK)"
+  },
+  {
+    "id": "BUC",
+    "british": false,
+    "label": "Burketown Airport (Australia) (YBKT / BUC)"
+  },
+  {
+    "id": "GIC",
+    "british": false,
+    "label": "Boigu Airport (Australia) (YBOI / GIC)"
+  },
+  {
+    "id": "OKY",
+    "british": false,
+    "label": "Oakey Airport (Australia) (YBOK / OKY)"
+  },
+  {
+    "id": "BQL",
+    "british": false,
+    "label": "Boulia Airport (Australia) (YBOU / BQL)"
+  },
+  {
+    "id": "BHS",
+    "british": false,
+    "label": "Bathurst Airport (Australia) (YBTH / BHS)"
+  },
+  {
+    "id": "BLT",
+    "british": false,
+    "label": "Blackwater Airport (Australia) (YBTR / BLT)"
+  },
+  {
+    "id": "CVQ",
+    "british": false,
+    "label": "Carnarvon Airport (Australia) (YCAR / CVQ)"
+  },
+  {
+    "id": "CAZ",
+    "british": false,
+    "label": "Cobar Airport (Australia) (YCBA / CAZ)"
+  },
+  {
+    "id": "CPD",
+    "british": false,
+    "label": "Coober Pedy Airport (Australia) (YCBP / CPD)"
+  },
+  {
+    "id": "CNC",
+    "british": false,
+    "label": "Coconut Island Airport (Australia) (YCCT / CNC)"
+  },
+  {
+    "id": "CNJ",
+    "british": false,
+    "label": "Cloncurry Airport (Australia) (YCCY / CNJ)"
+  },
+  {
+    "id": "CED",
+    "british": false,
+    "label": "Ceduna Airport (Australia) (YCDU / CED)"
+  },
+  {
+    "id": "CTN",
+    "british": false,
+    "label": "Cooktown Airport (Australia) (YCKN / CTN)"
+  },
+  {
+    "id": "CMA",
+    "british": false,
+    "label": "Cunnamulla Airport (Australia) (YCMU / CMA)"
+  },
+  {
+    "id": "CNB",
+    "british": false,
+    "label": "Coonamble Airport (Australia) (YCNM / CNB)"
+  },
+  {
+    "id": "CUQ",
+    "british": false,
+    "label": "Coen Airport (Australia) (YCOE / CUQ)"
+  },
+  {
+    "id": "OOM",
+    "british": false,
+    "label": "Cooma Snowy Mountains Airport (Australia) (YCOM / OOM)"
+  },
+  {
+    "id": "DMD",
+    "british": false,
+    "label": "Doomadgee Airport (Australia) (YDMG / DMD)"
+  },
+  {
+    "id": "NLF",
+    "british": false,
+    "label": "Darnley Island Airport (Australia) (YDNI / NLF)"
+  },
+  {
+    "id": "DPO",
+    "british": false,
+    "label": "Devonport Airport (Australia) (YDPO / DPO)"
+  },
+  {
+    "id": "ELC",
+    "british": false,
+    "label": "Elcho Island Airport (Australia) (YELD / ELC)"
+  },
+  {
+    "id": "EPR",
+    "british": false,
+    "label": "Esperance Airport (Australia) (YESP / EPR)"
+  },
+  {
+    "id": "FLS",
+    "british": false,
+    "label": "Flinders Island Airport (Australia) (YFLI / FLS)"
+  },
+  {
+    "id": "GET",
+    "british": false,
+    "label": "Geraldton Airport (Australia) (YGEL / GET)"
+  },
+  {
+    "id": "GLT",
+    "british": false,
+    "label": "Gladstone Airport (Australia) (YGLA / GLT)"
+  },
+  {
+    "id": "GTE",
+    "british": false,
+    "label": "Groote Eylandt Airport (Australia) (YGTE / GTE)"
+  },
+  {
+    "id": "GFF",
+    "british": false,
+    "label": "Griffith Airport (Australia) (YGTH / GFF)"
+  },
+  {
+    "id": "HID",
+    "british": false,
+    "label": "Horn Island Airport (Australia) (YHID / HID)"
+  },
+  {
+    "id": "HOK",
+    "british": false,
+    "label": "Hooker Creek Airport (Australia) (YHOO / HOK)"
+  },
+  {
+    "id": "MHU",
+    "british": false,
+    "label": "Mount Hotham Airport (Australia) (YHOT / MHU)"
+  },
+  {
+    "id": "HGD",
+    "british": false,
+    "label": "Hughenden Airport (Australia) (YHUG / HGD)"
+  },
+  {
+    "id": "JCK",
+    "british": false,
+    "label": "Julia Creek Airport (Australia) (YJLC / JCK)"
+  },
+  {
+    "id": "KAX",
+    "british": false,
+    "label": "Kalbarri Airport (Australia) (YKBR / KAX)"
+  },
+  {
+    "id": "KNS",
+    "british": false,
+    "label": "King Island Airport (Australia) (YKII / KNS)"
+  },
+  {
+    "id": "KFG",
+    "british": false,
+    "label": "Kalkgurung Airport (Australia) (YKKG / KFG)"
+  },
+  {
+    "id": "KRB",
+    "british": false,
+    "label": "Karumba Airport (Australia) (YKMB / KRB)"
+  },
+  {
+    "id": "KWM",
+    "british": false,
+    "label": "Kowanyama Airport (Australia) (YKOW / KWM)"
+  },
+  {
+    "id": "KUG",
+    "british": false,
+    "label": "Kubin Airport (Australia) (YKUB / KUG)"
+  },
+  {
+    "id": "LNO",
+    "british": false,
+    "label": "Leonora Airport (Australia) (YLEO / LNO)"
+  },
+  {
+    "id": "LEL",
+    "british": false,
+    "label": "Lake Evella Airport (Australia) (YLEV / LEL)"
+  },
+  {
+    "id": "LDH",
+    "british": false,
+    "label": "Lord Howe Island Airport (Australia) (YLHI / LDH)"
+  },
+  {
+    "id": "IRG",
+    "british": false,
+    "label": "Lockhart River Airport (Australia) (YLHR / IRG)"
+  },
+  {
+    "id": "LSY",
+    "british": false,
+    "label": "Lismore Airport (Australia) (YLIS / LSY)"
+  },
+  {
+    "id": "LHG",
+    "british": false,
+    "label": "Lightning Ridge Airport (Australia) (YLRD / LHG)"
+  },
+  {
+    "id": "LRE",
+    "british": false,
+    "label": "Longreach Airport (Australia) (YLRE / LRE)"
+  },
+  {
+    "id": "LER",
+    "british": false,
+    "label": "Leinster Airport (Australia) (YLST / LER)"
+  },
+  {
+    "id": "LVO",
+    "british": false,
+    "label": "Laverton Airport (Australia) (YLTN / LVO)"
+  },
+  {
+    "id": "UBB",
+    "british": false,
+    "label": "Mabuiag Island Airport (Australia) (YMAA / UBB)"
+  },
+  {
+    "id": "MKR",
+    "british": false,
+    "label": "Meekatharra Airport (Australia) (YMEK / MKR)"
+  },
+  {
+    "id": "MIM",
+    "british": false,
+    "label": "Merimbula Airport (Australia) (YMER / MIM)"
+  },
+  {
+    "id": "MGT",
+    "british": false,
+    "label": "Milingimbi Airport (Australia) (YMGB / MGT)"
+  },
+  {
+    "id": "MNG",
+    "british": false,
+    "label": "Maningrida Airport (Australia) (YMGD / MNG)"
+  },
+  {
+    "id": "MCV",
+    "british": false,
+    "label": "McArthur River Mine Airport (Australia) (YMHU / MCV)"
+  },
+  {
+    "id": "MQL",
+    "british": false,
+    "label": "Mildura Airport (Australia) (YMIA / MQL)"
+  },
+  {
+    "id": "MMG",
+    "british": false,
+    "label": "Mount Magnet Airport (Australia) (YMOG / MMG)"
+  },
+  {
+    "id": "MRZ",
+    "british": false,
+    "label": "Moree Airport (Australia) (YMOR / MRZ)"
+  },
+  {
+    "id": "MOV",
+    "british": false,
+    "label": "Moranbah Airport (Australia) (YMRB / MOV)"
+  },
+  {
+    "id": "MYA",
+    "british": false,
+    "label": "Moruya Airport (Australia) (YMRY / MYA)"
+  },
+  {
+    "id": "MGB",
+    "british": false,
+    "label": "Mount Gambier Airport (Australia) (YMTG / MGB)"
+  },
+  {
+    "id": "ONG",
+    "british": false,
+    "label": "Mornington Island Airport (Australia) (YMTI / ONG)"
+  },
+  {
+    "id": "MYI",
+    "british": false,
+    "label": "Murray Island Airport (Australia) (YMUI / MYI)"
+  },
+  {
+    "id": "MBH",
+    "british": false,
+    "label": "Maryborough Airport (Australia) (YMYB / MBH)"
+  },
+  {
+    "id": "NRA",
+    "british": false,
+    "label": "Narrandera Airport (Australia) (YNAR / NRA)"
+  },
+  {
+    "id": "NAA",
+    "british": false,
+    "label": "Narrabri Airport (Australia) (YNBR / NAA)"
+  },
+  {
+    "id": "NTN",
+    "british": false,
+    "label": "Normanton Airport (Australia) (YNTN / NTN)"
+  },
+  {
+    "id": "ZNE",
+    "british": false,
+    "label": "Newman Airport (Australia) (YNWN / ZNE)"
+  },
+  {
+    "id": "OLP",
+    "british": false,
+    "label": "Olympic Dam Airport (Australia) (YOLD / OLP)"
+  },
+  {
+    "id": "PUG",
+    "british": false,
+    "label": "Port Augusta Airport (Australia) (YPAG / PUG)"
+  },
+  {
+    "id": "PMK",
+    "british": false,
+    "label": "Palm Island Airport (Australia) (YPAM / PMK)"
+  },
+  {
+    "id": "PBO",
+    "british": false,
+    "label": "Paraburdoo Airport (Australia) (YPBO / PBO)"
+  },
+  {
+    "id": "CCK",
+    "british": false,
+    "label": "Cocos (Keeling) Islands Airport (Cocos (Keeling) Islands) (YPCC / CCK)"
+  },
+  {
+    "id": "GOV",
+    "british": false,
+    "label": "Gove Airport (Australia) (YPGV / GOV)"
+  },
+  {
+    "id": "PKE",
+    "british": false,
+    "label": "Parkes Airport (Australia) (YPKS / PKE)"
+  },
+  {
+    "id": "PLO",
+    "british": false,
+    "label": "Port Lincoln Airport (Australia) (YPLC / PLO)"
+  },
+  {
+    "id": "EDR",
+    "british": false,
+    "label": "Pormpuraaw Airport (Australia) (YPMP / EDR)"
+  },
+  {
+    "id": "PQQ",
+    "british": false,
+    "label": "Port Macquarie Airport (Australia) (YPMQ / PQQ)"
+  },
+  {
+    "id": "PTJ",
+    "british": false,
+    "label": "Portland Airport (Australia) (YPOD / PTJ)"
+  },
+  {
+    "id": "ULP",
+    "british": false,
+    "label": "Quilpie Airport (Australia) (YQLP / ULP)"
+  },
+  {
+    "id": "RAM",
+    "british": false,
+    "label": "Ramingining Airport (Australia) (YRNG / RAM)"
+  },
+  {
+    "id": "RMA",
+    "british": false,
+    "label": "Roma Airport (Australia) (YROM / RMA)"
+  },
+  {
+    "id": "SGO",
+    "british": false,
+    "label": "St George Airport (Australia) (YSGE / SGO)"
+  },
+  {
+    "id": "MJK",
+    "british": false,
+    "label": "Shark Bay Airport (Australia) (YSHK / MJK)"
+  },
+  {
+    "id": "SBR",
+    "british": false,
+    "label": "Saibai Island Airport (Australia) (YSII / SBR)"
+  },
+  {
+    "id": "SRN",
+    "british": false,
+    "label": "Strahan Airport (Australia) (YSRN / SRN)"
+  },
+  {
+    "id": "XTG",
+    "british": false,
+    "label": "Thargomindah Airport (Australia) (YTGM / XTG)"
+  },
+  {
+    "id": "TCA",
+    "british": false,
+    "label": "Tennant Creek Airport (Australia) (YTNK / TCA)"
+  },
+  {
+    "id": "VCD",
+    "british": false,
+    "label": "Victoria River Downs Airport (Australia) (YVRD / VCD)"
+  },
+  {
+    "id": "SYU",
+    "british": false,
+    "label": "Warraber Island Airport (Australia) (YWBS / SYU)"
+  },
+  {
+    "id": "WNR",
+    "british": false,
+    "label": "Windorah Airport (Australia) (YWDH / WNR)"
+  },
+  {
+    "id": "WYA",
+    "british": false,
+    "label": "Whyalla Airport (Australia) (YWHA / WYA)"
+  },
+  {
+    "id": "WUN",
+    "british": false,
+    "label": "Wiluna Airport (Australia) (YWLU / WUN)"
+  },
+  {
+    "id": "WOL",
+    "british": false,
+    "label": "Wollongong Airport (Australia) (YWOL / WOL)"
+  },
+  {
+    "id": "WIN",
+    "british": false,
+    "label": "Winton Airport (Australia) (YWTN / WIN)"
+  },
+  {
+    "id": "BWT",
+    "british": false,
+    "label": "Wynyard Airport (Australia) (YWYY / BWT)"
+  },
+  {
+    "id": "OKR",
+    "british": false,
+    "label": "Yorke Island Airport (Australia) (YYKI / OKR)"
+  },
+  {
+    "id": "XMY",
+    "british": false,
+    "label": "Yam Island Airport (Australia) (YYMI / XMY)"
+  },
+  {
+    "id": "NAY",
+    "british": false,
+    "label": "Beijing Nanyuan Airport (China) (ZBNY / NAY)"
+  },
+  {
+    "id": "CIF",
+    "british": false,
+    "label": "Chifeng Airport (China) (ZBCF / CIF)"
+  },
+  {
+    "id": "CIH",
+    "british": false,
+    "label": "Changzhi Airport (China) (ZBCZ / CIH)"
+  },
+  {
+    "id": "DAT",
+    "british": false,
+    "label": "Datong Airport (China) (ZBDT / DAT)"
+  },
+  {
+    "id": "HET",
+    "british": false,
+    "label": "Baita International Airport (China) (ZBHH / HET)"
+  },
+  {
+    "id": "BAV",
+    "british": false,
+    "label": "Baotou Airport (China) (ZBOW / BAV)"
+  },
+  {
+    "id": "SJW",
+    "british": false,
+    "label": "Shijiazhuang Daguocun International Airport (China) (ZBSJ / SJW)"
+  },
+  {
+    "id": "TGO",
+    "british": false,
+    "label": "Tongliao Airport (China) (ZBTL / TGO)"
+  },
+  {
+    "id": "HLH",
+    "british": false,
+    "label": "Ulanhot Airport (China) (ZBUL / HLH)"
+  },
+  {
+    "id": "XIL",
+    "british": false,
+    "label": "Xilinhot Airport (China) (ZBXH / XIL)"
+  },
+  {
+    "id": "BHY",
+    "british": false,
+    "label": "Beihai Airport (China) (ZGBH / BHY)"
+  },
+  {
+    "id": "CGD",
+    "british": false,
+    "label": "Changde Airport (China) (ZGCD / CGD)"
+  },
+  {
+    "id": "DYG",
+    "british": false,
+    "label": "Dayong Airport (China) (ZGDY / DYG)"
+  },
+  {
+    "id": "MXZ",
+    "british": false,
+    "label": "Meixian Airport (China) (ZGMX / MXZ)"
+  },
+  {
+    "id": "ZUH",
+    "british": false,
+    "label": "Zhuhai Jinwan Airport (China) (ZGSD / ZUH)"
+  },
+  {
+    "id": "LZH",
+    "british": false,
+    "label": "Liuzhou Bailian Airport (China) (ZGZH / LZH)"
+  },
+  {
+    "id": "ZHA",
+    "british": false,
+    "label": "Zhanjiang Airport (China) (ZGZJ / ZHA)"
+  },
+  {
+    "id": "ENH",
+    "british": false,
+    "label": "Enshi Airport (China) (ZHES / ENH)"
+  },
+  {
+    "id": "NNY",
+    "british": false,
+    "label": "Nanyang Jiangying Airport (China) (ZHNY / NNY)"
+  },
+  {
+    "id": "XFN",
+    "british": false,
+    "label": "Xiangyang Liuji Airport (China) (ZHXF / XFN)"
+  },
+  {
+    "id": "YIH",
+    "british": false,
+    "label": "Yichang Sanxia Airport (China) (ZHYC / YIH)"
+  },
+  {
+    "id": "AKA",
+    "british": false,
+    "label": "Ankang Wulipu Airport (China) (ZLAK / AKA)"
+  },
+  {
+    "id": "GOQ",
+    "british": false,
+    "label": "Golmud Airport (China) (ZLGM / GOQ)"
+  },
+  {
+    "id": "HZG",
+    "british": false,
+    "label": "Hanzhong Chenggu Airport (China) (ZLHZ / HZG)"
+  },
+  {
+    "id": "IQN",
+    "british": false,
+    "label": "Qingyang Airport (China) (ZLQY / IQN)"
+  },
+  {
+    "id": "XNN",
+    "british": false,
+    "label": "Xining Caojiabu Airport (China) (ZLXN / XNN)"
+  },
+  {
+    "id": "ENY",
+    "british": false,
+    "label": "Yan'an Ershilipu Airport (China) (ZLYA / ENY)"
+  },
+  {
+    "id": "UYN",
+    "british": false,
+    "label": "Yulin Yuyang Airport (China) (ZLYL / UYN)"
+  },
+  {
+    "id": "AVK",
+    "british": false,
+    "label": "Arvaikheer Airport (Mongolia) (ZMAH / AVK)"
+  },
+  {
+    "id": "LTI",
+    "british": false,
+    "label": "Altai Airport (Mongolia) (ZMAT / LTI)"
+  },
+  {
+    "id": "BYN",
+    "british": false,
+    "label": "Bayankhongor Airport (Mongolia) (ZMBH / BYN)"
+  },
+  {
+    "id": "DLZ",
+    "british": false,
+    "label": "Dalanzadgad Airport (Mongolia) (ZMDZ / DLZ)"
+  },
+  {
+    "id": "HVD",
+    "british": false,
+    "label": "Khovd Airport (Mongolia) (ZMKD / HVD)"
+  },
+  {
+    "id": "MXV",
+    "british": false,
+    "label": "Mörön Airport (Mongolia) (ZMMN / MXV)"
+  },
+  {
+    "id": "DIG",
+    "british": false,
+    "label": "Diqing Airport (China) (ZPDQ / DIG)"
+  },
+  {
+    "id": "LUM",
+    "british": false,
+    "label": "Mangshi Airport (China) (ZPLX / LUM)"
+  },
+  {
+    "id": "SYM",
+    "british": false,
+    "label": "Pu'er Simao Airport (China) (ZPSM / SYM)"
+  },
+  {
+    "id": "ZAT",
+    "british": false,
+    "label": "Zhaotong Airport (China) (ZPZT / ZAT)"
+  },
+  {
+    "id": "KOW",
+    "british": false,
+    "label": "Ganzhou Airport (China) (ZSGZ / KOW)"
+  },
+  {
+    "id": "JDZ",
+    "british": false,
+    "label": "Jingdezhen Airport (China) (ZSJD / JDZ)"
+  },
+  {
+    "id": "JIU",
+    "british": false,
+    "label": "Jiujiang Lushan Airport (China) (ZSJJ / JIU)"
+  },
+  {
+    "id": "JUZ",
+    "british": false,
+    "label": "Quzhou Airport (China) (ZSJU / JUZ)"
+  },
+  {
+    "id": "LYG",
+    "british": false,
+    "label": "Lianyungang Airport (China) (ZSLG / LYG)"
+  },
+  {
+    "id": "HYN",
+    "british": false,
+    "label": "Huangyan Luqiao Airport (China) (ZSLQ / HYN)"
+  },
+  {
+    "id": "LYI",
+    "british": false,
+    "label": "Shubuling Airport (China) (ZSLY / LYI)"
+  },
+  {
+    "id": "JJN",
+    "british": false,
+    "label": "Quanzhou Jinjiang International Airport (China) (ZSQZ / JJN)"
+  },
+  {
+    "id": "TXN",
+    "british": false,
+    "label": "Tunxi International Airport (China) (ZSTX / TXN)"
+  },
+  {
+    "id": "WEF",
+    "british": false,
+    "label": "Weifang Airport (China) (ZSWF / WEF)"
+  },
+  {
+    "id": "WEH",
+    "british": false,
+    "label": "Weihai Airport (China) (ZSWH / WEH)"
+  },
+  {
+    "id": "WUX",
+    "british": false,
+    "label": "Sunan Shuofang International Airport (China) (ZSWX / WUX)"
+  },
+  {
+    "id": "WUS",
+    "british": false,
+    "label": "Nanping Wuyishan Airport (China) (ZSWY / WUS)"
+  },
+  {
+    "id": "WNZ",
+    "british": false,
+    "label": "Wenzhou Longwan International Airport (China) (ZSWZ / WNZ)"
+  },
+  {
+    "id": "YNZ",
+    "british": false,
+    "label": "Yancheng Airport (China) (ZSYN / YNZ)"
+  },
+  {
+    "id": "YIW",
+    "british": false,
+    "label": "Yiwu Airport (China) (ZSYW / YIW)"
+  },
+  {
+    "id": "HSN",
+    "british": false,
+    "label": "Zhoushan Airport (China) (ZSZS / HSN)"
+  },
+  {
+    "id": "BPX",
+    "british": false,
+    "label": "Qamdo Bangda Airport (China) (ZUBD / BPX)"
+  },
+  {
+    "id": "DAX",
+    "british": false,
+    "label": "Dachuan Airport (China) (ZUDX / DAX)"
+  },
+  {
+    "id": "GYS",
+    "british": false,
+    "label": "Guangyuan Airport (China) (ZUGU / GYS)"
+  },
+  {
+    "id": "LZO",
+    "british": false,
+    "label": "Luzhou Airport (China) (ZULZ / LZO)"
+  },
+  {
+    "id": "MIG",
+    "british": false,
+    "label": "Mianyang Airport (China) (ZUMY / MIG)"
+  },
+  {
+    "id": "NAO",
+    "british": false,
+    "label": "Nanchong Airport (China) (ZUNC / NAO)"
+  },
+  {
+    "id": "LZY",
+    "british": false,
+    "label": "Nyingchi Airport (China) (ZUNZ / LZY)"
+  },
+  {
+    "id": "WXN",
+    "british": false,
+    "label": "Wanxian Airport (China) (ZUWX / WXN)"
+  },
+  {
+    "id": "AKU",
+    "british": false,
+    "label": "Aksu Airport (China) (ZWAK / AKU)"
+  },
+  {
+    "id": "IQM",
+    "british": false,
+    "label": "Qiemo Yudu Airport (China) (ZWCM / IQM)"
+  },
+  {
+    "id": "KCA",
+    "british": false,
+    "label": "Kuqa Airport (China) (ZWKC / KCA)"
+  },
+  {
+    "id": "KRL",
+    "british": false,
+    "label": "Korla Airport (China) (ZWKL / KRL)"
+  },
+  {
+    "id": "KRY",
+    "british": false,
+    "label": "Karamay Airport (China) (ZWKM / KRY)"
+  },
+  {
+    "id": "YIN",
+    "british": false,
+    "label": "Yining Airport (China) (ZWYN / YIN)"
+  },
+  {
+    "id": "HEK",
+    "british": false,
+    "label": "Heihe Airport (China) (ZYHE / HEK)"
+  },
+  {
+    "id": "JMU",
+    "british": false,
+    "label": "Jiamusi Airport (China) (ZYJM / JMU)"
+  },
+  {
+    "id": "JNZ",
+    "british": false,
+    "label": "Jinzhou Airport (China) (ZYJZ / JNZ)"
+  },
+  {
+    "id": "NDG",
+    "british": false,
+    "label": "Qiqihar Sanjiazi Airport (China) (ZYQQ / NDG)"
+  },
+  {
+    "id": "YNJ",
+    "british": false,
+    "label": "Yanji Chaoyangchuan Airport (China) (ZYYJ / YNJ)"
+  },
+  {
+    "id": "WKL",
+    "british": false,
+    "label": "Waikoloa Heliport (United States) (HI07 / WKL)"
+  },
+  {
+    "id": "WME",
+    "british": false,
+    "label": "Mount Keith Airport (Australia) (YMNE / WME)"
+  },
+  {
+    "id": "LRV",
+    "british": false,
+    "label": "Los Roques Airport (Venezuela) (SVRS / LRV)"
+  },
+  {
+    "id": "IOR",
+    "british": false,
+    "label": "Inishmore Aerodrome (Ireland) (EIIM / IOR)"
+  },
+  {
+    "id": "NNR",
+    "british": false,
+    "label": "Connemara Regional Airport (Ireland) (EICA / NNR)"
+  },
+  {
+    "id": "GTI",
+    "british": false,
+    "label": "Rügen Airport (Germany) (EDCG / GTI)"
+  },
+  {
+    "id": "EZV",
+    "british": false,
+    "label": "Berezovo Airport (Russia) (USHB / EZV)"
+  },
+  {
+    "id": "EPSD",
+    "british": false,
+    "label": "Szczecin-Dąbie Airport (Poland) (EPSD)"
+  },
+  {
+    "id": "ORH",
+    "british": false,
+    "label": "Worcester Regional Airport (United States) (KORH / ORH)"
+  },
+  {
+    "id": "AQG",
+    "british": false,
+    "label": "Anqing Tianzhushan Airport (China) (ZSAQ / AQG)"
+  },
+  {
+    "id": "SHP",
+    "british": false,
+    "label": "Shanhaiguan Airport (China) (ZBSH / SHP)"
+  },
+  {
+    "id": "YCU",
+    "british": false,
+    "label": "Yuncheng Guangong Airport (China) (ZBYC / YCU)"
+  },
+  {
+    "id": "ZLAN",
+    "british": false,
+    "label": "Lanzhou City Airport (China) (ZLAN)"
+  },
+  {
+    "id": "JGN",
+    "british": false,
+    "label": "Jiayuguan Airport (China) (ZLJQ / JGN)"
+  },
+  {
+    "id": "DDG",
+    "british": false,
+    "label": "Dandong Airport (China) (ZYDD / DDG)"
+  },
+  {
+    "id": "DSN",
+    "british": false,
+    "label": "Ordos Ejin Horo Airport (China) (ZBDS / DSN)"
+  },
+  {
+    "id": "PZI",
+    "british": false,
+    "label": "Bao'anying Airport (China) (ZUZH / PZI)"
+  },
+  {
+    "id": "PWT",
+    "british": false,
+    "label": "Bremerton National Airport (United States) (KPWT / PWT)"
+  },
+  {
+    "id": "SPW",
+    "british": false,
+    "label": "Spencer Municipal Airport (United States) (KSPW / SPW)"
+  },
+  {
+    "id": "JEF",
+    "british": false,
+    "label": "Jefferson City Memorial Airport (United States) (KJEF / JEF)"
+  },
+  {
+    "id": "EDMT",
+    "british": false,
+    "label": "Tannheim Airfield (Germany) (EDMT)"
+  },
+  {
+    "id": "UNT",
+    "british": true,
+    "label": "Unst Airport (United Kingdom) (EGPW / UNT)"
+  },
+  {
+    "id": "WA19",
+    "british": false,
+    "label": "Berkley Structures Heliport (Indonesia) (WA19)"
+  },
+  {
+    "id": "PVC",
+    "british": false,
+    "label": "Provincetown Municipal Airport (United States) (KPVC / PVC)"
+  },
+  {
+    "id": "WBAK",
+    "british": false,
+    "label": "Anduki Airport (Brunei) (WBAK)"
+  },
+  {
+    "id": "SBH",
+    "british": false,
+    "label": "Gustaf III Airport (France) (TFFJ / SBH)"
+  },
+  {
+    "id": "KMW",
+    "british": false,
+    "label": "Kostroma Sokerkino Airport (Russia) (UUBA / KMW)"
+  },
+  {
+    "id": "SUI",
+    "british": false,
+    "label": "Sukhumi Dranda Airport (Georgia) (UGSS / SUI)"
+  },
+  {
+    "id": "TBW",
+    "british": false,
+    "label": "Donskoye Airport (Russia) (UUOT / TBW)"
+  },
+  {
+    "id": "OBN",
+    "british": true,
+    "label": "Oban Airport (United Kingdom) (EGEO / OBN)"
+  },
+  {
+    "id": "ERM",
+    "british": false,
+    "label": "Erechim Airport (Brazil) (SSER / ERM)"
+  },
+  {
+    "id": "LSGP",
+    "british": false,
+    "label": "La Côte Airport (Switzerland) (LSGP)"
+  },
+  {
+    "id": "CVF",
+    "british": false,
+    "label": "Courchevel Airport (France) (LFLJ / CVF)"
+  },
+  {
+    "id": "FUL",
+    "british": false,
+    "label": "Fullerton Municipal Airport (United States) (KFUL / FUL)"
+  },
+  {
+    "id": "USA",
+    "british": false,
+    "label": "Concord-Padgett Regional Airport (United States) (KJQF / USA)"
+  },
+  {
+    "id": "EGHN",
+    "british": true,
+    "label": "Isle of Wight / Sandown Airport (United Kingdom) (EGHN)"
+  },
+  {
+    "id": "NVI",
+    "british": false,
+    "label": "Navoi Airport (Uzbekistan) (UTSA / NVI)"
+  },
+  {
+    "id": "LFCD",
+    "british": false,
+    "label": "Andernos Les Bains Airport (France) (LFCD)"
+  },
+  {
+    "id": "EDOI",
+    "british": false,
+    "label": "Bienenfarm Airport (Germany) (EDOI)"
+  },
+  {
+    "id": "QSF",
+    "british": false,
+    "label": "Ain Arnat Airport (Algeria) (DAAS / QSF)"
+  },
+  {
+    "id": "LRH",
+    "british": false,
+    "label": "La Rochelle-Île de Ré Airport (France) (LFBH / LRH)"
+  },
+  {
+    "id": "SUN",
+    "british": false,
+    "label": "Friedman Memorial Airport (United States) (KSUN / SUN)"
+  },
+  {
+    "id": "LSGY",
+    "british": false,
+    "label": "Yverdon-les-Bains Airport (Switzerland) (LSGY)"
+  },
+  {
+    "id": "EPBA",
+    "british": false,
+    "label": "Bielsko Biala Airport (Poland) (EPBA)"
+  },
+  {
+    "id": "MCW",
+    "british": false,
+    "label": "Mason City Municipal Airport (United States) (KMCW / MCW)"
+  },
+  {
+    "id": "AZA",
+    "british": false,
+    "label": "Phoenix-Mesa-Gateway Airport (United States) (KIWA / AZA)"
+  },
+  {
+    "id": "XAU",
+    "british": false,
+    "label": "Saúl Airport (French Guiana) (SOOS / XAU)"
+  },
+  {
+    "id": "NZTL",
+    "british": false,
+    "label": "Tekapo Aerodrome (New Zealand) (NZTL)"
+  },
+  {
+    "id": "LOGO",
+    "british": false,
+    "label": "Niederoeblarn Airport (Austria) (LOGO)"
+  },
+  {
+    "id": "LOAV",
+    "british": false,
+    "label": "Vöslau Airport (Austria) (LOAV)"
+  },
+  {
+    "id": "EDHE",
+    "british": false,
+    "label": "Uetersen/Heist Airport (Germany) (EDHE)"
+  },
+  {
+    "id": "AKP",
+    "british": false,
+    "label": "Anaktuvuk Pass Airport (United States) (PAKP / AKP)"
+  },
+  {
+    "id": "ANV",
+    "british": false,
+    "label": "Anvik Airport (United States) (PANV / ANV)"
+  },
+  {
+    "id": "ATK",
+    "british": false,
+    "label": "Atqasuk Edward Burnell Sr Memorial Airport (United States) (PATQ / ATK)"
+  },
+  {
+    "id": "GAM",
+    "british": false,
+    "label": "Gambell Airport (United States) (PAGM / GAM)"
+  },
+  {
+    "id": "HPB",
+    "british": false,
+    "label": "Hooper Bay Airport (United States) (PAHP / HPB)"
+  },
+  {
+    "id": "KAL",
+    "british": false,
+    "label": "Kaltag Airport (United States) (PAKV / KAL)"
+  },
+  {
+    "id": "KSM",
+    "british": false,
+    "label": "St Mary's Airport (United States) (PASM / KSM)"
+  },
+  {
+    "id": "KVL",
+    "british": false,
+    "label": "Kivalina Airport (United States) (PAVL / KVL)"
+  },
+  {
+    "id": "MYU",
+    "british": false,
+    "label": "Mekoryuk Airport (United States) (PAMY / MYU)"
+  },
+  {
+    "id": "RBY",
+    "british": false,
+    "label": "Ruby Airport (United States) (PARY / RBY)"
+  },
+  {
+    "id": "SHH",
+    "british": false,
+    "label": "Shishmaref Airport (United States) (PASH / SHH)"
+  },
+  {
+    "id": "SVA",
+    "british": false,
+    "label": "Savoonga Airport (United States) (PASA / SVA)"
+  },
+  {
+    "id": "WTK",
+    "british": false,
+    "label": "Noatak Airport (United States) (PAWN / WTK)"
+  },
+  {
+    "id": "OMC",
+    "british": false,
+    "label": "Ormoc Airport (Philippines) (RPVO / OMC)"
+  },
+  {
+    "id": "YPX",
+    "british": false,
+    "label": "Puvirnituq Airport (Canada) (CYPX / YPX)"
+  },
+  {
+    "id": "YTQ",
+    "british": false,
+    "label": "Tasiujaq Airport (Canada) (CYTQ / YTQ)"
+  },
+  {
+    "id": "ARC",
+    "british": false,
+    "label": "Arctic Village Airport (United States) (PARC / ARC)"
+  },
+  {
+    "id": "QOW",
+    "british": false,
+    "label": "Sam Mbakwe International Airport (Nigeria) (DNIM / QOW)"
+  },
+  {
+    "id": "FON",
+    "british": false,
+    "label": "Arenal Airport (Costa Rica) (MRAN / FON)"
+  },
+  {
+    "id": "TMU",
+    "british": false,
+    "label": "Tambor Airport (Costa Rica) (MRTR / TMU)"
+  },
+  {
+    "id": "CYZ",
+    "british": false,
+    "label": "Cauayan Airport (Philippines) (RPUY / CYZ)"
+  },
+  {
+    "id": "KVK",
+    "british": false,
+    "label": "Kirovsk-Apatity Airport (Russia) (ULMK / KVK)"
+  },
+  {
+    "id": "GVR",
+    "british": false,
+    "label": "Coronel Altino Machado de Oliveira Airport (Brazil) (SBGV / GVR)"
+  },
+  {
+    "id": "KPC",
+    "british": false,
+    "label": "Port Clarence Coast Guard Station (United States) (PAPC / KPC)"
+  },
+  {
+    "id": "PJA",
+    "british": false,
+    "label": "Pajala Airport (Sweden) (ESUP / PJA)"
+  },
+  {
+    "id": "QBC",
+    "british": false,
+    "label": "Bella Coola Airport (Canada) (CYBD / QBC)"
+  },
+  {
+    "id": "HGR",
+    "british": false,
+    "label": "Hagerstown Regional Richard A Henson Field (United States) (KHGR / HGR)"
+  },
+  {
+    "id": "ACR",
+    "british": false,
+    "label": "Araracuara Airport (Colombia) (SKAC / ACR)"
+  },
+  {
+    "id": "GOP",
+    "british": false,
+    "label": "Gorakhpur Airport (India) (VEGK / GOP)"
+  },
+  {
+    "id": "SDP",
+    "british": false,
+    "label": "Sand Point Airport (United States) (PASD / SDP)"
+  },
+  {
+    "id": "HMI",
+    "british": false,
+    "label": "Hami Airport (China) (ZWHM / HMI)"
+  },
+  {
+    "id": "WUZ",
+    "british": false,
+    "label": "Wuzhou Changzhoudao Airport (China) (ZGWZ / WUZ)"
+  },
+  {
+    "id": "TBH",
+    "british": false,
+    "label": "Tugdan Airport (Philippines) (RPVU / TBH)"
+  },
+  {
+    "id": "ACP",
+    "british": false,
+    "label": "Sahand Airport (Iran) (OITM / ACP)"
+  },
+  {
+    "id": "GBT",
+    "british": false,
+    "label": "Gorgan Airport (Iran) (OING / GBT)"
+  },
+  {
+    "id": "IIL",
+    "british": false,
+    "label": "Ilam Airport (Iran) (OICI / IIL)"
+  },
+  {
+    "id": "PFQ",
+    "british": false,
+    "label": "Parsabade Moghan Airport (Iran) (OITP / PFQ)"
+  },
+  {
+    "id": "SPCH",
+    "british": false,
+    "label": "Tocache Airport (Peru) (SPCH)"
+  },
+  {
+    "id": "TCG",
+    "british": false,
+    "label": "Tacheng Airport (China) (ZWTC / TCG)"
+  },
+  {
+    "id": "MQM",
+    "british": false,
+    "label": "Mardin Airport (Turkey) (LTCR / MQM)"
+  },
+  {
+    "id": "AFS",
+    "british": false,
+    "label": "Sugraly Airport (Uzbekistan) (UTSN / AFS)"
+  },
+  {
+    "id": "DRG",
+    "british": false,
+    "label": "Deering Airport (United States) (PADE / DRG)"
+  },
+  {
+    "id": "LEN",
+    "british": false,
+    "label": "Leon Airport (Spain) (LELN / LEN)"
+  },
+  {
+    "id": "RGS",
+    "british": false,
+    "label": "Burgos Airport (Spain) (LEBG / RGS)"
+  },
+  {
+    "id": "EGM",
+    "british": false,
+    "label": "Sege Airport (Solomon Islands) (AGGS / EGM)"
+  },
+  {
+    "id": "CQD",
+    "british": false,
+    "label": "Shahrekord Airport (Iran) (OIFS / CQD)"
+  },
+  {
+    "id": "DHM",
+    "british": false,
+    "label": "Kangra Airport (India) (VIGG / DHM)"
+  },
+  {
+    "id": "NDC",
+    "british": false,
+    "label": "Nanded Airport (India) (VAND / NDC)"
+  },
+  {
+    "id": "SLV",
+    "british": false,
+    "label": "Shimla Airport (India) (VISM / SLV)"
+  },
+  {
+    "id": "IGG",
+    "british": false,
+    "label": "Igiugig Airport (United States) (PAIG / IGG)"
+  },
+  {
+    "id": "KNW",
+    "british": false,
+    "label": "New Stuyahok Airport (United States) (PANW / KNW)"
+  },
+  {
+    "id": "KVC",
+    "british": false,
+    "label": "King Cove Airport (United States) (PAVC / KVC)"
+  },
+  {
+    "id": "PTH",
+    "british": false,
+    "label": "Port Heiden Airport (United States) (PAPH / PTH)"
+  },
+  {
+    "id": "TOG",
+    "british": false,
+    "label": "Togiak Airport (United States) (PATG / TOG)"
+  },
+  {
+    "id": "EGN",
+    "british": false,
+    "label": "Geneina Airport (Sudan) (HSGN / EGN)"
+  },
+  {
+    "id": "LKH",
+    "british": false,
+    "label": "Long Akah Airport (Malaysia) (WBGL / LKH)"
+  },
+  {
+    "id": "WLH",
+    "british": false,
+    "label": "Walaha Airport (Vanuatu) (NVSW / WLH)"
+  },
+  {
+    "id": "CHG",
+    "british": false,
+    "label": "Chaoyang Airport (China) (ZYCY / CHG)"
+  },
+  {
+    "id": "UAS",
+    "british": false,
+    "label": "Buffalo Spring (Kenya) (HKSB / UAS)"
+  },
+  {
+    "id": "BHG",
+    "british": false,
+    "label": "Brus Laguna Airport (Honduras) (MHBL / BHG)"
+  },
+  {
+    "id": "YVB",
+    "british": false,
+    "label": "Bonaventure Airport (Canada) (CYVB / YVB)"
+  },
+  {
+    "id": "SKT",
+    "british": false,
+    "label": "Sialkot Airport (Pakistan) (OPST / SKT)"
+  },
+  {
+    "id": "PDP",
+    "british": false,
+    "label": "Capitan Corbeta CA Curbelo International Airport (Uruguay) (SULS / PDP)"
+  },
+  {
+    "id": "WVB",
+    "british": false,
+    "label": "Walvis Bay Airport (Namibia) (FYWB / WVB)"
+  },
+  {
+    "id": "MPA",
+    "british": false,
+    "label": "Katima Mulilo Airport (Namibia) (FYKM / MPA)"
+  },
+  {
+    "id": "AOE",
+    "british": false,
+    "label": "Anadolu Airport (Turkey) (LTBY / AOE)"
+  },
+  {
+    "id": "CKZ",
+    "british": false,
+    "label": "Çanakkale Airport (Turkey) (LTBH / CKZ)"
+  },
+  {
+    "id": "MSR",
+    "british": false,
+    "label": "Muş Airport (Turkey) (LTCK / MSR)"
+  },
+  {
+    "id": "NOP",
+    "british": false,
+    "label": "Sinop Airport (Turkey) (LTCM / NOP)"
+  },
+  {
+    "id": "TEQ",
+    "british": false,
+    "label": "Tekirdağ Çorlu Airport (Turkey) (LTBU / TEQ)"
+  },
+  {
+    "id": "YEI",
+    "british": false,
+    "label": "Bursa Yenişehir Airport (Turkey) (LTBR / YEI)"
+  },
+  {
+    "id": "LSS",
+    "british": false,
+    "label": "Terre-de-Haut Airport (Guadeloupe) (TFFS / LSS)"
+  },
+  {
+    "id": "KMV",
+    "british": false,
+    "label": "Kalay Airport (Myanmar) (VYKL / KMV)"
+  },
+  {
+    "id": "VQS",
+    "british": false,
+    "label": "Vieques Airport (Puerto Rico) (TJCG / VQS)"
+  },
+  {
+    "id": "YIF",
+    "british": false,
+    "label": "St Augustin Airport (Canada) (CYIF / YIF)"
+  },
+  {
+    "id": "HDM",
+    "british": false,
+    "label": "Hamadan Airport (Iran) (OIHH / HDM)"
+  },
+  {
+    "id": "MRQ",
+    "british": false,
+    "label": "Marinduque Airport (Philippines) (RPUW / MRQ)"
+  },
+  {
+    "id": "GFN",
+    "british": false,
+    "label": "Grafton Airport (Australia) (YGFN / GFN)"
+  },
+  {
+    "id": "OAG",
+    "british": false,
+    "label": "Orange Airport (Australia) (YORG / OAG)"
+  },
+  {
+    "id": "TRO",
+    "british": false,
+    "label": "Taree Airport (Australia) (YTRE / TRO)"
+  },
+  {
+    "id": "COQ",
+    "british": false,
+    "label": "Choibalsan Airport (Mongolia) (ZMCD / COQ)"
+  },
+  {
+    "id": "HOH",
+    "british": false,
+    "label": "Hohenems-Dornbirn Airport (Austria) (LOIH / HOH)"
+  },
+  {
+    "id": "EDWM",
+    "british": false,
+    "label": "Weser-Wümme Airport (Germany) (EDWM)"
+  },
+  {
+    "id": "LOAG",
+    "british": false,
+    "label": "Krems Airport (Austria) (LOAG)"
+  },
+  {
+    "id": "ESC",
+    "british": false,
+    "label": "Delta County Airport (United States) (KESC / ESC)"
+  },
+  {
+    "id": "YAK",
+    "british": false,
+    "label": "Yakutat Airport (United States) (PAYA / YAK)"
+  },
+  {
+    "id": "GUL",
+    "british": false,
+    "label": "Goulburn Airport (Australia) (YGLB / GUL)"
+  },
+  {
+    "id": "CES",
+    "british": false,
+    "label": "Cessnock Airport (Australia) (YCNK / CES)"
+  },
+  {
+    "id": "NSO",
+    "british": false,
+    "label": "Scone Airport (Australia) (YSCO / NSO)"
+  },
+  {
+    "id": "DGE",
+    "british": false,
+    "label": "Mudgee Airport (Australia) (YMDG / DGE)"
+  },
+  {
+    "id": "MTL",
+    "british": false,
+    "label": "Maitland Airport (Australia) (YMND / MTL)"
+  },
+  {
+    "id": "CPX",
+    "british": false,
+    "label": "Benjamin Rivera Noriega Airport (Puerto Rico) (TJCP / CPX)"
+  },
+  {
+    "id": "LSTA",
+    "british": false,
+    "label": "Raron Airport (Switzerland) (LSTA)"
+  },
+  {
+    "id": "UMMB",
+    "british": false,
+    "label": "Borovaya Airfield (Belarus) (UMMB)"
+  },
+  {
+    "id": "LSPA",
+    "british": false,
+    "label": "Amlikon Glider Airport (Switzerland) (LSPA)"
+  },
+  {
+    "id": "LSZT",
+    "british": false,
+    "label": "Lommis Airfield (Switzerland) (LSZT)"
+  },
+  {
+    "id": "MWA",
+    "british": false,
+    "label": "Williamson County Regional Airport (United States) (KMWA / MWA)"
+  },
+  {
+    "id": "KBMQ",
+    "british": false,
+    "label": "Burnet Municipal Kate Craddock Field (Kenya) (KBMQ)"
+  },
+  {
+    "id": "OCN",
+    "british": false,
+    "label": "Oceanside Municipal Airport (Australia) (KOKB / OCN)"
+  },
+  {
+    "id": "EDAS",
+    "british": false,
+    "label": "Flugplatz Finsterwalde/Heinrichsruh (Germany) (EDAS)"
+  },
+  {
+    "id": "KIK",
+    "british": false,
+    "label": "Kirkuk Air Base (Iraq) (ORKK / KIK)"
+  },
+  {
+    "id": "XJD",
+    "british": false,
+    "label": "Al Udeid Air Base (Qatar) (OTBH / XJD)"
+  },
+  {
+    "id": "GBZ",
+    "british": false,
+    "label": "Great Barrier Aerodrome (New Zealand) (NZGB / GBZ)"
+  },
+  {
+    "id": "IMT",
+    "british": false,
+    "label": "Ford Airport (United States) (KIMT / IMT)"
+  },
+  {
+    "id": "KMQT",
+    "british": false,
+    "label": "Marquette Airport (United States) (KMQT)"
+  },
+  {
+    "id": "AET",
+    "british": false,
+    "label": "Allakaket Airport (United States) (PFAL / AET)"
+  },
+  {
+    "id": "EDLD",
+    "british": false,
+    "label": "Dinslaken/Schwarze Heide Airport (Germany) (EDLD)"
+  },
+  {
+    "id": "EDVI",
+    "british": false,
+    "label": "Höxter-Holzminden Airport (Germany) (EDVI)"
+  },
+  {
+    "id": "RJAN",
+    "british": false,
+    "label": "Niijima Airport (Japan) (RJAN)"
+  },
+  {
+    "id": "MGC",
+    "british": false,
+    "label": "Michigan City Municipal Airport (United States) (KMGC / MGC)"
+  },
+  {
+    "id": "SWD",
+    "british": false,
+    "label": "Seward Airport (United States) (PAWD / SWD)"
+  },
+  {
+    "id": "GRM",
+    "british": false,
+    "label": "Grand Marais Cook County Airport (United States) (KCKC / GRM)"
+  },
+  {
+    "id": "AUW",
+    "british": false,
+    "label": "Wausau Downtown Airport (United States) (KAUW / AUW)"
+  },
+  {
+    "id": "EKKL",
+    "british": false,
+    "label": "Kalundborg Airport (Denmark) (EKKL)"
+  },
+  {
+    "id": "MYP",
+    "british": false,
+    "label": "Mary Airport (Turkmenistan) (UTAM / MYP)"
+  },
+  {
+    "id": "YBUU",
+    "british": false,
+    "label": "Bungle Bungle Airport (Australia) (YBUU)"
+  },
+  {
+    "id": "LKSZ",
+    "british": false,
+    "label": "Sazená Airport (Czech Republic) (LKSZ)"
+  },
+  {
+    "id": "FVSV",
+    "british": false,
+    "label": "Spray View Airport (Zimbabwe) (FVSV)"
+  },
+  {
+    "id": "MVA",
+    "british": false,
+    "label": "Reykjahlíð Airport (Iceland) (BIRL / MVA)"
+  },
+  {
+    "id": "QSA",
+    "british": false,
+    "label": "Sabadell Airport (Spain) (LELL / QSA)"
+  },
+  {
+    "id": "WSY",
+    "british": false,
+    "label": "Whitsunday Island Airport (Australia) (YWHI / WSY)"
+  },
+  {
+    "id": "MIE",
+    "british": false,
+    "label": "Delaware County Johnson Field (United States) (KMIE / MIE)"
+  },
+  {
+    "id": "LAF",
+    "british": false,
+    "label": "Purdue University Airport (United States) (KLAF / LAF)"
+  },
+  {
+    "id": "KGEO",
+    "british": false,
+    "label": "Brown County Airport (United States) (KGEO)"
+  },
+  {
+    "id": "VGT",
+    "british": false,
+    "label": "North Las Vegas Airport (United States) (KVGT / VGT)"
+  },
+  {
+    "id": "ENW",
+    "british": false,
+    "label": "Kenosha Regional Airport (United States) (KENW / ENW)"
+  },
+  {
+    "id": "MTJ",
+    "british": false,
+    "label": "Montrose Regional Airport (United States) (KMTJ / MTJ)"
+  },
+  {
+    "id": "RIW",
+    "british": false,
+    "label": "Riverton Regional Airport (United States) (KRIW / RIW)"
+  },
+  {
+    "id": "PDT",
+    "british": false,
+    "label": "Eastern Oregon Regional At Pendleton Airport (United States) (KPDT / PDT)"
+  },
+  {
+    "id": "LYM",
+    "british": true,
+    "label": "Lympne Airport (United Kingdom) (EGMK / LYM)"
+  },
+  {
+    "id": "PKH",
+    "british": false,
+    "label": "Porto Cheli Airport (Greece) (LGHL / PKH)"
+  },
+  {
+    "id": "LOWZ",
+    "british": false,
+    "label": "Zell Am See Airport (Austria) (LOWZ)"
+  },
+  {
+    "id": "YAMB",
+    "british": false,
+    "label": "RAAF Base Amberley (Australia) (YAMB)"
+  },
+  {
+    "id": "KTR",
+    "british": false,
+    "label": "Tindal Airport (Australia) (YPTN / KTR)"
+  },
+  {
+    "id": "YLVT",
+    "british": false,
+    "label": "RAAF Williams, Laverton Base (Australia) (YLVT)"
+  },
+  {
+    "id": "NOA",
+    "british": false,
+    "label": "Nowra Airport (Australia) (YSNW / NOA)"
+  },
+  {
+    "id": "UCK",
+    "british": false,
+    "label": "Lutsk Airport (Ukraine) (UKLC / UCK)"
+  },
+  {
+    "id": "CEJ",
+    "british": false,
+    "label": "Chernihiv Shestovitsa Airport (Ukraine) (UKRR / CEJ)"
+  },
+  {
+    "id": "UKLT",
+    "british": false,
+    "label": "Ternopil International Airport (Ukraine) (UKLT)"
+  },
+  {
+    "id": "BQT",
+    "british": false,
+    "label": "Brest Airport (Belarus) (UMBB / BQT)"
+  },
+  {
+    "id": "OSH",
+    "british": false,
+    "label": "Wittman Regional Airport (United States) (KOSH / OSH)"
+  },
+  {
+    "id": "EDXP",
+    "british": false,
+    "label": "Harle Airport (Germany) (EDXP)"
+  },
+  {
+    "id": "AGE",
+    "british": false,
+    "label": "Wangerooge Airport (Germany) (EDWG / AGE)"
+  },
+  {
+    "id": "YPEA",
+    "british": false,
+    "label": "RAAF Base Pearce (Australia) (YPEA)"
+  },
+  {
+    "id": "BXG",
+    "british": false,
+    "label": "Bendigo Airport (Australia) (YBDG / BXG)"
+  },
+  {
+    "id": "EAT",
+    "british": false,
+    "label": "Pangborn Memorial Airport (United States) (KEAT / EAT)"
+  },
+  {
+    "id": "ARE",
+    "british": false,
+    "label": "Antonio Nery Juarbe Pol Airport (Puerto Rico) (TJAB / ARE)"
+  },
+  {
+    "id": "RIN",
+    "british": false,
+    "label": "Ringi Cove Airport (Solomon Islands) (AGRC / RIN)"
+  },
+  {
+    "id": "KCK",
+    "british": false,
+    "label": "Kirensk Airport (Russia) (UIKK / KCK)"
+  },
+  {
+    "id": "UKX",
+    "british": false,
+    "label": "Ust-Kut Airport (Russia) (UITT / UKX)"
+  },
+  {
+    "id": "RMT",
+    "british": false,
+    "label": "Rimatara Airport (French Polynesia) (NTAM / RMT)"
+  },
+  {
+    "id": "LSPN",
+    "british": false,
+    "label": "Triengen Airport (Switzerland) (LSPN)"
+  },
+  {
+    "id": "QLS",
+    "british": false,
+    "label": "Lausanne-Blécherette Airport (Switzerland) (LSGL / QLS)"
+  },
+  {
+    "id": "LSZK",
+    "british": false,
+    "label": "Speck-Fehraltorf Airport (Switzerland) (LSZK)"
+  },
+  {
+    "id": "ZJI",
+    "british": false,
+    "label": "Locarno Airport (Switzerland) (LSZL / ZJI)"
+  },
+  {
+    "id": "QNC",
+    "british": false,
+    "label": "Neuchatel Airport (Switzerland) (LSGN / QNC)"
+  },
+  {
+    "id": "TGK",
+    "british": false,
+    "label": "Taganrog Yuzhny Airport (Russia) (URRT / TGK)"
+  },
+  {
+    "id": "GDZ",
+    "british": false,
+    "label": "Gelendzhik Airport (Russia) (URKG / GDZ)"
+  },
+  {
+    "id": "ZIA",
+    "british": false,
+    "label": "Zhukovsky International Airport (Russia) (UUBW / ZIA)"
+  },
+  {
+    "id": "UIIR",
+    "british": false,
+    "label": "Irkutsk Northwest Airport (Russia) (UIIR)"
+  },
+  {
+    "id": "UHHT",
+    "british": false,
+    "label": "Khabarovsk Airport (Russia) (UHHT)"
+  },
+  {
+    "id": "UHKD",
+    "british": false,
+    "label": "Dzemgi Airport (Russia) (UHKD)"
+  },
+  {
+    "id": "UIIB",
+    "british": false,
+    "label": "Belaya Air Base (Russia) (UIIB)"
+  },
+  {
+    "id": "IAR",
+    "british": false,
+    "label": "Tunoshna Airport (Russia) (UUDL / IAR)"
+  },
+  {
+    "id": "OHE",
+    "british": false,
+    "label": "Gu-Lian Airport (China) (ZYMH / OHE)"
+  },
+  {
+    "id": "JNG",
+    "british": false,
+    "label": "Jining Qufu Airport (China) (ZLJN / JNG)"
+  },
+  {
+    "id": "DRK",
+    "british": false,
+    "label": "Drake Bay Airport (Costa Rica) (MRDK / DRK)"
+  },
+  {
+    "id": "AAT",
+    "british": false,
+    "label": "Altay Air Base (China) (ZWAT / AAT)"
+  },
+  {
+    "id": "TZL",
+    "british": false,
+    "label": "Tuzla International Airport (Bosnia and Herzegovina) (LQTZ / TZL)"
+  },
+  {
+    "id": "FWH",
+    "british": false,
+    "label": "NAS Fort Worth JRB/Carswell Field (United States) (KNFW / FWH)"
+  },
+  {
+    "id": "NYT",
+    "british": false,
+    "label": "Naypyidaw Airport (Burma) (VYEL / NYT)"
+  },
+  {
+    "id": "VYXG",
+    "british": false,
+    "label": "Kyaukhtu South Airport (Burma) (VYXG)"
+  },
+  {
+    "id": "ENJA",
+    "british": false,
+    "label": "Jan Mayensfield (Norway) (ENJA)"
+  },
+  {
+    "id": "VBP",
+    "british": false,
+    "label": "Bokpyinn Airport (Burma) (VYBP / VBP)"
+  },
+  {
+    "id": "NZH",
+    "british": false,
+    "label": "Manzhouli Xijiao Airport (China) (ZBMZ / NZH)"
+  },
+  {
+    "id": "WUA",
+    "british": false,
+    "label": "Wuhai Airport (China) (ZBUH / WUA)"
+  },
+  {
+    "id": "GYY",
+    "british": false,
+    "label": "Gary Chicago International Airport (United States) (KGYY / GYY)"
+  },
+  {
+    "id": "BRD",
+    "british": false,
+    "label": "Brainerd Lakes Regional Airport (United States) (KBRD / BRD)"
+  },
+  {
+    "id": "LWB",
+    "british": false,
+    "label": "Greenbrier Valley Airport (United States) (KLWB / LWB)"
+  },
+  {
+    "id": "PGV",
+    "british": false,
+    "label": "Pitt Greenville Airport (United States) (KPGV / PGV)"
+  },
+  {
+    "id": "CYF",
+    "british": false,
+    "label": "Chefornak Airport (United States) (PACK / CYF)"
+  },
+  {
+    "id": "OXR",
+    "british": false,
+    "label": "Oxnard Airport (United States) (KOXR / OXR)"
+  },
+  {
+    "id": "BKG",
+    "british": false,
+    "label": "Branson Airport (United States) (KBBG / BKG)"
+  },
+  {
+    "id": "TEN",
+    "british": false,
+    "label": "Tongren Fenghuang Airport (China) (ZUTR / TEN)"
+  },
+  {
+    "id": "JGS",
+    "british": false,
+    "label": "Jinggangshan Airport (China) (ZSJA / JGS)"
+  },
+  {
+    "id": "NIU",
+    "british": false,
+    "label": "Naiu Airport (French Polynesia) (NTKN / NIU)"
+  },
+  {
+    "id": "SCH",
+    "british": false,
+    "label": "Schenectady County Airport (United States) (KSCH / SCH)"
+  },
+  {
+    "id": "NBC",
+    "british": false,
+    "label": "Begishevo Airport (Russia) (UWKE / NBC)"
+  },
+  {
+    "id": "QRW",
+    "british": false,
+    "label": "Warri Airport (Nigeria) (DNSU / QRW)"
+  },
+  {
+    "id": "EHVK",
+    "british": false,
+    "label": "Volkel Air Base (Netherlands) (EHVK)"
+  },
+  {
+    "id": "IAO",
+    "british": false,
+    "label": "Siargao Airport (Philippines) (RPNS / IAO)"
+  },
+  {
+    "id": "LGO",
+    "british": false,
+    "label": "Langeoog Airport (Germany) (EDWL / LGO)"
+  },
+  {
+    "id": "LSZP",
+    "british": false,
+    "label": "Biel-Kappelen Airport (Switzerland) (LSZP)"
+  },
+  {
+    "id": "NLP",
+    "british": false,
+    "label": "Nelspruit Airport (South Africa) (FANS / NLP)"
+  },
+  {
+    "id": "CKC",
+    "british": false,
+    "label": "Cherkasy International Airport (Ukraine) (UKKE / CKC)"
+  },
+  {
+    "id": "UST",
+    "british": false,
+    "label": "Northeast Florida Regional Airport (United States) (KSGJ / UST)"
+  },
+  {
+    "id": "NLV",
+    "british": false,
+    "label": "Mykolaiv International Airport (Ukraine) (UKON / NLV)"
+  },
+  {
+    "id": "RHP",
+    "british": false,
+    "label": "Ramechhap Airport (Nepal) (VNRC / RHP)"
+  },
+  {
+    "id": "STS",
+    "british": false,
+    "label": "Charles M. Schulz Sonoma County Airport (United States) (KSTS / STS)"
+  },
+  {
+    "id": "ISM",
+    "british": false,
+    "label": "Kissimmee Gateway Airport (United States) (KISM / ISM)"
+  },
+  {
+    "id": "LCQ",
+    "british": false,
+    "label": "Lake City Gateway Airport (United States) (KLCQ / LCQ)"
+  },
+  {
+    "id": "KDED",
+    "british": false,
+    "label": "Deland Municipal Sidney H Taylor Field (United States) (KDED)"
+  },
+  {
+    "id": "7FL4",
+    "british": false,
+    "label": "Haller Airpark (United States) (7FL4)"
+  },
+  {
+    "id": "SLPA",
+    "british": false,
+    "label": "Palmar Airport (Peru) (SLPA)"
+  },
+  {
+    "id": "LGU",
+    "british": false,
+    "label": "Logan-Cache Airport (United States) (KLGU / LGU)"
+  },
+  {
+    "id": "BMC",
+    "british": false,
+    "label": "Brigham City Regional Airport (United States) (KBMC / BMC)"
+  },
+  {
+    "id": "KMLD",
+    "british": false,
+    "label": "Malad City Airport (United States) (KMLD)"
+  },
+  {
+    "id": "ASE",
+    "british": false,
+    "label": "Aspen-Pitkin Co/Sardy Field (United States) (KASE / ASE)"
+  },
+  {
+    "id": "ULV",
+    "british": false,
+    "label": "Ulyanovsk Baratayevka Airport (Russia) (UWLL / ULV)"
+  },
+  {
+    "id": "ERV",
+    "british": false,
+    "label": "Kerrville Municipal Louis Schreiner Field (United States) (KERV / ERV)"
+  },
+  {
+    "id": "LSZF",
+    "british": false,
+    "label": "Birrfeld Airport (Switzerland) (LSZF)"
+  },
+  {
+    "id": "GED",
+    "british": false,
+    "label": "Sussex County Airport (United States) (KGED / GED)"
+  },
+  {
+    "id": "ZSW",
+    "british": false,
+    "label": "Prince Rupert/Seal Cove Seaplane Base (Canada) (CZSW / ZSW)"
+  },
+  {
+    "id": "GBD",
+    "british": false,
+    "label": "Great Bend Municipal Airport (United States) (KGBD / GBD)"
+  },
+  {
+    "id": "HYS",
+    "british": false,
+    "label": "Hays Regional Airport (United States) (KHYS / HYS)"
+  },
+  {
+    "id": "SUS",
+    "british": false,
+    "label": "Spirit of St Louis Airport (United States) (KSUS / SUS)"
+  },
+  {
+    "id": "LYU",
+    "british": false,
+    "label": "Ely Municipal Airport (United States) (KELO / LYU)"
+  },
+  {
+    "id": "GPZ",
+    "british": false,
+    "label": "Grand Rapids Itasca Co-Gordon Newstrom field (United States) (KGPZ / GPZ)"
+  },
+  {
+    "id": "TVF",
+    "british": false,
+    "label": "Thief River Falls Regional Airport (United States) (KTVF / TVF)"
+  },
+  {
+    "id": "EGV",
+    "british": false,
+    "label": "Eagle River Union Airport (United States) (KEGV / EGV)"
+  },
+  {
+    "id": "ARV",
+    "british": false,
+    "label": "Lakeland-Noble F. Lee Memorial field (United States) (KARV / ARV)"
+  },
+  {
+    "id": "KIKV",
+    "british": false,
+    "label": "Ankeny Regional Airport (United States) (KIKV)"
+  },
+  {
+    "id": "YBV",
+    "british": false,
+    "label": "Berens River Airport (Canada) (CYBV / YBV)"
+  },
+  {
+    "id": "KNGP",
+    "british": false,
+    "label": "Corpus Christi Naval Air Station/Truax Field (United States) (KNGP)"
+  },
+  {
+    "id": "AVX",
+    "british": false,
+    "label": "Catalina Airport (United States) (KAVX / AVX)"
+  },
+  {
+    "id": "MHV",
+    "british": false,
+    "label": "Mojave Airport (United States) (KMHV / MHV)"
+  },
+  {
+    "id": "ZIN",
+    "british": false,
+    "label": "Interlaken Air Base (Switzerland) (LSMI / ZIN)"
+  },
+  {
+    "id": "INQ",
+    "british": false,
+    "label": "Inisheer Aerodrome (Ireland) (EIIR / INQ)"
+  },
+  {
+    "id": "SWT",
+    "british": false,
+    "label": "Strezhevoy Airport (Russia) (UNSS / SWT)"
+  },
+  {
+    "id": "HUT",
+    "british": false,
+    "label": "Hutchinson Municipal Airport (United States) (KHUT / HUT)"
+  },
+  {
+    "id": "OAI",
+    "british": false,
+    "label": "Bagram Air Base (Afghanistan) (OAIX / OAI)"
+  },
+  {
+    "id": "AKH",
+    "british": false,
+    "label": "Prince Sultan Air Base (Saudi Arabia) (OEPS / AKH)"
+  },
+  {
+    "id": "STJ",
+    "british": false,
+    "label": "Rosecrans Memorial Airport (United States) (KSTJ / STJ)"
+  },
+  {
+    "id": "LHPA",
+    "british": false,
+    "label": "Pápa Air Base (Hungary) (LHPA)"
+  },
+  {
+    "id": "KNDZ",
+    "british": false,
+    "label": "Whiting Field Naval Air Station South Airport (Germany) (KNDZ)"
+  },
+  {
+    "id": "VOK",
+    "british": false,
+    "label": "Volk Field (United States) (KVOK / VOK)"
+  },
+  {
+    "id": "GUC",
+    "british": false,
+    "label": "Gunnison Crested Butte Regional Airport (United States) (KGUC / GUC)"
+  },
+  {
+    "id": "SIA",
+    "british": false,
+    "label": "Xi'an Xiguan Airport (China) (ZLSN / SIA)"
+  },
+  {
+    "id": "TOA",
+    "british": false,
+    "label": "Zamperini Field (United States) (KTOA / TOA)"
+  },
+  {
+    "id": "MBL",
+    "british": false,
+    "label": "Manistee Co Blacker Airport (United States) (KMBL / MBL)"
+  },
+  {
+    "id": "PGD",
+    "british": false,
+    "label": "Charlotte County Airport (United States) (KPGD / PGD)"
+  },
+  {
+    "id": "WFK",
+    "british": false,
+    "label": "Northern Aroostook Regional Airport (United States) (KFVE / WFK)"
+  },
+  {
+    "id": "JHW",
+    "british": false,
+    "label": "Chautauqua County-Jamestown Airport (United States) (KJHW / JHW)"
+  },
+  {
+    "id": "YTM",
+    "british": false,
+    "label": "La Macaza / Mont-Tremblant International Inc Airport (Canada) (CYFJ / YTM)"
+  },
+  {
+    "id": "SME",
+    "british": false,
+    "label": "Lake Cumberland Regional Airport (United States) (KSME / SME)"
+  },
+  {
+    "id": "SHD",
+    "british": false,
+    "label": "Shenandoah Valley Regional Airport (United States) (KSHD / SHD)"
+  },
+  {
+    "id": "DVL",
+    "british": false,
+    "label": "Devils Lake Regional Airport (United States) (KDVL / DVL)"
+  },
+  {
+    "id": "DIK",
+    "british": false,
+    "label": "Dickinson Theodore Roosevelt Regional Airport (United States) (KDIK / DIK)"
+  },
+  {
+    "id": "SDY",
+    "british": false,
+    "label": "Sidney - Richland Regional Airport (United States) (KSDY / SDY)"
+  },
+  {
+    "id": "CDR",
+    "british": false,
+    "label": "Chadron Municipal Airport (United States) (KCDR / CDR)"
+  },
+  {
+    "id": "AIA",
+    "british": false,
+    "label": "Alliance Municipal Airport (United States) (KAIA / AIA)"
+  },
+  {
+    "id": "MCK",
+    "british": false,
+    "label": "Mc Cook Ben Nelson Regional Airport (United States) (KMCK / MCK)"
+  },
+  {
+    "id": "MTH",
+    "british": false,
+    "label": "The Florida Keys Marathon Airport (United States) (KMTH / MTH)"
+  },
+  {
+    "id": "GDV",
+    "british": false,
+    "label": "Dawson Community Airport (United States) (KGDV / GDV)"
+  },
+  {
+    "id": "OLF",
+    "british": false,
+    "label": "L M Clayton Airport (United States) (KOLF / OLF)"
+  },
+  {
+    "id": "WYS",
+    "british": false,
+    "label": "Yellowstone Airport (United States) (KWYS / WYS)"
+  },
+  {
+    "id": "ALS",
+    "british": false,
+    "label": "San Luis Valley Regional Bergman Field (United States) (KALS / ALS)"
+  },
+  {
+    "id": "CNY",
+    "british": false,
+    "label": "Canyonlands Field (United States) (KCNY / CNY)"
+  },
+  {
+    "id": "ELY",
+    "british": false,
+    "label": "Ely Airport Yelland Field (United States) (KELY / ELY)"
+  },
+  {
+    "id": "VEL",
+    "british": false,
+    "label": "Vernal Regional Airport (United States) (KVEL / VEL)"
+  },
+  {
+    "id": "RUI",
+    "british": false,
+    "label": "Sierra Blanca Regional Airport (United States) (KSRR / RUI)"
+  },
+  {
+    "id": "SOW",
+    "british": false,
+    "label": "Show Low Regional Airport (United States) (KSOW / SOW)"
+  },
+  {
+    "id": "MYL",
+    "british": false,
+    "label": "McCall Municipal Airport (United States) (KMYL / MYL)"
+  },
+  {
+    "id": "SMN",
+    "british": false,
+    "label": "Lemhi County Airport (United States) (KSMN / SMN)"
+  },
+  {
+    "id": "MMH",
+    "british": false,
+    "label": "Mammoth Yosemite Airport (United States) (KMMH / MMH)"
+  },
+  {
+    "id": "FRD",
+    "british": false,
+    "label": "Friday Harbor Airport (United States) (KFHR / FRD)"
+  },
+  {
+    "id": "ESD",
+    "british": false,
+    "label": "Orcas Island Airport (United States) (KORS / ESD)"
+  },
+  {
+    "id": "AST",
+    "british": false,
+    "label": "Astoria Regional Airport (United States) (KAST / AST)"
+  },
+  {
+    "id": "ONP",
+    "british": false,
+    "label": "Newport Municipal Airport (United States) (KONP / ONP)"
+  },
+  {
+    "id": "EMK",
+    "british": false,
+    "label": "Emmonak Airport (United States) (PAEM / EMK)"
+  },
+  {
+    "id": "UNK",
+    "british": false,
+    "label": "Unalakleet Airport (United States) (PAUN / UNK)"
+  },
+  {
+    "id": "UUK",
+    "british": false,
+    "label": "Ugnu-Kuparuk Airport (United States) (PAKU / UUK)"
+  },
+  {
+    "id": "SHX",
+    "british": false,
+    "label": "Shageluk Airport (United States) (PAHX / SHX)"
+  },
+  {
+    "id": "CHU",
+    "british": false,
+    "label": "Chuathbaluk Airport (United States) (PACH / CHU)"
+  },
+  {
+    "id": "NUI",
+    "british": false,
+    "label": "Nuiqsut Airport (United States) (PAQT / NUI)"
+  },
+  {
+    "id": "EEK",
+    "british": false,
+    "label": "Eek Airport (United States) (PAEE / EEK)"
+  },
+  {
+    "id": "KUK",
+    "british": false,
+    "label": "Kasigluk Airport (United States) (PFKA / KUK)"
+  },
+  {
+    "id": "KWT",
+    "british": false,
+    "label": "Kwethluk Airport (United States) (PFKW / KWT)"
+  },
+  {
+    "id": "KWK",
+    "british": false,
+    "label": "Kwigillingok Airport (United States) (PAGG / KWK)"
+  },
+  {
+    "id": "MLL",
+    "british": false,
+    "label": "Marshall Don Hunter Sr Airport (United States) (PADM / MLL)"
+  },
+  {
+    "id": "RSH",
+    "british": false,
+    "label": "Russian Mission Airport (United States) (PARS / RSH)"
+  },
+  {
+    "id": "KGK",
+    "british": false,
+    "label": "Koliganek Airport (United States) (PAJZ / KGK)"
+  },
+  {
+    "id": "KMO",
+    "british": false,
+    "label": "Manokotak Airport (United States) (PAMB / KMO)"
+  },
+  {
+    "id": "CIK",
+    "british": false,
+    "label": "Chalkyitsik Airport (United States) (PACI / CIK)"
+  },
+  {
+    "id": "EAA",
+    "british": false,
+    "label": "Eagle Airport (United States) (PAEG / EAA)"
+  },
+  {
+    "id": "HUS",
+    "british": false,
+    "label": "Hughes Airport (United States) (PAHU / HUS)"
+  },
+  {
+    "id": "HSL",
+    "british": false,
+    "label": "Huslia Airport (United States) (PAHL / HSL)"
+  },
+  {
+    "id": "NUL",
+    "british": false,
+    "label": "Nulato Airport (United States) (PANU / NUL)"
+  },
+  {
+    "id": "VEE",
+    "british": false,
+    "label": "Venetie Airport (United States) (PAVE / VEE)"
+  },
+  {
+    "id": "WBQ",
+    "british": false,
+    "label": "Beaver Airport (United States) (PAWB / WBQ)"
+  },
+  {
+    "id": "CEM",
+    "british": false,
+    "label": "Central Airport (United States) (PACE / CEM)"
+  },
+  {
+    "id": "SHG",
+    "british": false,
+    "label": "Shungnak Airport (United States) (PAGH / SHG)"
+  },
+  {
+    "id": "IYK",
+    "british": false,
+    "label": "Inyokern Airport (United States) (KIYK / IYK)"
+  },
+  {
+    "id": "VIS",
+    "british": false,
+    "label": "Visalia Municipal Airport (United States) (KVIS / VIS)"
+  },
+  {
+    "id": "MCE",
+    "british": false,
+    "label": "Merced Regional Macready Field (United States) (KMCE / MCE)"
+  },
+  {
+    "id": "CYR",
+    "british": false,
+    "label": "Laguna de Los Patos International Airport (Uruguay) (SUCA / CYR)"
+  },
+  {
+    "id": "CPQ",
+    "british": false,
+    "label": "Amarais Airport (Brazil) (SDAM / CPQ)"
+  },
+  {
+    "id": "GYR",
+    "british": false,
+    "label": "Phoenix Goodyear Airport (United States) (KGYR / GYR)"
+  },
+  {
+    "id": "TWB",
+    "british": false,
+    "label": "Toowoomba Airport (Australia) (YTWB / TWB)"
+  },
+  {
+    "id": "BBL",
+    "british": false,
+    "label": "Ballera Airport (Australia) (YLLE / BBL)"
+  },
+  {
+    "id": "YGAT",
+    "british": false,
+    "label": "Gatton Campus Airport (Australia) (YGAT)"
+  },
+  {
+    "id": "AYK",
+    "british": false,
+    "label": "Arkalyk North Airport (Kazakhstan) (UAUR / AYK)"
+  },
+  {
+    "id": "EDTN",
+    "british": false,
+    "label": "Nabern/Teck Airport (Germany) (EDTN)"
+  },
+  {
+    "id": "AGN",
+    "british": false,
+    "label": "Angoon Seaplane Base (United States) (PAGN / AGN)"
+  },
+  {
+    "id": "ELV",
+    "british": false,
+    "label": "Elfin Cove Seaplane Base (United States) (PAEL / ELV)"
+  },
+  {
+    "id": "FNR",
+    "british": false,
+    "label": "Funter Bay Seaplane Base (United States) (PANR / FNR)"
+  },
+  {
+    "id": "HNH",
+    "british": false,
+    "label": "Hoonah Airport (United States) (PAOH / HNH)"
+  },
+  {
+    "id": "PAFE",
+    "british": false,
+    "label": "Kake Airport (United States) (PAFE)"
+  },
+  {
+    "id": "MTM",
+    "british": false,
+    "label": "Metlakatla Seaplane Base (United States) (PAMM / MTM)"
+  },
+  {
+    "id": "HYG",
+    "british": false,
+    "label": "Hydaburg Seaplane Base (United States) (PAHY / HYG)"
+  },
+  {
+    "id": "EGX",
+    "british": false,
+    "label": "Egegik Airport (United States) (PAII / EGX)"
+  },
+  {
+    "id": "KPV",
+    "british": false,
+    "label": "Perryville Airport (United States) (PAPE / KPV)"
+  },
+  {
+    "id": "PIP",
+    "british": false,
+    "label": "Pilot Point Airport (United States) (PAPN / PIP)"
+  },
+  {
+    "id": "WSN",
+    "british": false,
+    "label": "South Naknek Nr 2 Airport (United States) (PFWS / WSN)"
+  },
+  {
+    "id": "AKK",
+    "british": false,
+    "label": "Akhiok Airport (United States) (PAKH / AKK)"
+  },
+  {
+    "id": "KYK",
+    "british": false,
+    "label": "Karluk Airport (United States) (PAKY / KYK)"
+  },
+  {
+    "id": "KLN",
+    "british": false,
+    "label": "Larsen Bay Airport (United States) (PALB / KLN)"
+  },
+  {
+    "id": "ABL",
+    "british": false,
+    "label": "Ambler Airport (United States) (PAFM / ABL)"
+  },
+  {
+    "id": "BKC",
+    "british": false,
+    "label": "Buckland Airport (United States) (PABL / BKC)"
+  },
+  {
+    "id": "IAN",
+    "british": false,
+    "label": "Bob Baker Memorial Airport (United States) (PAIK / IAN)"
+  },
+  {
+    "id": "OBU",
+    "british": false,
+    "label": "Kobuk Airport (United States) (PAOB / OBU)"
+  },
+  {
+    "id": "ORV",
+    "british": false,
+    "label": "Robert (Bob) Curtis Memorial Airport (United States) (PFNO / ORV)"
+  },
+  {
+    "id": "WLK",
+    "british": false,
+    "label": "Selawik Airport (United States) (PASK / WLK)"
+  },
+  {
+    "id": "KTS",
+    "british": false,
+    "label": "Brevig Mission Airport (United States) (PFKT / KTS)"
+  },
+  {
+    "id": "ELI",
+    "british": false,
+    "label": "Elim Airport (United States) (PFEL / ELI)"
+  },
+  {
+    "id": "GLV",
+    "british": false,
+    "label": "Golovin Airport (United States) (PAGL / GLV)"
+  },
+  {
+    "id": "TLA",
+    "british": false,
+    "label": "Teller Airport (United States) (PATE / TLA)"
+  },
+  {
+    "id": "WAA",
+    "british": false,
+    "label": "Wales Airport (United States) (PAIW / WAA)"
+  },
+  {
+    "id": "WMO",
+    "british": false,
+    "label": "White Mountain Airport (United States) (PAWM / WMO)"
+  },
+  {
+    "id": "KKA",
+    "british": false,
+    "label": "Koyuk Alfred Adams Airport (United States) (PAKK / KKA)"
+  },
+  {
+    "id": "SMK",
+    "british": false,
+    "label": "St Michael Airport (United States) (PAMK / SMK)"
+  },
+  {
+    "id": "SKK",
+    "british": false,
+    "label": "Shaktoolik Airport (United States) (PFSH / SKK)"
+  },
+  {
+    "id": "TNC",
+    "british": false,
+    "label": "Tin City Long Range Radar Station Airport (United States) (PATC / TNC)"
+  },
+  {
+    "id": "AKB",
+    "british": false,
+    "label": "Atka Airport (United States) (PAAK / AKB)"
+  },
+  {
+    "id": "IKO",
+    "british": false,
+    "label": "Nikolski Air Station (United States) (PAKO / IKO)"
+  },
+  {
+    "id": "CYT",
+    "british": false,
+    "label": "Yakataga Airport (United States) (PACY / CYT)"
+  },
+  {
+    "id": "AUK",
+    "british": false,
+    "label": "Alakanuk Airport (United States) (PAUK / AUK)"
+  },
+  {
+    "id": "KPN",
+    "british": false,
+    "label": "Kipnuk Airport (United States) (PAKI / KPN)"
+  },
+  {
+    "id": "KFP",
+    "british": false,
+    "label": "False Pass Airport (United States) (PAKF / KFP)"
+  },
+  {
+    "id": "NLG",
+    "british": false,
+    "label": "Nelson Lagoon Airport (United States) (PAOU / NLG)"
+  },
+  {
+    "id": "PML",
+    "british": false,
+    "label": "Port Moller Airport (United States) (PAAL / PML)"
+  },
+  {
+    "id": "KLW",
+    "british": false,
+    "label": "Klawock Airport (United States) (PAKW / KLW)"
+  },
+  {
+    "id": "KWN",
+    "british": false,
+    "label": "Quinhagak Airport (United States) (PAQH / KWN)"
+  },
+  {
+    "id": "KOT",
+    "british": false,
+    "label": "Kotlik Airport (United States) (PFKO / KOT)"
+  },
+  {
+    "id": "KYU",
+    "british": false,
+    "label": "Koyukuk Airport (United States) (PFKU / KYU)"
+  },
+  {
+    "id": "SCM",
+    "british": false,
+    "label": "Scammon Bay Airport (United States) (PACM / SCM)"
+  },
+  {
+    "id": "NNL",
+    "british": false,
+    "label": "Nondalton Airport (United States) (PANO / NNL)"
+  },
+  {
+    "id": "KKH",
+    "british": false,
+    "label": "Kongiganak Airport (United States) (PADY / KKH)"
+  },
+  {
+    "id": "NIB",
+    "british": false,
+    "label": "Nikolai Airport (United States) (PAFS / NIB)"
+  },
+  {
+    "id": "AKI",
+    "british": false,
+    "label": "Akiak Airport (United States) (PFAK / AKI)"
+  },
+  {
+    "id": "AIN",
+    "british": false,
+    "label": "Wainwright Airport (United States) (PAWI / AIN)"
+  },
+  {
+    "id": "APZ",
+    "british": false,
+    "label": "Zapala Airport (Argentina) (SAHZ / APZ)"
+  },
+  {
+    "id": "RDS",
+    "british": false,
+    "label": "Rincon De Los Sauces Airport (Argentina) (SAHS / RDS)"
+  },
+  {
+    "id": "PNT",
+    "british": false,
+    "label": "Tte. Julio Gallardo Airport (Chile) (SCNT / PNT)"
+  },
+  {
+    "id": "SGV",
+    "british": false,
+    "label": "Sierra Grande Airport (Argentina) (SAVS / SGV)"
+  },
+  {
+    "id": "IGB",
+    "british": false,
+    "label": "Cabo F.A.A. H. R. Bordón Airport (Argentina) (SAVJ / IGB)"
+  },
+  {
+    "id": "NCN",
+    "british": false,
+    "label": "Chenega Bay Airport (United States) (PFCB / NCN)"
+  },
+  {
+    "id": "TKJ",
+    "british": false,
+    "label": "Tok Junction Airport (United States) (PFTO / TKJ)"
+  },
+  {
+    "id": "IRC",
+    "british": false,
+    "label": "Circle City /New/ Airport (United States) (PACR / IRC)"
+  },
+  {
+    "id": "SLQ",
+    "british": false,
+    "label": "Sleetmute Airport (United States) (PASL / SLQ)"
+  },
+  {
+    "id": "PAHV",
+    "british": false,
+    "label": "Healy River Airport (United States) (PAHV)"
+  },
+  {
+    "id": "PAQC",
+    "british": false,
+    "label": "Klawock Seaplane Base (United States) (PAQC)"
+  },
+  {
+    "id": "LMA",
+    "british": false,
+    "label": "Minchumina Airport (United States) (PAMH / LMA)"
+  },
+  {
+    "id": "MLY",
+    "british": false,
+    "label": "Manley Hot Springs Airport (United States) (PAML / MLY)"
+  },
+  {
+    "id": "YNP",
+    "british": false,
+    "label": "Natuashish Airport (Canada) (CNH2 / YNP)"
+  },
+  {
+    "id": "YSO",
+    "british": false,
+    "label": "Postville Airport (Canada) (CCD4 / YSO)"
+  },
+  {
+    "id": "YWB",
+    "british": false,
+    "label": "Kangiqsujuaq (Wakeham Bay) Airport (Canada) (CYKG / YWB)"
+  },
+  {
+    "id": "YTF",
+    "british": false,
+    "label": "Alma Airport (Canada) (CYTF / YTF)"
+  },
+  {
+    "id": "YGV",
+    "british": false,
+    "label": "Havre St Pierre Airport (Canada) (CYGV / YGV)"
+  },
+  {
+    "id": "YXK",
+    "british": false,
+    "label": "Rimouski Airport (Canada) (CYXK / YXK)"
+  },
+  {
+    "id": "XTL",
+    "british": false,
+    "label": "Tadoule Lake Airport (Canada) (CYBQ / XTL)"
+  },
+  {
+    "id": "XLB",
+    "british": false,
+    "label": "Lac Brochet Airport (Canada) (CZWH / XLB)"
+  },
+  {
+    "id": "XSI",
+    "british": false,
+    "label": "South Indian Lake Airport (Canada) (CZSN / XSI)"
+  },
+  {
+    "id": "YBT",
+    "british": false,
+    "label": "Brochet Airport (Canada) (CYBT / YBT)"
+  },
+  {
+    "id": "ZGR",
+    "british": false,
+    "label": "Little Grand Rapids Airport (Canada) (CZGR / ZGR)"
+  },
+  {
+    "id": "YCR",
+    "british": false,
+    "label": "Cross Lake (Charlie Sinclair Memorial) Airport (Canada) (CYCR / YCR)"
+  },
+  {
+    "id": "YRS",
+    "british": false,
+    "label": "Red Sucker Lake Airport (Canada) (CYRS / YRS)"
+  },
+  {
+    "id": "YOP",
+    "british": false,
+    "label": "Rainbow Lake Airport (Canada) (CYOP / YOP)"
+  },
+  {
+    "id": "YBY",
+    "british": false,
+    "label": "Bonnyville Airport (Canada) (CYBF / YBY)"
+  },
+  {
+    "id": "ZNA",
+    "british": false,
+    "label": "Nanaimo Harbour Water Airport (Canada) (CAC8 / ZNA)"
+  },
+  {
+    "id": "YGG",
+    "british": false,
+    "label": "Ganges Seaplane Base (Canada) (CAX6 / YGG)"
+  },
+  {
+    "id": "CYJM",
+    "british": false,
+    "label": "Fort St James Airport (Canada) (CYJM)"
+  },
+  {
+    "id": "YDT",
+    "british": false,
+    "label": "Boundary Bay Airport (Canada) (CZBB / YDT)"
+  },
+  {
+    "id": "YLY",
+    "british": false,
+    "label": "Langley Airport (Canada) (CYNJ / YLY)"
+  },
+  {
+    "id": "CYJQ",
+    "british": false,
+    "label": "Denny Island Airport (Canada) (CYJQ)"
+  },
+  {
+    "id": "YFJ",
+    "british": false,
+    "label": "Wekweètì Airport (Canada) (CFJ2 / YFJ)"
+  },
+  {
+    "id": "MM52",
+    "british": false,
+    "label": "Camaguey-Campo Cuatro Milpas Airport (Mexico) (MM52)"
+  },
+  {
+    "id": "MMSL",
+    "british": false,
+    "label": "Cabo San Lucas International Airport (Mexico) (MMSL)"
+  },
+  {
+    "id": "RNI",
+    "british": false,
+    "label": "Corn Island (Nicaragua) (MNCI / RNI)"
+  },
+  {
+    "id": "BZA",
+    "british": false,
+    "label": "San Pedro Airport (Nicaragua) (MNBZ / BZA)"
+  },
+  {
+    "id": "RFS",
+    "british": false,
+    "label": "Rosita Airport (Nicaragua) (MNRT / RFS)"
+  },
+  {
+    "id": "SIU",
+    "british": false,
+    "label": "Siuna (Nicaragua) (MNSI / SIU)"
+  },
+  {
+    "id": "WSP",
+    "british": false,
+    "label": "Waspam Airport (Nicaragua) (MNWP / WSP)"
+  },
+  {
+    "id": "NCR",
+    "british": false,
+    "label": "San Carlos (Nicaragua) (MNSC / NCR)"
+  },
+  {
+    "id": "PLD",
+    "british": false,
+    "label": "Playa Samara/Carrillo Airport (Costa Rica) (MRCR / PLD)"
+  },
+  {
+    "id": "COZ",
+    "british": false,
+    "label": "Constanza - Expedición 14 de Junio National Airport (Dominican Republic) (MDCZ / COZ)"
+  },
+  {
+    "id": "NEG",
+    "british": false,
+    "label": "Negril Airport (Jamaica) (MKNG / NEG)"
+  },
+  {
+    "id": "NRR",
+    "british": false,
+    "label": "José Aponte de la Torre Airport (Puerto Rico) (TJRV / NRR)"
+  },
+  {
+    "id": "SPB",
+    "british": false,
+    "label": "Charlotte Amalie Harbor Seaplane Base (Virgin Islands) (VI22 / SPB)"
+  },
+  {
+    "id": "ARR",
+    "british": false,
+    "label": "D. Casimiro Szlapelis Airport (Argentina) (SAVR / ARR)"
+  },
+  {
+    "id": "JSM",
+    "british": false,
+    "label": "Jose De San Martin Airport (Argentina) (SAWS / JSM)"
+  },
+  {
+    "id": "UYU",
+    "british": false,
+    "label": "Uyuni Airport (Bolivia) (SLUY / UYU)"
+  },
+  {
+    "id": "RBQ",
+    "british": false,
+    "label": "Rurenabaque Airport (Bolivia) (SLRQ / RBQ)"
+  },
+  {
+    "id": "ABF",
+    "british": false,
+    "label": "Abaiang Airport (Kiribati) (NGAB / ABF)"
+  },
+  {
+    "id": "SMAF",
+    "british": false,
+    "label": "Afobakka Airstrip (Suriname) (SMAF)"
+  },
+  {
+    "id": "SMDU",
+    "british": false,
+    "label": "Alalapadu Airstrip (Suriname) (SMDU)"
+  },
+  {
+    "id": "ABN",
+    "british": false,
+    "label": "Albina Airport (Suriname) (SMBN / ABN)"
+  },
+  {
+    "id": "SMLA",
+    "british": false,
+    "label": "Lawa Anapaike Airstrip (Suriname) (SMLA)"
+  },
+  {
+    "id": "SMPT",
+    "british": false,
+    "label": "Apetina Airstrip (Suriname) (SMPT)"
+  },
+  {
+    "id": "DRJ",
+    "british": false,
+    "label": "Drietabbetje Airport (Suriname) (SMDA / DRJ)"
+  },
+  {
+    "id": "SMKA",
+    "british": false,
+    "label": "Kabalebo Airport (Suriname) (SMKA)"
+  },
+  {
+    "id": "SMKE",
+    "british": false,
+    "label": "Kayser Airport (Suriname) (SMKE)"
+  },
+  {
+    "id": "SMSM",
+    "british": false,
+    "label": "Kwamalasoemoetoe Airport (Suriname) (SMSM)"
+  },
+  {
+    "id": "MOJ",
+    "british": false,
+    "label": "Moengo Airstrip (Suriname) (SMMO / MOJ)"
+  },
+  {
+    "id": "ICK",
+    "british": false,
+    "label": "Nieuw Nickerie Airport (Suriname) (SMNI / ICK)"
+  },
+  {
+    "id": "OEM",
+    "british": false,
+    "label": "Vincent Fayks Airport (Suriname) (SMPA / OEM)"
+  },
+  {
+    "id": "SMSK",
+    "british": false,
+    "label": "Sarakreek Airstrip (Suriname) (SMSK)"
+  },
+  {
+    "id": "SMSI",
+    "british": false,
+    "label": "Sipaliwini Airport (Suriname) (SMSI)"
+  },
+  {
+    "id": "SMZ",
+    "british": false,
+    "label": "Stoelmanseiland Airport (Suriname) (SMST / SMZ)"
+  },
+  {
+    "id": "TOT",
+    "british": false,
+    "label": "Totness Airport (Suriname) (SMCO / TOT)"
+  },
+  {
+    "id": "AGI",
+    "british": false,
+    "label": "Wageningen Airstrip (Suriname) (SMWA / AGI)"
+  },
+  {
+    "id": "MRCA",
+    "british": false,
+    "label": "Codela Airport (Costa Rica) (MRCA)"
+  },
+  {
+    "id": "ORJ",
+    "british": false,
+    "label": "Orinduik Airport (Guyana) (SYOR / ORJ)"
+  },
+  {
+    "id": "NAI",
+    "british": false,
+    "label": "Annai Airport (Guyana) (SYAN / NAI)"
+  },
+  {
+    "id": "SYAP",
+    "british": false,
+    "label": "Apoteri Airport (Guyana) (SYAP)"
+  },
+  {
+    "id": "IMB",
+    "british": false,
+    "label": "Imbaimadai Airport (Guyana) (SYIB / IMB)"
+  },
+  {
+    "id": "KAR",
+    "british": false,
+    "label": "Kamarang Airport (Guyana) (SYKM / KAR)"
+  },
+  {
+    "id": "USI",
+    "british": false,
+    "label": "Mabaruma Airport (Guyana) (SYMB / USI)"
+  },
+  {
+    "id": "MHA",
+    "british": false,
+    "label": "Mahdia Airport (Guyana) (SYMD / MHA)"
+  },
+  {
+    "id": "PJC",
+    "british": false,
+    "label": "Dr Augusto Roberto Fuster International Airport (Paraguay) (SGPJ / PJC)"
+  },
+  {
+    "id": "ACD",
+    "british": false,
+    "label": "Alcides Fernández Airport (Colombia) (SKAD / ACD)"
+  },
+  {
+    "id": "RVE",
+    "british": false,
+    "label": "Los Colonizadores Airport (Colombia) (SKSA / RVE)"
+  },
+  {
+    "id": "BQJ",
+    "british": false,
+    "label": "Batagay Airport (Russia) (UEBB / BQJ)"
+  },
+  {
+    "id": "VGZ",
+    "british": false,
+    "label": "Villa Garzón Airport (Colombia) (SKVG / VGZ)"
+  },
+  {
+    "id": "EBG",
+    "british": false,
+    "label": "El Bagre Airport (Colombia) (SKEB / EBG)"
+  },
+  {
+    "id": "CAQ",
+    "british": false,
+    "label": "Juan H White Airport (Colombia) (SKCU / CAQ)"
+  },
+  {
+    "id": "COG",
+    "british": false,
+    "label": "Mandinga Airport (Colombia) (SKCD / COG)"
+  },
+  {
+    "id": "TLU",
+    "british": false,
+    "label": "Golfo de Morrosquillo Airport (Colombia) (SKTL / TLU)"
+  },
+  {
+    "id": "CFB",
+    "british": false,
+    "label": "Cabo Frio Airport (Brazil) (SBCB / CFB)"
+  },
+  {
+    "id": "OPS",
+    "british": false,
+    "label": "Presidente João Batista Figueiredo Airport (Brazil) (SWSI / OPS)"
+  },
+  {
+    "id": "GRP",
+    "british": false,
+    "label": "Gurupi Airport (Brazil) (SWGI / GRP)"
+  },
+  {
+    "id": "CMP",
+    "british": false,
+    "label": "Santana do Araguaia Airport (Brazil) (SNKE / CMP)"
+  },
+  {
+    "id": "BVS",
+    "british": false,
+    "label": "Breves Airport (Brazil) (SNVS / BVS)"
+  },
+  {
+    "id": "SFK",
+    "british": false,
+    "label": "Soure Airport (Brazil) (SNSW / SFK)"
+  },
+  {
+    "id": "PIN",
+    "british": false,
+    "label": "Parintins Airport (Brazil) (SWPI / PIN)"
+  },
+  {
+    "id": "BRA",
+    "british": false,
+    "label": "Barreiras Airport (Brazil) (SNBR / BRA)"
+  },
+  {
+    "id": "STZ",
+    "british": false,
+    "label": "Santa Terezinha Airport (Brazil) (SWST / STZ)"
+  },
+  {
+    "id": "MQH",
+    "british": false,
+    "label": "Minaçu Airport (Brazil) (SBMC / MQH)"
+  },
+  {
+    "id": "AUX",
+    "british": false,
+    "label": "Araguaína Airport (Brazil) (SWGN / AUX)"
+  },
+  {
+    "id": "NVP",
+    "british": false,
+    "label": "Novo Aripuanã Airport (Brazil) (SWNA / NVP)"
+  },
+  {
+    "id": "SWFE",
+    "british": false,
+    "label": "Fazenda Colen Airport (Brazil) (SWFE)"
+  },
+  {
+    "id": "FRC",
+    "british": false,
+    "label": "Tenente Lund Pressoto Airport (Brazil) (SIMK / FRC)"
+  },
+  {
+    "id": "DOU",
+    "british": false,
+    "label": "Dourados Airport (Brazil) (SSDO / DOU)"
+  },
+  {
+    "id": "LBR",
+    "british": false,
+    "label": "Lábrea Airport (Brazil) (SWLB / LBR)"
+  },
+  {
+    "id": "ROO",
+    "british": false,
+    "label": "Maestro Marinho Franco Airport (Brazil) (SWRD / ROO)"
+  },
+  {
+    "id": "GPB",
+    "british": false,
+    "label": "Tancredo Thomas de Faria Airport (Brazil) (SBGU / GPB)"
+  },
+  {
+    "id": "JCB",
+    "british": false,
+    "label": "Santa Terezinha Airport (Brazil) (SSJA / JCB)"
+  },
+  {
+    "id": "RVD",
+    "british": false,
+    "label": "General Leite de Castro Airport (Brazil) (SWLC / RVD)"
+  },
+  {
+    "id": "AAX",
+    "british": false,
+    "label": "Romeu Zema Airport (Brazil) (SBAX / AAX)"
+  },
+  {
+    "id": "MBZ",
+    "british": false,
+    "label": "Maués Airport (Brazil) (SWMW / MBZ)"
+  },
+  {
+    "id": "RBB",
+    "british": false,
+    "label": "Borba Airport (Brazil) (SWBR / RBB)"
+  },
+  {
+    "id": "CIZ",
+    "british": false,
+    "label": "Coari Airport (Brazil) (SWKO / CIZ)"
+  },
+  {
+    "id": "BAZ",
+    "british": false,
+    "label": "Barcelos Airport (Brazil) (SWBC / BAZ)"
+  },
+  {
+    "id": "DMT",
+    "british": false,
+    "label": "Diamantino Airport (Brazil) (SWDM / DMT)"
+  },
+  {
+    "id": "GNM",
+    "british": false,
+    "label": "Guanambi Airport (Brazil) (SNGI / GNM)"
+  },
+  {
+    "id": "QDJ",
+    "british": false,
+    "label": "Tsletsi Airport (Algeria) (DAFI / QDJ)"
+  },
+  {
+    "id": "NZA",
+    "british": false,
+    "label": "Nzagi Airport (Angola) (FNZG / NZA)"
+  },
+  {
+    "id": "LBZ",
+    "british": false,
+    "label": "Lucapa Airport (Angola) (FNLK / LBZ)"
+  },
+  {
+    "id": "KNP",
+    "british": false,
+    "label": "Capanda Airport (Angola) (FNCP / KNP)"
+  },
+  {
+    "id": "AMC",
+    "british": false,
+    "label": "Am Timan Airport (Chad) (FTTN / AMC)"
+  },
+  {
+    "id": "GSQ",
+    "british": false,
+    "label": "Shark El Oweinat International Airport (Egypt) (HEOW / GSQ)"
+  },
+  {
+    "id": "MRB",
+    "british": false,
+    "label": "Eastern WV Regional Airport/Shepherd Field (United States) (KMRB / MRB)"
+  },
+  {
+    "id": "AWA",
+    "british": false,
+    "label": "Awassa Airport (Ethiopia) (HALA / AWA)"
+  },
+  {
+    "id": "JIJ",
+    "british": false,
+    "label": "Wilwal International Airport (Ethiopia) (HAJJ / JIJ)"
+  },
+  {
+    "id": "MKS",
+    "british": false,
+    "label": "Mekane Selam Airport (Ethiopia) (HAMA / MKS)"
+  },
+  {
+    "id": "DBM",
+    "british": false,
+    "label": "Debra Marcos Airport (Ethiopia) (HADM / DBM)"
+  },
+  {
+    "id": "DBT",
+    "british": false,
+    "label": "Debre Tabor Airport (Ethiopia) (HADT / DBT)"
+  },
+  {
+    "id": "QHR",
+    "british": false,
+    "label": "Harar Meda Airport (Ethiopia) (HAHM / QHR)"
+  },
+  {
+    "id": "GOB",
+    "british": false,
+    "label": "Robe Airport (Ethiopia) (HAGB / GOB)"
+  },
+  {
+    "id": "MYB",
+    "british": false,
+    "label": "Mayumba Airport (Gabon) (FOOY / MYB)"
+  },
+  {
+    "id": "MRE",
+    "british": false,
+    "label": "Mara Serena Lodge Airstrip (Kenya) (HKMS / MRE)"
+  },
+  {
+    "id": "JJM",
+    "british": false,
+    "label": "Mulika Lodge Airport (Kenya) (HKMK / JJM)"
+  },
+  {
+    "id": "RBX",
+    "british": false,
+    "label": "Rumbek Airport (Sudan) (HSMK / RBX)"
+  },
+  {
+    "id": "HSYE",
+    "british": false,
+    "label": "Yei Airport (Sudan) (HSYE)"
+  },
+  {
+    "id": "CPA",
+    "british": false,
+    "label": "Cape Palmas Airport (Liberia) (GLCP / CPA)"
+  },
+  {
+    "id": "LSGE",
+    "british": false,
+    "label": "Ecuvillens Airport (Switzerland) (LSGE)"
+  },
+  {
+    "id": "IHC",
+    "british": false,
+    "label": "Inhaca Airport (Mozambique) (FQIA / IHC)"
+  },
+  {
+    "id": "MAX",
+    "british": false,
+    "label": "Ouro Sogui Airport (Senegal) (GOSM / MAX)"
+  },
+  {
+    "id": "BDI",
+    "british": false,
+    "label": "Bird Island Airport (Seychelles) (FSSB / BDI)"
+  },
+  {
+    "id": "WHF",
+    "british": false,
+    "label": "Wadi Halfa Airport (Sudan) (HSSW / WHF)"
+  },
+  {
+    "id": "NBE",
+    "british": false,
+    "label": "Enfidha - Hammamet International Airport (Tunisia) (DTNH / NBE)"
+  },
+  {
+    "id": "HUKD",
+    "british": false,
+    "label": "Kidepo Airport (Uganda) (HUKD)"
+  },
+  {
+    "id": "HUKT",
+    "british": false,
+    "label": "Kitgum Airport (Uganda) (HUKT)"
+  },
+  {
+    "id": "HUPA",
+    "british": false,
+    "label": "Bugungu Airport (Uganda) (HUPA)"
+  },
+  {
+    "id": "ENSA",
+    "british": false,
+    "label": "Svea Airport (Svalbard) (ENSA)"
+  },
+  {
+    "id": "ENAS",
+    "british": false,
+    "label": "Ny-Ålesund Airport (Hamnerabben) (Svalbard) (ENAS)"
+  },
+  {
+    "id": "HTY",
+    "british": false,
+    "label": "Hatay Airport (Turkey) (LTDA / HTY)"
+  },
+  {
+    "id": "EEKU",
+    "british": false,
+    "label": "Kihnu Airfield (Estonia) (EEKU)"
+  },
+  {
+    "id": "EERU",
+    "british": false,
+    "label": "Ruhnu Airfield (Estonia) (EERU)"
+  },
+  {
+    "id": "RVV",
+    "british": false,
+    "label": "Raivavae Airport (French Polynesia) (NTAV / RVV)"
+  },
+  {
+    "id": "FUO",
+    "british": false,
+    "label": "Foshan Shadi Airport (China) (ZGFS / FUO)"
+  },
+  {
+    "id": "HUZ",
+    "british": false,
+    "label": "Huizhou Airport (China) (ZGHZ / HUZ)"
+  },
+  {
+    "id": "ILD",
+    "british": false,
+    "label": "Lleida-Alguaire Airport (Spain) (LEDA / ILD)"
+  },
+  {
+    "id": "LFEC",
+    "british": false,
+    "label": "Ouessant Airport (France) (LFEC)"
+  },
+  {
+    "id": "BIU",
+    "british": false,
+    "label": "Bildudalur Airport (Iceland) (BIBD / BIU)"
+  },
+  {
+    "id": "GJR",
+    "british": false,
+    "label": "Gjögur Airport (Iceland) (BIGJ / GJR)"
+  },
+  {
+    "id": "SAK",
+    "british": false,
+    "label": "Sauðárkrókur Airport (Iceland) (BIKR / SAK)"
+  },
+  {
+    "id": "BISF",
+    "british": false,
+    "label": "Selfoss Airport (Iceland) (BISF)"
+  },
+  {
+    "id": "IIA",
+    "british": false,
+    "label": "Inishmaan Aerodrome (Ireland) (EIMN / IIA)"
+  },
+  {
+    "id": "UAAT",
+    "british": false,
+    "label": "Ak Bashat Airport (Kazakhstan) (UAAT)"
+  },
+  {
+    "id": "ULG",
+    "british": false,
+    "label": "Ulgii Mongolei Airport (Mongolia) (ZMUL / ULG)"
+  },
+  {
+    "id": "KQT",
+    "british": false,
+    "label": "Qurghonteppa International Airport (Tajikistan) (UTDT / KQT)"
+  },
+  {
+    "id": "VGD",
+    "british": false,
+    "label": "Vologda Airport (Russia) (ULWW / VGD)"
+  },
+  {
+    "id": "UHMW",
+    "british": false,
+    "label": "Severo-Evensk Airport (Russia) (UHMW)"
+  },
+  {
+    "id": "ONK",
+    "british": false,
+    "label": "Olenyok Airport (Russia) (UERO / ONK)"
+  },
+  {
+    "id": "SYS",
+    "british": false,
+    "label": "Saskylakh Airport (Russia) (UERS / SYS)"
+  },
+  {
+    "id": "LDG",
+    "british": false,
+    "label": "Leshukonskoye Airport (Russia) (ULAL / LDG)"
+  },
+  {
+    "id": "UIUN",
+    "british": false,
+    "label": "Nizhneangarsk Airport (Russia) (UIUN)"
+  },
+  {
+    "id": "UNIW",
+    "british": false,
+    "label": "Vanavara Airport (Russia) (UNIW)"
+  },
+  {
+    "id": "UERA",
+    "british": false,
+    "label": "Aykhal Airport (Russia) (UERA)"
+  },
+  {
+    "id": "USSK",
+    "british": false,
+    "label": "Uktus Airport (Russia) (USSK)"
+  },
+  {
+    "id": "UNIB",
+    "british": false,
+    "label": "Baykit Airport (Russia) (UNIB)"
+  },
+  {
+    "id": "UNBI",
+    "british": false,
+    "label": "Biysk Airport (Russia) (UNBI)"
+  },
+  {
+    "id": "HSK",
+    "british": false,
+    "label": "Huesca/Pirineos Airport (Spain) (LEHC / HSK)"
+  },
+  {
+    "id": "CQM",
+    "british": false,
+    "label": "Ciudad Real Central Airport (Spain) (LERL / CQM)"
+  },
+  {
+    "id": "NJF",
+    "british": false,
+    "label": "Al Najaf International Airport (Iraq) (ORNI / NJF)"
+  },
+  {
+    "id": "CSA",
+    "british": true,
+    "label": "Colonsay Airstrip (United Kingdom) (EGEY / CSA)"
+  },
+  {
+    "id": "RKH",
+    "british": false,
+    "label": "Rock Hill - York County Airport (United States) (KUZA / RKH)"
+  },
+  {
+    "id": "AGC",
+    "british": false,
+    "label": "Allegheny County Airport (United States) (KAGC / AGC)"
+  },
+  {
+    "id": "VQQ",
+    "british": false,
+    "label": "Cecil Airport (United States) (KVQQ / VQQ)"
+  },
+  {
+    "id": "FTY",
+    "british": false,
+    "label": "Fulton County Airport Brown Field (United States) (KFTY / FTY)"
+  },
+  {
+    "id": "EGHT",
+    "british": true,
+    "label": "Tresco Heliport (United Kingdom) (EGHT)"
+  },
+  {
+    "id": "TII",
+    "british": false,
+    "label": "Tarin Kowt Airport (Afghanistan) (OATN / TII)"
+  },
+  {
+    "id": "ZAJ",
+    "british": false,
+    "label": "Zaranj Airport (Afghanistan) (OAZJ / ZAJ)"
+  },
+  {
+    "id": "CCN",
+    "british": false,
+    "label": "Chakcharan Airport (Afghanistan) (OACC / CCN)"
+  },
+  {
+    "id": "FUG",
+    "british": false,
+    "label": "Fuyang Xiguan Airport (China) (ZSFY / FUG)"
+  },
+  {
+    "id": "LCX",
+    "british": false,
+    "label": "Longyan Guanzhishan Airport (China) (ZSLD / LCX)"
+  },
+  {
+    "id": "BSD",
+    "british": false,
+    "label": "Baoshan Yunduan Airport (China) (ZPBS / BSD)"
+  },
+  {
+    "id": "ACX",
+    "british": false,
+    "label": "Xingyi Airport (China) (ZUYI / ACX)"
+  },
+  {
+    "id": "HZH",
+    "british": false,
+    "label": "Liping Airport (China) (ZUNP / HZH)"
+  },
+  {
+    "id": "UB13",
+    "british": false,
+    "label": "Stepanakert Air Base (Azerbaijan) (UB13)"
+  },
+  {
+    "id": "OSU",
+    "british": false,
+    "label": "The Ohio State University Airport - Don Scott Field (United States) (KOSU / OSU)"
+  },
+  {
+    "id": "ADS",
+    "british": false,
+    "label": "Addison Airport (United States) (KADS / ADS)"
+  },
+  {
+    "id": "DSI",
+    "british": false,
+    "label": "Destin Executive Airport (United States) (KDTS / DSI)"
+  },
+  {
+    "id": "KHE",
+    "british": false,
+    "label": "Kherson International Airport (Ukraine) (UKOH / KHE)"
+  },
+  {
+    "id": "SZS",
+    "british": false,
+    "label": "Ryan's Creek Aerodrome (New Zealand) (NZRC / SZS)"
+  },
+  {
+    "id": "FSAS",
+    "british": false,
+    "label": "Assumption Island Airport (Seychelles) (FSAS)"
+  },
+  {
+    "id": "HJJ",
+    "british": false,
+    "label": "Zhijiang Airport (China) (ZGCJ / HJJ)"
+  },
+  {
+    "id": "YQI",
+    "british": false,
+    "label": "Yarmouth Airport (Canada) (CYQI / YQI)"
+  },
+  {
+    "id": "ISO",
+    "british": false,
+    "label": "Kinston Regional Jetport At Stallings Field (United States) (KISO / ISO)"
+  },
+  {
+    "id": "FFA",
+    "british": false,
+    "label": "First Flight Airport (United States) (KFFA / FFA)"
+  },
+  {
+    "id": "LNJ",
+    "british": false,
+    "label": "Lintsang Airfield (China) (ZPLC / LNJ)"
+  },
+  {
+    "id": "SWMK",
+    "british": false,
+    "label": "Maturacá Airport (Brazil) (SWMK)"
+  },
+  {
+    "id": "CKS",
+    "british": false,
+    "label": "Carajás Airport (Brazil) (SBCJ / CKS)"
+  },
+  {
+    "id": "SNCW",
+    "british": false,
+    "label": "Centro de Lançamento de Alcântara Airport (Brazil) (SNCW)"
+  },
+  {
+    "id": "MWK",
+    "british": false,
+    "label": "Tarempa Airport (Indonesia) (WIOM / MWK)"
+  },
+  {
+    "id": "EDFW",
+    "british": false,
+    "label": "Würzburg-Schenkenturm Airport (Germany) (EDFW)"
+  },
+  {
+    "id": "LPAV",
+    "british": false,
+    "label": "São Jacinto Airport (Portugal) (LPAV)"
+  },
+  {
+    "id": "ETNP",
+    "british": false,
+    "label": "Hopsten Air Base (Germany) (ETNP)"
+  },
+  {
+    "id": "PGU",
+    "british": false,
+    "label": "Persian Gulf International Airport (Iran) (OIBP / PGU)"
+  },
+  {
+    "id": "YES",
+    "british": false,
+    "label": "Yasouj Airport (Iran) (OISY / YES)"
+  },
+  {
+    "id": "OSM",
+    "british": false,
+    "label": "Mosul International Airport (Iraq) (ORBM / OSM)"
+  },
+  {
+    "id": "TJH",
+    "british": false,
+    "label": "Tajima Airport (Japan) (RJBT / TJH)"
+  },
+  {
+    "id": "AXJ",
+    "british": false,
+    "label": "Amakusa Airport (Japan) (RJDA / AXJ)"
+  },
+  {
+    "id": "KKX",
+    "british": false,
+    "label": "Kikai Airport (Japan) (RJKI / KKX)"
+  },
+  {
+    "id": "AGJ",
+    "british": false,
+    "label": "Aguni Airport (Japan) (RORA / AGJ)"
+  },
+  {
+    "id": "ULZ",
+    "british": false,
+    "label": "Donoi Airport (Mongolia) (ZMDN / ULZ)"
+  },
+  {
+    "id": "UGA",
+    "british": false,
+    "label": "Bulgan Airport (Mongolia) (ZMBN / UGA)"
+  },
+  {
+    "id": "ULO",
+    "british": false,
+    "label": "Ulaangom Airport (Mongolia) (ZMUG / ULO)"
+  },
+  {
+    "id": "RPVW",
+    "british": false,
+    "label": "Borongan Airport (Philippines) (RPVW)"
+  },
+  {
+    "id": "LBX",
+    "british": false,
+    "label": "Lubang Airport (Philippines) (RPLU / LBX)"
+  },
+  {
+    "id": "TJU",
+    "british": false,
+    "label": "Kulob Airport (Tajikistan) (UTDK / TJU)"
+  },
+  {
+    "id": "CMJ",
+    "british": false,
+    "label": "Chi Mei Airport (Taiwan) (RCCM / CMJ)"
+  },
+  {
+    "id": "TAZ",
+    "british": false,
+    "label": "Daşoguz Airport (Turkmenistan) (UTAT / TAZ)"
+  },
+  {
+    "id": "BWB",
+    "british": false,
+    "label": "Barrow Island Airport (Australia) (YBWX / BWB)"
+  },
+  {
+    "id": "DRB",
+    "british": false,
+    "label": "Derby Airport (Australia) (YDBY / DRB)"
+  },
+  {
+    "id": "WGE",
+    "british": false,
+    "label": "Walgett Airport (Australia) (YWLG / WGE)"
+  },
+  {
+    "id": "BRT",
+    "british": false,
+    "label": "Bathurst Island Airport (Australia) (YBTI / BRT)"
+  },
+  {
+    "id": "DKI",
+    "british": false,
+    "label": "Dunk Island Airport (Australia) (YDKI / DKI)"
+  },
+  {
+    "id": "LZR",
+    "british": false,
+    "label": "Lizard Island Airport (Australia) (YLZI / LZR)"
+  },
+  {
+    "id": "HLT",
+    "british": false,
+    "label": "Hamilton Airport (Australia) (YHML / HLT)"
+  },
+  {
+    "id": "HCQ",
+    "british": false,
+    "label": "Halls Creek Airport (Australia) (YHLC / HCQ)"
+  },
+  {
+    "id": "FIZ",
+    "british": false,
+    "label": "Fitzroy Crossing Airport (Australia) (YFTZ / FIZ)"
+  },
+  {
+    "id": "RVT",
+    "british": false,
+    "label": "Ravensthorpe Airport (Australia) (YNRV / RVT)"
+  },
+  {
+    "id": "YWKS",
+    "british": false,
+    "label": "Wilkins Runway (Antarctica) (YWKS)"
+  },
+  {
+    "id": "PVU",
+    "british": false,
+    "label": "Provo Municipal Airport (United States) (KPVU / PVU)"
+  },
+  {
+    "id": "SBS",
+    "british": false,
+    "label": "Steamboat Springs Bob Adams Field (United States) (KSBS / SBS)"
+  },
+  {
+    "id": "DTA",
+    "british": false,
+    "label": "Delta Municipal Airport (United States) (KDTA / DTA)"
+  },
+  {
+    "id": "KRIF",
+    "british": false,
+    "label": "Richfield Municipal Airport (United States) (KRIF)"
+  },
+  {
+    "id": "PUC",
+    "british": false,
+    "label": "Carbon County Regional/Buck Davis Field (United States) (KPUC / PUC)"
+  },
+  {
+    "id": "LAM",
+    "british": false,
+    "label": "Los Alamos Airport (United States) (KLAM / LAM)"
+  },
+  {
+    "id": "HII",
+    "british": false,
+    "label": "Lake Havasu City Airport (United States) (KHII / HII)"
+  },
+  {
+    "id": "INW",
+    "british": false,
+    "label": "Winslow Lindbergh Regional Airport (United States) (KINW / INW)"
+  },
+  {
+    "id": "DGL",
+    "british": false,
+    "label": "Douglas Municipal Airport (United States) (KDGL / DGL)"
+  },
+  {
+    "id": "MZK",
+    "british": false,
+    "label": "Marakei Airport (Kiribati) (NGMK / MZK)"
+  },
+  {
+    "id": "AEA",
+    "british": false,
+    "label": "Abemama Atoll Airport (Kiribati) (NGTB / AEA)"
+  },
+  {
+    "id": "AAK",
+    "british": false,
+    "label": "Buariki Airport (Kiribati) (NGUK / AAK)"
+  },
+  {
+    "id": "KUC",
+    "british": false,
+    "label": "Kuria Airport (Kiribati) (NGKT / KUC)"
+  },
+  {
+    "id": "AIS",
+    "british": false,
+    "label": "Arorae Island Airport (Kiribati) (NGTR / AIS)"
+  },
+  {
+    "id": "TMN",
+    "british": false,
+    "label": "Tamana Island Airport (Kiribati) (NGTM / TMN)"
+  },
+  {
+    "id": "BEZ",
+    "british": false,
+    "label": "Beru Airport (Kiribati) (NGBR / BEZ)"
+  },
+  {
+    "id": "NIG",
+    "british": false,
+    "label": "Nikunau Airport (Kiribati) (NGNU / NIG)"
+  },
+  {
+    "id": "BBG",
+    "british": false,
+    "label": "Butaritari Atoll Airport (Kiribati) (NGTU / BBG)"
+  },
+  {
+    "id": "MTK",
+    "british": false,
+    "label": "Makin Island Airport (Kiribati) (NGMN / MTK)"
+  },
+  {
+    "id": "MNK",
+    "british": false,
+    "label": "Maiana Airport (Kiribati) (NGMA / MNK)"
+  },
+  {
+    "id": "NON",
+    "british": false,
+    "label": "Nonouti Airport (Kiribati) (NGTO / NON)"
+  },
+  {
+    "id": "TSU",
+    "british": false,
+    "label": "Tabiteuea South Airport (Kiribati) (NGTS / TSU)"
+  },
+  {
+    "id": "WTZ",
+    "british": false,
+    "label": "Whitianga Airport (New Zealand) (NZWT / WTZ)"
+  },
+  {
+    "id": "KTF",
+    "british": false,
+    "label": "Takaka Airport (New Zealand) (NZTK / KTF)"
+  },
+  {
+    "id": "AFT",
+    "british": false,
+    "label": "Afutara Aerodrome (Solomon Islands) (AGAF / AFT)"
+  },
+  {
+    "id": "RNA",
+    "british": false,
+    "label": "Ulawa Airport (Solomon Islands) (AGAR / RNA)"
+  },
+  {
+    "id": "CHY",
+    "british": false,
+    "label": "Choiseul Bay Airport (Solomon Islands) (AGGC / CHY)"
+  },
+  {
+    "id": "NNB",
+    "british": false,
+    "label": "Santa Ana Airport (Solomon Islands) (AGGT / NNB)"
+  },
+  {
+    "id": "XYA",
+    "british": false,
+    "label": "Yandina Airport (Solomon Islands) (AGGY / XYA)"
+  },
+  {
+    "id": "BPF",
+    "british": false,
+    "label": "Batuna Aerodrome (Solomon Islands) (AGBT / BPF)"
+  },
+  {
+    "id": "BOW",
+    "british": false,
+    "label": "Bartow Municipal Airport (United States) (KBOW / BOW)"
+  },
+  {
+    "id": "UUBD",
+    "british": false,
+    "label": "Dyagilevo Air Base (Russia) (UUBD)"
+  },
+  {
+    "id": "FTI",
+    "british": false,
+    "label": "Fitiuta Airport (American Samoa) (NSFQ / FTI)"
+  },
+  {
+    "id": "LVK",
+    "british": false,
+    "label": "Livermore Municipal Airport (United States) (KLVK / LVK)"
+  },
+  {
+    "id": "RMY",
+    "british": false,
+    "label": "Mariposa Yosemite Airport (United States) (KMPI / RMY)"
+  },
+  {
+    "id": "GFY",
+    "british": false,
+    "label": "Grootfontein Airport (Namibia) (FYGF / GFY)"
+  },
+  {
+    "id": "NDU",
+    "british": false,
+    "label": "Rundu Airport (Namibia) (FYRU / NDU)"
+  },
+  {
+    "id": "BGAM",
+    "british": false,
+    "label": "Tasiilaq Heliport (Greenland) (BGAM)"
+  },
+  {
+    "id": "TRM",
+    "british": false,
+    "label": "Jacqueline Cochran Regional Airport (United States) (KTRM / TRM)"
+  },
+  {
+    "id": "SMO",
+    "british": false,
+    "label": "Santa Monica Municipal Airport (United States) (KSMO / SMO)"
+  },
+  {
+    "id": "UDD",
+    "british": false,
+    "label": "Bermuda Dunes Airport (United States) (KUDD / UDD)"
+  },
+  {
+    "id": "SCF",
+    "british": false,
+    "label": "Scottsdale Airport (United States) (KSDL / SCF)"
+  },
+  {
+    "id": "OLM",
+    "british": false,
+    "label": "Olympia Regional Airport (United States) (KOLM / OLM)"
+  },
+  {
+    "id": "KDWA",
+    "british": false,
+    "label": "Yolo County Davis Woodland Winters Airport (United States) (KDWA)"
+  },
+  {
+    "id": "RIL",
+    "british": false,
+    "label": "Garfield County Regional Airport (United States) (KRIL / RIL)"
+  },
+  {
+    "id": "SAA",
+    "british": false,
+    "label": "Shively Field (United States) (KSAA / SAA)"
+  },
+  {
+    "id": "PDK",
+    "british": false,
+    "label": "DeKalb Peachtree Airport (United States) (KPDK / PDK)"
+  },
+  {
+    "id": "BMG",
+    "british": false,
+    "label": "Monroe County Airport (United States) (KBMG / BMG)"
+  },
+  {
+    "id": "SUA",
+    "british": false,
+    "label": "Witham Field (United States) (KSUA / SUA)"
+  },
+  {
+    "id": "MMU",
+    "british": false,
+    "label": "Morristown Municipal Airport (United States) (KMMU / MMU)"
+  },
+  {
+    "id": "APC",
+    "british": false,
+    "label": "Napa County Airport (United States) (KAPC / APC)"
+  },
+  {
+    "id": "SDM",
+    "british": false,
+    "label": "Brown Field Municipal Airport (United States) (KSDM / SDM)"
+  },
+  {
+    "id": "LSPV",
+    "british": false,
+    "label": "Wangen-Lachen Airport (Switzerland) (LSPV)"
+  },
+  {
+    "id": "VNC",
+    "british": false,
+    "label": "Venice Municipal Airport (United States) (KVNC / VNC)"
+  },
+  {
+    "id": "PHK",
+    "british": false,
+    "label": "Palm Beach County Glades Airport (United States) (KPHK / PHK)"
+  },
+  {
+    "id": "ECP",
+    "british": false,
+    "label": "Northwest Florida Beaches International Airport (United States) (KECP / ECP)"
+  },
+  {
+    "id": "SBD",
+    "british": false,
+    "label": "San Bernardino International Airport (United States) (KSBD / SBD)"
+  },
+  {
+    "id": "VAL",
+    "british": false,
+    "label": "Valença Airport (Brazil) (SNVB / VAL)"
+  },
+  {
+    "id": "CAU",
+    "british": false,
+    "label": "Caruaru Airport (Brazil) (SNRU / CAU)"
+  },
+  {
+    "id": "AWK",
+    "british": false,
+    "label": "Wake Island Airfield (Wake Island) (PWAK / AWK)"
+  },
+  {
+    "id": "QNV",
+    "british": false,
+    "label": "Aeroclube Airport (Brazil) (SDNY / QNV)"
+  },
+  {
+    "id": "SQL",
+    "british": false,
+    "label": "San Carlos Airport (United States) (KSQL / SQL)"
+  },
+  {
+    "id": "LSZJ",
+    "british": false,
+    "label": "Courtelary Airport (Switzerland) (LSZJ)"
+  },
+  {
+    "id": "EPKO",
+    "british": false,
+    "label": "Lotnisko Korne (Poland) (EPKO)"
+  },
+  {
+    "id": "FBCO",
+    "british": false,
+    "label": "Camp Okavango Airport (Botswana) (FBCO)"
+  },
+  {
+    "id": "RWI",
+    "british": false,
+    "label": "Rocky Mount Wilson Regional Airport (United States) (KRWI / RWI)"
+  },
+  {
+    "id": "PAWR",
+    "british": false,
+    "label": "Whittier Airport (United States) (PAWR)"
+  },
+  {
+    "id": "SXQ",
+    "british": false,
+    "label": "Soldotna Airport (United States) (PASX / SXQ)"
+  },
+  {
+    "id": "SEE",
+    "british": false,
+    "label": "Gillespie Field (United States) (KSEE / SEE)"
+  },
+  {
+    "id": "KNUC",
+    "british": false,
+    "label": "San Clemente Island Naval Auxiliary Landing Field (United States) (KNUC)"
+  },
+  {
+    "id": "PHA",
+    "british": false,
+    "label": "Phan Rang Airport (Vietnam) (VVPR / PHA)"
+  },
+  {
+    "id": "SQH",
+    "british": false,
+    "label": "Na-San Airport (Vietnam) (VVNS / SQH)"
+  },
+  {
+    "id": "TKF",
+    "british": false,
+    "label": "Truckee Tahoe Airport (United States) (KTRK / TKF)"
+  },
+  {
+    "id": "FRJ",
+    "british": false,
+    "label": "Fréjus Airport (France) (LFTU / FRJ)"
+  },
+  {
+    "id": "GEX",
+    "british": false,
+    "label": "Geelong Airport (Australia) (YGLG / GEX)"
+  },
+  {
+    "id": "ULAE",
+    "british": false,
+    "label": "Mezen Airport (Russia) (ULAE)"
+  },
+  {
+    "id": "ULAH",
+    "british": false,
+    "label": "Vaskovo Airport (Russia) (ULAH)"
+  },
+  {
+    "id": "KRYY",
+    "british": false,
+    "label": "Cobb County-Mc Collum Field (United States) (KRYY)"
+  },
+  {
+    "id": "LOXT",
+    "british": false,
+    "label": "Brumowski  Air Base (Austria) (LOXT)"
+  },
+  {
+    "id": "K4U9",
+    "british": false,
+    "label": "Dell Flight Strip (United States) (K4U9)"
+  },
+  {
+    "id": "LVM",
+    "british": false,
+    "label": "Mission Field (United States) (KLVM / LVM)"
+  },
+  {
+    "id": "K6S0",
+    "british": false,
+    "label": "Big Timber Airport (United States) (K6S0)"
+  },
+  {
+    "id": "KBIV",
+    "british": false,
+    "label": "Tulip City Airport (United States) (KBIV)"
+  },
+  {
+    "id": "EGLW",
+    "british": true,
+    "label": "London Heliport (United Kingdom) (EGLW)"
+  },
+  {
+    "id": "LIPV",
+    "british": false,
+    "label": "Venice-Lido Airport (Italy) (LIPV)"
+  },
+  {
+    "id": "EECL",
+    "british": false,
+    "label": "Tallinn Linnahall Heliport (Estonia) (EECL)"
+  },
+  {
+    "id": "EFHE",
+    "british": false,
+    "label": "Hernesaari Heliport (Finland) (EFHE)"
+  },
+  {
+    "id": "EDRI",
+    "british": false,
+    "label": "Linkenheim Airport (Germany) (EDRI)"
+  },
+  {
+    "id": "GMV",
+    "british": false,
+    "label": "Monument Valley Airport (United States) (UT25 / GMV)"
+  },
+  {
+    "id": "EHHV",
+    "british": false,
+    "label": "Hilversum Airfield (Netherlands) (EHHV)"
+  },
+  {
+    "id": "JRA",
+    "british": false,
+    "label": "West 30th St. Heliport (United States) (KJRA / JRA)"
+  },
+  {
+    "id": "EHTX",
+    "british": false,
+    "label": "Texel Airfield (Netherlands) (EHTX)"
+  },
+  {
+    "id": "LECD",
+    "british": false,
+    "label": "La Cerdanya Airport (Spain) (LECD)"
+  },
+  {
+    "id": "LAL",
+    "british": false,
+    "label": "Lakeland Linder International Airport (United States) (KLAL / LAL)"
+  },
+  {
+    "id": "UUOS",
+    "british": false,
+    "label": "Stary Oskol Airport (Russia) (UUOS)"
+  },
+  {
+    "id": "SYH",
+    "british": false,
+    "label": "Syangboche Airport (Nepal) (VNSB / SYH)"
+  },
+  {
+    "id": "KIDL",
+    "british": false,
+    "label": "Indianola Municipal Airport (United States) (KIDL)"
+  },
+  {
+    "id": "UNKM",
+    "british": false,
+    "label": "Cheremshanka Airport (Russia) (UNKM)"
+  },
+  {
+    "id": "RBK",
+    "british": false,
+    "label": "French Valley Airport (United States) (KF70 / RBK)"
+  },
+  {
+    "id": "FNU",
+    "british": false,
+    "label": "Oristano-Fenosu Airport (Italy) (LIER / FNU)"
+  },
+  {
+    "id": "EGLM",
+    "british": true,
+    "label": "White Waltham Airfield (United Kingdom) (EGLM)"
+  },
+  {
+    "id": "MYQ",
+    "british": false,
+    "label": "Mysore Airport (India) (VOMY / MYQ)"
+  },
+  {
+    "id": "KPCW",
+    "british": false,
+    "label": "Carl R Keller Field (United States) (KPCW)"
+  },
+  {
+    "id": "MGY",
+    "british": false,
+    "label": "Dayton-Wright Brothers Airport (United States) (KMGY / MGY)"
+  },
+  {
+    "id": "KRID",
+    "british": false,
+    "label": "Richmond Municipal Airport (United States) (KRID)"
+  },
+  {
+    "id": "FDY",
+    "british": false,
+    "label": "Findlay Airport (United States) (KFDY / FDY)"
+  },
+  {
+    "id": "CZBA",
+    "british": false,
+    "label": "Burlington Executive (Canada) (CZBA)"
+  },
+  {
+    "id": "PEA",
+    "british": false,
+    "label": "Penneshaw Airport (Australia) (YPSH / PEA)"
+  },
+  {
+    "id": "EBEN",
+    "british": false,
+    "label": "Engels heliport (Germany) (EBEN)"
+  },
+  {
+    "id": "EMP",
+    "british": false,
+    "label": "Emporia Municipal Airport (Germany) (KEMP / EMP)"
+  },
+  {
+    "id": "ESSE",
+    "british": false,
+    "label": "Skå-Edeby Airport (Germany) (ESSE)"
+  },
+  {
+    "id": "HYC",
+    "british": true,
+    "label": "Wycombe Air Park (United Kingdom) (EGTB / HYC)"
+  },
+  {
+    "id": "BBP",
+    "british": true,
+    "label": "Bembridge Airport (United Kingdom) (EGHJ / BBP)"
+  },
+  {
+    "id": "CCW3",
+    "british": false,
+    "label": "Waterville / Kings County Municipal Airport (Canada) (CCW3)"
+  },
+  {
+    "id": "SPF",
+    "british": false,
+    "label": "Black Hills Airport-Clyde Ice Field (United States) (KSPF / SPF)"
+  },
+  {
+    "id": "EBKW",
+    "british": false,
+    "label": "Westkapelle heliport (Belgium) (EBKW)"
+  },
+  {
+    "id": "YRED",
+    "british": false,
+    "label": "Redcliffe Airport (Australia) (YRED)"
+  },
+  {
+    "id": "QYD",
+    "british": false,
+    "label": "Oksywie Military Air Base (Poland) (EPOK / QYD)"
+  },
+  {
+    "id": "EPMB",
+    "british": false,
+    "label": "Malbork Military Air Base (Poland) (EPMB)"
+  },
+  {
+    "id": "EPLK",
+    "british": false,
+    "label": "Lask Military Air Base (Poland) (EPLK)"
+  },
+  {
+    "id": "EPMI",
+    "british": false,
+    "label": "Miroslawiec Military Air Base (Poland) (EPMI)"
+  },
+  {
+    "id": "EPKS",
+    "british": false,
+    "label": "Krzesiny Military Air Base (Poland) (EPKS)"
+  },
+  {
+    "id": "OLV",
+    "british": false,
+    "label": "Olive Branch Airport (United States) (KOLV / OLV)"
+  },
+  {
+    "id": "KNA",
+    "british": false,
+    "label": "Viña del mar Airport (Chile) (SCVM / KNA)"
+  },
+  {
+    "id": "CNC3",
+    "british": false,
+    "label": "Brampton Airport (Canada) (CNC3)"
+  },
+  {
+    "id": "ONQ",
+    "british": false,
+    "label": "Zonguldak Airport (Turkey) (LTAS / ONQ)"
+  },
+  {
+    "id": "BJC",
+    "british": false,
+    "label": "Rocky Mountain Metropolitan Airport (United States) (KBJC / BJC)"
+  },
+  {
+    "id": "SLE",
+    "british": false,
+    "label": "Salem Municipal Airport/McNary Field (United States) (KSLE / SLE)"
+  },
+  {
+    "id": "UTM",
+    "british": false,
+    "label": "Tunica Municipal Airport (United States) (KUTA / UTM)"
+  },
+  {
+    "id": "UA30",
+    "british": false,
+    "label": "Batken Airport (Kyrgyzstan) (UA30)"
+  },
+  {
+    "id": "ZKB",
+    "british": false,
+    "label": "Kasaba Bay Airport (Zambia) (FLKY / ZKB)"
+  },
+  {
+    "id": "LND",
+    "british": false,
+    "label": "Hunt Field (Germany) (KLND / LND)"
+  },
+  {
+    "id": "EHHO",
+    "british": false,
+    "label": "Hoogeveen Airfield (Netherlands) (EHHO)"
+  },
+  {
+    "id": "EHTE",
+    "british": false,
+    "label": "Teuge Airport (Netherlands) (EHTE)"
+  },
+  {
+    "id": "EHMZ",
+    "british": false,
+    "label": "Midden-Zeeland Airport (Netherlands) (EHMZ)"
+  },
+  {
+    "id": "EHAL",
+    "british": false,
+    "label": "Ameland Airfield (Netherlands) (EHAL)"
+  },
+  {
+    "id": "LFPZ",
+    "british": false,
+    "label": "Saint-Cyr-l'École Airport (France) (LFPZ)"
+  },
+  {
+    "id": "MWC",
+    "british": false,
+    "label": "Lawrence J Timmerman Airport (United States) (KMWC / MWC)"
+  },
+  {
+    "id": "JVL",
+    "british": false,
+    "label": "Southern Wisconsin Regional Airport (United States) (KJVL / JVL)"
+  },
+  {
+    "id": "FXMN",
+    "british": false,
+    "label": "Mantsonyane Airport (Lesotho) (FXMN)"
+  },
+  {
+    "id": "KGKY",
+    "british": false,
+    "label": "Arlington Municipal Airport (United States) (KGKY)"
+  },
+  {
+    "id": "LZU",
+    "british": false,
+    "label": "Gwinnett County Briscoe Field (United States) (KLZU / LZU)"
+  },
+  {
+    "id": "BWG",
+    "british": false,
+    "label": "Bowling Green Warren County Regional Airport (United States) (KBWG / BWG)"
+  },
+  {
+    "id": "RVS",
+    "british": false,
+    "label": "Richard Lloyd Jones Jr Airport (United States) (KRVS / RVS)"
+  },
+  {
+    "id": "NHD",
+    "british": false,
+    "label": "Al Minhad Air Base (United Arab Emirates) (OMDM / NHD)"
+  },
+  {
+    "id": "KGO",
+    "british": false,
+    "label": "Kirovograd Airport (Ukraine) (UKKG / KGO)"
+  },
+  {
+    "id": "EDAW",
+    "british": false,
+    "label": "Roitzschjora Airfield (Germany) (EDAW)"
+  },
+  {
+    "id": "DBB",
+    "british": false,
+    "label": "El Alamein International Airport (Egypt) (HEAL / DBB)"
+  },
+  {
+    "id": "BCE",
+    "british": false,
+    "label": "Bryce Canyon Airport (United States) (KBCE / BCE)"
+  },
+  {
+    "id": "KBUY",
+    "british": false,
+    "label": "Burlington Alamance Regional Airport (United States) (KBUY)"
+  },
+  {
+    "id": "CKL",
+    "british": false,
+    "label": "Chkalovskiy Air Base (Russia) (UUMU / CKL)"
+  },
+  {
+    "id": "TCZ",
+    "british": false,
+    "label": "Tengchong Tuofeng Airport (China) (ZUTC / TCZ)"
+  },
+  {
+    "id": "UKS",
+    "british": false,
+    "label": "Belbek Airport (Ukraine) (UKFB / UKS)"
+  },
+  {
+    "id": "EHDP",
+    "british": false,
+    "label": "De Peel Air Base (Netherlands) (EHDP)"
+  },
+  {
+    "id": "OAZ",
+    "british": false,
+    "label": "Camp Bastion Airport (Afghanistan) (OAZI / OAZ)"
+  },
+  {
+    "id": "JCI",
+    "british": false,
+    "label": "New Century Aircenter Airport (United States) (KIXD / JCI)"
+  },
+  {
+    "id": "ESN",
+    "british": false,
+    "label": "Easton Newnam Field (United States) (KESN / ESN)"
+  },
+  {
+    "id": "HMR",
+    "british": false,
+    "label": "Stafsberg Airport (Norway) (ENHA / HMR)"
+  },
+  {
+    "id": "ENRI",
+    "british": false,
+    "label": "Ringebu Airfield Frya (Norway) (ENRI)"
+  },
+  {
+    "id": "MYV",
+    "british": false,
+    "label": "Yuba County Airport (United States) (KMYV / MYV)"
+  },
+  {
+    "id": "YPID",
+    "british": false,
+    "label": "Phillip Island Airport (Australia) (YPID)"
+  },
+  {
+    "id": "DUC",
+    "british": false,
+    "label": "Halliburton Field (United States) (KDUC / DUC)"
+  },
+  {
+    "id": "UVA",
+    "british": false,
+    "label": "Garner Field (United States) (KUVA / UVA)"
+  },
+  {
+    "id": "LOT",
+    "british": false,
+    "label": "Lewis University Airport (United States) (KLOT / LOT)"
+  },
+  {
+    "id": "CCR",
+    "british": false,
+    "label": "Buchanan Field (United States) (KCCR / CCR)"
+  },
+  {
+    "id": "OCA",
+    "british": false,
+    "label": "Ocean Reef Club Airport (United States) (07FA / OCA)"
+  },
+  {
+    "id": "LFGC",
+    "british": false,
+    "label": "Strasbourg Neuhof Airfield (France) (LFGC)"
+  },
+  {
+    "id": "EDRN",
+    "british": false,
+    "label": "Nannhausen Airport (Germany) (EDRN)"
+  },
+  {
+    "id": "YUS",
+    "british": false,
+    "label": "Yushu Batang Airport (China) (ZYLS / YUS)"
+  },
+  {
+    "id": "HIA",
+    "british": false,
+    "label": "Lianshui Airport (China) (ZSSH / HIA)"
+  },
+  {
+    "id": "YOO",
+    "british": false,
+    "label": "Toronto/Oshawa Executive Airport (Canada) (CYOO / YOO)"
+  },
+  {
+    "id": "EDLM",
+    "british": false,
+    "label": "Marl-Loemühle Airfield (Germany) (EDLM)"
+  },
+  {
+    "id": "ESNF",
+    "british": false,
+    "label": "Färila Air Base (Sweden) (ESNF)"
+  },
+  {
+    "id": "LHA",
+    "british": false,
+    "label": "Lahr Airport (Germany) (EDTL / LHA)"
+  },
+  {
+    "id": "NYW",
+    "british": false,
+    "label": "Monywar Airport (Burma) (VYMY / NYW)"
+  },
+  {
+    "id": "ATO",
+    "british": false,
+    "label": "Ohio University Snyder Field (United States) (KUNI / ATO)"
+  },
+  {
+    "id": "SGH",
+    "british": false,
+    "label": "Springfield-Beckley Municipal Airport (United States) (KSGH / SGH)"
+  },
+  {
+    "id": "\\N",
+    "british": false,
+    "label": "Sun Island Resort and SPA (Maldives) ()"
+  },
+  {
+    "id": "GMFU",
+    "british": false,
+    "label": "Fes Sefrou Airport (Morocco) (GMFU)"
+  },
+  {
+    "id": "HEX",
+    "british": false,
+    "label": "Herrera Airport (Dominican Republic) (MDHE / HEX)"
+  },
+  {
+    "id": "CDA",
+    "british": false,
+    "label": "Cooinda Airport (Australia) (YCOO / CDA)"
+  },
+  {
+    "id": "JAB",
+    "british": false,
+    "label": "Jabiru Airport (Australia) (YJAB / JAB)"
+  },
+  {
+    "id": "EDNR",
+    "british": false,
+    "label": "Regensburg-Oberhub Airport (Germany) (EDNR)"
+  },
+  {
+    "id": "HGS",
+    "british": false,
+    "label": "Hastings Airport (Sierra Leone) (GFHA / HGS)"
+  },
+  {
+    "id": "TOP",
+    "british": false,
+    "label": "Philip Billard Municipal Airport (United States) (KTOP / TOP)"
+  },
+  {
+    "id": "2XS8",
+    "british": false,
+    "label": "Benson Airstrip (United States) (2XS8)"
+  },
+  {
+    "id": "K2I3",
+    "british": false,
+    "label": "Rough River State Park Airport (United States) (K2I3)"
+  },
+  {
+    "id": "MQY",
+    "british": false,
+    "label": "Smyrna Airport (United States) (KMQY / MQY)"
+  },
+  {
+    "id": "UOS",
+    "british": false,
+    "label": "Franklin County Airport (United States) (KUOS / UOS)"
+  },
+  {
+    "id": "NGQ",
+    "british": false,
+    "label": "Ngari Gunsa Airport (China) (ZUAL / NGQ)"
+  },
+  {
+    "id": "CSO",
+    "british": false,
+    "label": "Cochstedt Airport (Germany) (EDBC / CSO)"
+  },
+  {
+    "id": "KTKI",
+    "british": false,
+    "label": "Collin County Regional At Mc Kinney Airport (United States) (KTKI)"
+  },
+  {
+    "id": "PWK",
+    "british": false,
+    "label": "Chicago Executive Airport (United States) (KPWK / PWK)"
+  },
+  {
+    "id": "KLS",
+    "british": false,
+    "label": "Southwest Washington Regional Airport (United States) (KKLS / KLS)"
+  },
+  {
+    "id": "LKBE",
+    "british": false,
+    "label": "Benešov Airport (Czech Republic) (LKBE)"
+  },
+  {
+    "id": "GABG",
+    "british": false,
+    "label": "Bougouni Airport (Mali) (GABG)"
+  },
+  {
+    "id": "ZTA",
+    "british": false,
+    "label": "Tureia Airport (French Polynesia) (NTGY / ZTA)"
+  },
+  {
+    "id": "NZIR",
+    "british": false,
+    "label": "McMurdo Station Ice Runway (Antarctica) (NZIR)"
+  },
+  {
+    "id": "HKKE",
+    "british": false,
+    "label": "Keekorok Airport (Kenya) (HKKE)"
+  },
+  {
+    "id": "PUE",
+    "british": false,
+    "label": "Puerto Obaldia Airport (Panama) (MPOA / PUE)"
+  },
+  {
+    "id": "KHC",
+    "british": false,
+    "label": "Kerch Airport (Ukraine) (UKFK / KHC)"
+  },
+  {
+    "id": "UKA",
+    "british": false,
+    "label": "Ukunda Airstrip (Kenya) (HKUK / UKA)"
+  },
+  {
+    "id": "ILN",
+    "british": false,
+    "label": "Wilmington Airpark (United States) (KILN / ILN)"
+  },
+  {
+    "id": "AVW",
+    "british": false,
+    "label": "Marana Regional Airport (United States) (KAVQ / AVW)"
+  },
+  {
+    "id": "CGZ",
+    "british": false,
+    "label": "Casa Grande Municipal Airport (United States) (KCGZ / CGZ)"
+  },
+  {
+    "id": "1AZ0",
+    "british": false,
+    "label": "Mobile Airport (United States) (1AZ0)"
+  },
+  {
+    "id": "BXK",
+    "british": false,
+    "label": "Buckeye Municipal Airport (United States) (KBXK / BXK)"
+  },
+  {
+    "id": "KE63",
+    "british": false,
+    "label": "Gila Bend Municipal Airport (United States) (KE63)"
+  },
+  {
+    "id": "MMI",
+    "british": false,
+    "label": "McMinn County Airport (United States) (KMMI / MMI)"
+  },
+  {
+    "id": "STK",
+    "british": false,
+    "label": "Sterling Municipal Airport (United States) (KSTK / STK)"
+  },
+  {
+    "id": "RWL",
+    "british": false,
+    "label": "Rawlins Municipal Airport/Harvey Field (United States) (KRWL / RWL)"
+  },
+  {
+    "id": "CYZY",
+    "british": false,
+    "label": "Mackenzie Airport (Canada) (CYZY)"
+  },
+  {
+    "id": "CDW",
+    "british": false,
+    "label": "Essex County Airport (United States) (KCDW / CDW)"
+  },
+  {
+    "id": "AIZ",
+    "british": false,
+    "label": "Lee C Fine Memorial Airport (United States) (KAIZ / AIZ)"
+  },
+  {
+    "id": "TVI",
+    "british": false,
+    "label": "Thomasville Regional Airport (United States) (KTVI / TVI)"
+  },
+  {
+    "id": "HSH",
+    "british": false,
+    "label": "Henderson Executive Airport (United States) (KHND / HSH)"
+  },
+  {
+    "id": "GML",
+    "british": false,
+    "label": "Gostomel Airport (Ukraine) (UKKM / GML)"
+  },
+  {
+    "id": "TMA",
+    "british": false,
+    "label": "Henry Tift Myers Airport (United States) (KTMA / TMA)"
+  },
+  {
+    "id": "EDML",
+    "british": false,
+    "label": "Landshut Airport (Germany) (EDML)"
+  },
+  {
+    "id": "EDHF",
+    "british": false,
+    "label": "Itzehoe/Hungriger Wolf Airport (Germany) (EDHF)"
+  },
+  {
+    "id": "RDO",
+    "british": false,
+    "label": "Radom Airport (Poland) (EPRA / RDO)"
+  },
+  {
+    "id": "DVT",
+    "british": false,
+    "label": "Phoenix Deer Valley Airport (United States) (KDVT / DVT)"
+  },
+  {
+    "id": "CYBW",
+    "british": false,
+    "label": "Calgary / Springbank Airport (Canada) (CYBW)"
+  },
+  {
+    "id": "CYGE",
+    "british": false,
+    "label": "Golden Airport (Canada) (CYGE)"
+  },
+  {
+    "id": "YRV",
+    "british": false,
+    "label": "Revelstoke Airport (Canada) (CYRV / YRV)"
+  },
+  {
+    "id": "FRG",
+    "british": false,
+    "label": "Republic Airport (United States) (KFRG / FRG)"
+  },
+  {
+    "id": "EDBT",
+    "british": false,
+    "label": "Allstedt Airport (Germany) (EDBT)"
+  },
+  {
+    "id": "SCIC",
+    "british": false,
+    "label": "General Freire Airport (Chile) (SCIC)"
+  },
+  {
+    "id": "EDVP",
+    "british": false,
+    "label": "Peine-Eddesse Airport (Germany) (EDVP)"
+  },
+  {
+    "id": "KHDO",
+    "british": false,
+    "label": "South Texas Regional Airport at Hondo (United States) (KHDO)"
+  },
+  {
+    "id": "ZHY",
+    "british": false,
+    "label": "Zhongwei Shapotou Airport (China) (ZLZW / ZHY)"
+  },
+  {
+    "id": "MCL",
+    "british": false,
+    "label": "McKinley National Park Airport (United States) (PAIN / MCL)"
+  },
+  {
+    "id": "PALH",
+    "british": false,
+    "label": "Lake Hood Airport (United States) (PALH)"
+  },
+  {
+    "id": "PPC",
+    "british": false,
+    "label": "Prospect Creek Airport (United States) (PAPR / PPC)"
+  },
+  {
+    "id": "KHW",
+    "british": false,
+    "label": "Khwai River Lodge Airport (Botswana) (FBKR / KHW)"
+  },
+  {
+    "id": "EDCY",
+    "british": false,
+    "label": "Spremberg-Welzow Airport (Germany) (EDCY)"
+  },
+  {
+    "id": "TXG",
+    "british": false,
+    "label": "Taichung Airport (Taiwan) (RCLG / TXG)"
+  },
+  {
+    "id": "HLG",
+    "british": false,
+    "label": "Wheeling Ohio County Airport (United States) (KHLG / HLG)"
+  },
+  {
+    "id": "KFZG",
+    "british": false,
+    "label": "Fitzgerald Municipal Airport (United States) (KFZG)"
+  },
+  {
+    "id": "XYE",
+    "british": false,
+    "label": "Ye Airport (Burma) (VYYE / XYE)"
+  },
+  {
+    "id": "SCFX",
+    "british": false,
+    "label": "Isla San Felix Airport (Chile) (SCFX)"
+  },
+  {
+    "id": "OESB",
+    "british": false,
+    "label": "Shaibah Airport (Saudi Arabia) (OESB)"
+  },
+  {
+    "id": "DWC",
+    "british": false,
+    "label": "Al Maktoum International Airport (United Arab Emirates) (OMDW / DWC)"
+  },
+  {
+    "id": "RKP",
+    "british": false,
+    "label": "Aransas County Airport (United States) (KRKP / RKP)"
+  },
+  {
+    "id": "MVV",
+    "british": false,
+    "label": "Megève Airport (France) (LFHM / MVV)"
+  },
+  {
+    "id": "MFX",
+    "british": false,
+    "label": "Méribel Altiport (France) (LFKX / MFX)"
+  },
+  {
+    "id": "AEB",
+    "british": false,
+    "label": "Baise Youjiang Airport (China) (ZGBS / AEB)"
+  },
+  {
+    "id": "OKF",
+    "british": false,
+    "label": "Okaukuejo Airport (Namibia) (FYOO / OKF)"
+  },
+  {
+    "id": "OKU",
+    "british": false,
+    "label": "Mokuti Lodge Airport (Namibia) (FYMO / OKU)"
+  },
+  {
+    "id": "EDXQ",
+    "british": false,
+    "label": "Rotenburg (Wümme) Airport (Germany) (EDXQ)"
+  },
+  {
+    "id": "EDKN",
+    "british": false,
+    "label": "Wipperfürth-Neye Airport (Germany) (EDKN)"
+  },
+  {
+    "id": "EDWO",
+    "british": false,
+    "label": "Osnabrück-Atterheide Airport (Germany) (EDWO)"
+  },
+  {
+    "id": "EDCB",
+    "british": false,
+    "label": "Flugplatz Ballenstedt (Germany) (EDCB)"
+  },
+  {
+    "id": "EDHM",
+    "british": false,
+    "label": "Flugplatz Hartenholm (Germany) (EDHM)"
+  },
+  {
+    "id": "EDWQ",
+    "british": false,
+    "label": "Ganderkesee Atlas Airfield (Germany) (EDWQ)"
+  },
+  {
+    "id": "EDXI",
+    "british": false,
+    "label": "Nienburg-Holzbalge Airport (Germany) (EDXI)"
+  },
+  {
+    "id": "EDWC",
+    "british": false,
+    "label": "Damme Airfield (Germany) (EDWC)"
+  },
+  {
+    "id": "EDLB",
+    "british": false,
+    "label": "Borkenberge Airport (Germany) (EDLB)"
+  },
+  {
+    "id": "EDCO",
+    "british": false,
+    "label": "Obermehler-Schlotheim Airport (Germany) (EDCO)"
+  },
+  {
+    "id": "EDVH",
+    "british": false,
+    "label": "Hodenhagen Airport (Germany) (EDVH)"
+  },
+  {
+    "id": "EDHB",
+    "british": false,
+    "label": "Grube Airport (Germany) (EDHB)"
+  },
+  {
+    "id": "EKTD",
+    "british": false,
+    "label": "Tønder Airport (Denmark) (EKTD)"
+  },
+  {
+    "id": "EDVC",
+    "british": false,
+    "label": "Celle-Arloh Airport (Germany) (EDVC)"
+  },
+  {
+    "id": "EDVU",
+    "british": false,
+    "label": "Uelzen Airport (Germany) (EDVU)"
+  },
+  {
+    "id": "EDLH",
+    "british": false,
+    "label": "Hamm-Lippewiesen Airport (Germany) (EDLH)"
+  },
+  {
+    "id": "EDOJ",
+    "british": false,
+    "label": "Lüsse Airport (Germany) (EDOJ)"
+  },
+  {
+    "id": "EDVY",
+    "british": false,
+    "label": "Porta Westfalica Airport (Germany) (EDVY)"
+  },
+  {
+    "id": "EDKO",
+    "british": false,
+    "label": "Brilon/Hochsauerlandkreis Airfield (Germany) (EDKO)"
+  },
+  {
+    "id": "EDVW",
+    "british": false,
+    "label": "Hameln-Pyrmont Airport (Germany) (EDVW)"
+  },
+  {
+    "id": "EDXN",
+    "british": false,
+    "label": "Nordholz-Spieka Airfield (Germany) (EDXN)"
+  },
+  {
+    "id": "KOQ",
+    "british": false,
+    "label": "Köthen Airport (Germany) (EDCK / KOQ)"
+  },
+  {
+    "id": "EDXM",
+    "british": false,
+    "label": "St. Michaelisdonn Airport (Germany) (EDXM)"
+  },
+  {
+    "id": "EDVS",
+    "british": false,
+    "label": "Salzgitter-Drütte Airport (Germany) (EDVS)"
+  },
+  {
+    "id": "EDWK",
+    "british": false,
+    "label": "Karlshöfen Airport (Germany) (EDWK)"
+  },
+  {
+    "id": "EDWH",
+    "british": false,
+    "label": "Oldenburg-Hatten Airfield (Germany) (EDWH)"
+  },
+  {
+    "id": "EDVR",
+    "british": false,
+    "label": "Rinteln Airport (Germany) (EDVR)"
+  },
+  {
+    "id": "EDLT",
+    "british": false,
+    "label": "Münster-Telgte Airport (Germany) (EDLT)"
+  },
+  {
+    "id": "PSH",
+    "british": false,
+    "label": "St. Peter-Ording Airport (Germany) (EDXO / PSH)"
+  },
+  {
+    "id": "EDHC",
+    "british": false,
+    "label": "Lüchow-Rehbeck Airport (Germany) (EDHC)"
+  },
+  {
+    "id": "EDCL",
+    "british": false,
+    "label": "Klietz/Scharlibbe Airport (Germany) (EDCL)"
+  },
+  {
+    "id": "EDBG",
+    "british": false,
+    "label": "Burg Airport (Germany) (EDBG)"
+  },
+  {
+    "id": "KCKF",
+    "british": false,
+    "label": "Crisp County Cordele Airport (United States) (KCKF)"
+  },
+  {
+    "id": "KOMN",
+    "british": false,
+    "label": "Ormond Beach Municipal Airport (United States) (KOMN)"
+  },
+  {
+    "id": "EDRA",
+    "british": false,
+    "label": "Bad Neuenahr-Ahrweiler Airfield (Germany) (EDRA)"
+  },
+  {
+    "id": "EDRF",
+    "british": false,
+    "label": "Bad Dürkheim Airport (Germany) (EDRF)"
+  },
+  {
+    "id": "TTD",
+    "british": false,
+    "label": "Portland Troutdale Airport (United States) (KTTD / TTD)"
+  },
+  {
+    "id": "HIO",
+    "british": false,
+    "label": "Portland Hillsboro Airport (United States) (KHIO / HIO)"
+  },
+  {
+    "id": "NK39",
+    "british": false,
+    "label": "One Police Plaza Heliport (United States) (NK39)"
+  },
+  {
+    "id": "EDKL",
+    "british": false,
+    "label": "Leverkusen Airport (Germany) (EDKL)"
+  },
+  {
+    "id": "EDRV",
+    "british": false,
+    "label": "Wershofen/Eifel Airfield (Germany) (EDRV)"
+  },
+  {
+    "id": "KHT",
+    "british": false,
+    "label": "Khost Airport (Afghanistan) (OAKS / KHT)"
+  },
+  {
+    "id": "NMT",
+    "british": false,
+    "label": "Namtu Airport (Burma) (VYNT / NMT)"
+  },
+  {
+    "id": "KBDN",
+    "british": false,
+    "label": "Bend Municipal Airport (United States) (KBDN)"
+  },
+  {
+    "id": "K62S",
+    "british": false,
+    "label": "Christmas Valley Airport (United States) (K62S)"
+  },
+  {
+    "id": "BNO",
+    "british": false,
+    "label": "Burns Municipal Airport (United States) (KBNO / BNO)"
+  },
+  {
+    "id": "PRZ",
+    "british": false,
+    "label": "Prineville Airport (United States) (KS39 / PRZ)"
+  },
+  {
+    "id": "RBL",
+    "british": false,
+    "label": "Red Bluff Municipal Airport (United States) (KRBL / RBL)"
+  },
+  {
+    "id": "NOT",
+    "british": false,
+    "label": "Marin County Airport - Gnoss Field (United States) (KDVO / NOT)"
+  },
+  {
+    "id": "LKV",
+    "british": false,
+    "label": "Lake County Airport (United States) (KLKV / LKV)"
+  },
+  {
+    "id": "OTK",
+    "british": false,
+    "label": "Tillamook Airport (United States) (KTMK / OTK)"
+  },
+  {
+    "id": "ONO",
+    "british": false,
+    "label": "Ontario Municipal Airport (United States) (KONO / ONO)"
+  },
+  {
+    "id": "DLS",
+    "british": false,
+    "label": "Columbia Gorge Regional the Dalles Municipal Airport (United States) (KDLS / DLS)"
+  },
+  {
+    "id": "GAI",
+    "british": false,
+    "label": "Montgomery County Airpark (United States) (KGAI / GAI)"
+  },
+  {
+    "id": "OAS",
+    "british": false,
+    "label": "Sharana Airstrip (Afghanistan) (OASA / OAS)"
+  },
+  {
+    "id": "YTA",
+    "british": false,
+    "label": "Pembroke Airport (Canada) (CYTA / YTA)"
+  },
+  {
+    "id": "TSB",
+    "british": false,
+    "label": "Tsumeb Airport (Namibia) (FYTM / TSB)"
+  },
+  {
+    "id": "YSD",
+    "british": false,
+    "label": "Suffield Heliport (Canada) (CYSD / YSD)"
+  },
+  {
+    "id": "BNU",
+    "british": false,
+    "label": "Blumenau Airport (Brazil) (SSBL / BNU)"
+  },
+  {
+    "id": "UUDG",
+    "british": false,
+    "label": "Bolshoye Gryzlovo Airfield (Russia) (UUDG)"
+  },
+  {
+    "id": "KCVX",
+    "british": false,
+    "label": "Charlevoix Municipal Airport (United States) (KCVX)"
+  },
+  {
+    "id": "EKMS",
+    "british": false,
+    "label": "Mykines Heliport (Faroe Islands) (EKMS)"
+  },
+  {
+    "id": "YCC",
+    "british": false,
+    "label": "Cornwall Regional Airport (Canada) (CYCC / YCC)"
+  },
+  {
+    "id": "EHSE",
+    "british": false,
+    "label": "Seppe Airfield (Netherlands) (EHSE)"
+  },
+  {
+    "id": "LSTS",
+    "british": false,
+    "label": "St Stephan Airport (Switzerland) (LSTS)"
+  },
+  {
+    "id": "IZA",
+    "british": false,
+    "label": "Zona da Mata Regional Airport (Brazil) (SDZY / IZA)"
+  },
+  {
+    "id": "LRBG",
+    "british": false,
+    "label": "IAR Gimbav Heliport (Romania) (LRBG)"
+  },
+  {
+    "id": "KXFL",
+    "british": false,
+    "label": "Flagler Executive Airport (United States) (KXFL)"
+  },
+  {
+    "id": "MVL",
+    "british": false,
+    "label": "Morrisville Stowe State Airport (United States) (KMVL / MVL)"
+  },
+  {
+    "id": "RBD",
+    "british": false,
+    "label": "Dallas Executive Airport (United States) (KRBD / RBD)"
+  },
+  {
+    "id": "LILY",
+    "british": false,
+    "label": "Como (Idroscalo - Water Ad) Hidroport (Italy) (LILY)"
+  },
+  {
+    "id": "BXY",
+    "british": false,
+    "label": "Krainiy Airport (Kazakhstan) (UAOL / BXY)"
+  },
+  {
+    "id": "WST",
+    "british": false,
+    "label": "Westerly State Airport (United States) (KWST / WST)"
+  },
+  {
+    "id": "BID",
+    "british": false,
+    "label": "Block Island State Airport (United States) (KBID / BID)"
+  },
+  {
+    "id": "NME",
+    "british": false,
+    "label": "Nightmute Airport (United States) (PAGT / NME)"
+  },
+  {
+    "id": "OOK",
+    "british": false,
+    "label": "Toksook Bay Airport (United States) (PAOO / OOK)"
+  },
+  {
+    "id": "OBY",
+    "british": false,
+    "label": "Ittoqqortoormiit Heliport (Greenland) (BGSC / OBY)"
+  },
+  {
+    "id": "VIN",
+    "british": false,
+    "label": "Vinnytsia/Gavyryshivka Airport (Ukraine) (UKWW / VIN)"
+  },
+  {
+    "id": "BGE",
+    "british": false,
+    "label": "Decatur County Industrial Air Park (United States) (KBGE / BGE)"
+  },
+  {
+    "id": "ZGS",
+    "british": false,
+    "label": "La Romaine Airport (Canada) (CTT5 / ZGS)"
+  },
+  {
+    "id": "ZKG",
+    "british": false,
+    "label": "Kegaska Airport (Canada) (CTK6 / ZKG)"
+  },
+  {
+    "id": "YBI",
+    "british": false,
+    "label": "Black Tickle Airport (Canada) (CCE4 / YBI)"
+  },
+  {
+    "id": "KSPZ",
+    "british": false,
+    "label": "Silver Springs Airport (United States) (KSPZ)"
+  },
+  {
+    "id": "WHP",
+    "british": false,
+    "label": "Whiteman Airport (United States) (KWHP / WHP)"
+  },
+  {
+    "id": "MAE",
+    "british": false,
+    "label": "Madera Municipal Airport (United States) (KMAE / MAE)"
+  },
+  {
+    "id": "YZZ",
+    "british": false,
+    "label": "Trail Airport (Canada) (CAD4 / YZZ)"
+  },
+  {
+    "id": "CAP5",
+    "british": false,
+    "label": "Victoria Airport (Canada) (CAP5)"
+  },
+  {
+    "id": "YAB",
+    "british": false,
+    "label": "Old Arctic Bay Airport (Canada) (CJX7 / YAB)"
+  },
+  {
+    "id": "PABV",
+    "british": false,
+    "label": "Birchwood Airport (Belize) (PABV)"
+  },
+  {
+    "id": "GSI",
+    "british": false,
+    "label": "Grand-Santi Airport (French Guiana) (SOGS / GSI)"
+  },
+  {
+    "id": "MPY",
+    "british": false,
+    "label": "Maripasoula Airport (French Guiana) (SOOA / MPY)"
+  },
+  {
+    "id": "LDX",
+    "british": false,
+    "label": "Saint-Laurent-du-Maroni Airport (French Guiana) (SOOM / LDX)"
+  },
+  {
+    "id": "KJI",
+    "british": false,
+    "label": "Kanas Airport (China) (ZWKN / KJI)"
+  },
+  {
+    "id": "CPB",
+    "british": false,
+    "label": "Capurganá Airport (Colombia) (SKCA / CPB)"
+  },
+  {
+    "id": "HMB",
+    "british": false,
+    "label": "Sohag International Airport (Egypt) (HEMK / HMB)"
+  },
+  {
+    "id": "RVY",
+    "british": false,
+    "label": "Presidente General Don Oscar D. Gestido International Airport (Uruguay) (SURV / RVY)"
+  },
+  {
+    "id": "POJ",
+    "british": false,
+    "label": "Patos de Minas Airport (Brazil) (SNPD / POJ)"
+  },
+  {
+    "id": "JTC",
+    "british": false,
+    "label": "Bauru - Arealva Airport (Brazil) (SJTC / JTC)"
+  },
+  {
+    "id": "OIA",
+    "british": false,
+    "label": "Ourilândia do Norte Airport (Brazil) (SDOW / OIA)"
+  },
+  {
+    "id": "RDC",
+    "british": false,
+    "label": "Redenção Airport (Brazil) (SNDC / RDC)"
+  },
+  {
+    "id": "SXX",
+    "british": false,
+    "label": "São Félix do Xingu Airport (Brazil) (SNFX / SXX)"
+  },
+  {
+    "id": "BYO",
+    "british": false,
+    "label": "Bonito Airport (Brazil) (SJDB / BYO)"
+  },
+  {
+    "id": "SXO",
+    "british": false,
+    "label": "São Félix do Araguaia Airport (Brazil) (SWFX / SXO)"
+  },
+  {
+    "id": "CFC",
+    "british": false,
+    "label": "Caçador Airport (Brazil) (SBCD / CFC)"
+  },
+  {
+    "id": "CAF",
+    "british": false,
+    "label": "Carauari Airport (Brazil) (SWCA / CAF)"
+  },
+  {
+    "id": "SWUY",
+    "british": false,
+    "label": "Urucu Airport (Brazil) (SWUY)"
+  },
+  {
+    "id": "ERN",
+    "british": false,
+    "label": "Eirunepé Airport (Brazil) (SWEI / ERN)"
+  },
+  {
+    "id": "CCI",
+    "british": false,
+    "label": "Concórdia Airport (Brazil) (SSCK / CCI)"
+  },
+  {
+    "id": "FBE",
+    "british": false,
+    "label": "Francisco Beltrão Airport (Brazil) (SSFB / FBE)"
+  },
+  {
+    "id": "CFO",
+    "british": false,
+    "label": "Confresa Airport (Brazil) (SJHG / CFO)"
+  },
+  {
+    "id": "AAF",
+    "british": false,
+    "label": "Apalachicola Regional Airport (United States) (KAAF / AAF)"
+  },
+  {
+    "id": "UMU",
+    "british": false,
+    "label": "Umuarama Airport (Brazil) (SSUM / UMU)"
+  },
+  {
+    "id": "DTI",
+    "british": false,
+    "label": "Diamantina Airport (Brazil) (SNDT / DTI)"
+  },
+  {
+    "id": "FBA",
+    "british": false,
+    "label": "Fonte Boa Airport (Brazil) (SWOB / FBA)"
+  },
+  {
+    "id": "OLC",
+    "british": false,
+    "label": "Senadora Eunice Micheles Airport (Brazil) (SDCG / OLC)"
+  },
+  {
+    "id": "HUW",
+    "british": false,
+    "label": "Humaitá Airport (Brazil) (SWHT / HUW)"
+  },
+  {
+    "id": "IRZ",
+    "british": false,
+    "label": "Tapuruquara Airport (Brazil) (SWTP / IRZ)"
+  },
+  {
+    "id": "ORX",
+    "british": false,
+    "label": "Oriximiná Airport (Brazil) (SNOX / ORX)"
+  },
+  {
+    "id": "UNA",
+    "british": false,
+    "label": "Hotel Transamérica Airport (Brazil) (SBTC / UNA)"
+  },
+  {
+    "id": "TEF",
+    "british": false,
+    "label": "Telfer Airport (Australia) (YTEF / TEF)"
+  },
+  {
+    "id": "GZP",
+    "british": false,
+    "label": "Gazipaşa Airport (Turkey) (LTGP / GZP)"
+  },
+  {
+    "id": "OAA",
+    "british": false,
+    "label": "Shank Air Base (Afghanistan) (OASH / OAA)"
+  },
+  {
+    "id": "KDQH",
+    "british": false,
+    "label": "Douglas Municipal Airport (United States) (KDQH)"
+  },
+  {
+    "id": "FPR",
+    "british": false,
+    "label": "St Lucie County International Airport (United States) (KFPR / FPR)"
+  },
+  {
+    "id": "KTAN",
+    "british": false,
+    "label": "Taunton Municipal King Field (United States) (KTAN)"
+  },
+  {
+    "id": "PYM",
+    "british": false,
+    "label": "Plymouth Municipal Airport (United States) (KPYM / PYM)"
+  },
+  {
+    "id": "NCO",
+    "british": false,
+    "label": "Quonset State Airport (United States) (KOQU / NCO)"
+  },
+  {
+    "id": "OWD",
+    "british": false,
+    "label": "Norwood Memorial Airport (United States) (KOWD / OWD)"
+  },
+  {
+    "id": "BAF",
+    "british": false,
+    "label": "Westfield-Barnes Regional Airport (United States) (KBAF / BAF)"
+  },
+  {
+    "id": "KIJD",
+    "british": false,
+    "label": "Windham Airport (United States) (KIJD)"
+  },
+  {
+    "id": "MGJ",
+    "british": false,
+    "label": "Orange County Airport (United States) (KMGJ / MGJ)"
+  },
+  {
+    "id": "HAR",
+    "british": false,
+    "label": "Capital City Airport (United States) (KCXY / HAR)"
+  },
+  {
+    "id": "KGHG",
+    "british": false,
+    "label": "Marshfield Municipal George Harlow Field (United States) (KGHG)"
+  },
+  {
+    "id": "DXR",
+    "british": false,
+    "label": "Danbury Municipal Airport (United States) (KDXR / DXR)"
+  },
+  {
+    "id": "ASH",
+    "british": false,
+    "label": "Boire Field (United States) (KASH / ASH)"
+  },
+  {
+    "id": "LWM",
+    "british": false,
+    "label": "Lawrence Municipal Airport (United States) (KLWM / LWM)"
+  },
+  {
+    "id": "OXC",
+    "british": false,
+    "label": "Waterbury Oxford Airport (United States) (KOXC / OXC)"
+  },
+  {
+    "id": "KFIT",
+    "british": false,
+    "label": "Fitchburg Municipal Airport (United States) (KFIT)"
+  },
+  {
+    "id": "20GA",
+    "british": false,
+    "label": "Earl L. Small Jr. Field/Stockmar Airport (United States) (20GA)"
+  },
+  {
+    "id": "KVPC",
+    "british": false,
+    "label": "Cartersville Airport (United States) (KVPC)"
+  },
+  {
+    "id": "KPYP",
+    "british": false,
+    "label": "Centre-Piedmont-Cherokee County Regional Airport (United States) (KPYP)"
+  },
+  {
+    "id": "RMG",
+    "british": false,
+    "label": "Richard B Russell Airport (United States) (KRMG / RMG)"
+  },
+  {
+    "id": "GAD",
+    "british": false,
+    "label": "Northeast Alabama Regional Airport (United States) (KGAD / GAD)"
+  },
+  {
+    "id": "KDKX",
+    "british": false,
+    "label": "Knoxville Downtown Island Airport (United States) (KDKX)"
+  },
+  {
+    "id": "WDR",
+    "british": false,
+    "label": "Barrow County Airport (United States) (KWDR / WDR)"
+  },
+  {
+    "id": "KJYL",
+    "british": false,
+    "label": "Plantation Airpark (United States) (KJYL)"
+  },
+  {
+    "id": "DNN",
+    "british": false,
+    "label": "Dalton Municipal Airport (United States) (KDNN / DNN)"
+  },
+  {
+    "id": "KCTJ",
+    "british": false,
+    "label": "West Georgia Regional O V Gray Field (United States) (KCTJ)"
+  },
+  {
+    "id": "LGC",
+    "british": false,
+    "label": "LaGrange Callaway Airport (United States) (KLGC / LGC)"
+  },
+  {
+    "id": "KMLJ",
+    "british": false,
+    "label": "Baldwin County Regional Airport (United States) (KMLJ)"
+  },
+  {
+    "id": "PIM",
+    "british": false,
+    "label": "Harris County Airport (United States) (KPIM / PIM)"
+  },
+  {
+    "id": "KFFC",
+    "british": false,
+    "label": "Peachtree City Falcon Field (United States) (KFFC)"
+  },
+  {
+    "id": "GVL",
+    "british": false,
+    "label": "Lee Gilmer Memorial Airport (United States) (KGVL / GVL)"
+  },
+  {
+    "id": "PHD",
+    "british": false,
+    "label": "Harry Clever Field (United States) (KPHD / PHD)"
+  },
+  {
+    "id": "KUDG",
+    "british": false,
+    "label": "Darlington County Airport (United States) (KUDG)"
+  },
+  {
+    "id": "HHH",
+    "british": false,
+    "label": "Hilton Head Airport (United States) (KHXD / HHH)"
+  },
+  {
+    "id": "DNL",
+    "british": false,
+    "label": "Daniel Field (United States) (KDNL / DNL)"
+  },
+  {
+    "id": "MRN",
+    "british": false,
+    "label": "Foothills Regional Airport (United States) (KMRN / MRN)"
+  },
+  {
+    "id": "PVL",
+    "british": false,
+    "label": "Pike County-Hatcher Field (United States) (KPBX / PVL)"
+  },
+  {
+    "id": "GA04",
+    "british": false,
+    "label": "Mallards Landing Airport (United States) (GA04)"
+  },
+  {
+    "id": "TOC",
+    "british": false,
+    "label": "Toccoa Airport - R.G. Letourneau Field (United States) (KTOC / TOC)"
+  },
+  {
+    "id": "EGHA",
+    "british": true,
+    "label": "Compton Abbas Aerodrome (United Kingdom) (EGHA)"
+  },
+  {
+    "id": "PLV",
+    "british": false,
+    "label": "Suprunovka Airport (Ukraine) (UKHP / PLV)"
+  },
+  {
+    "id": "HSAW",
+    "british": false,
+    "label": "Aweil Airport (Sudan) (HSAW)"
+  },
+  {
+    "id": "WUU",
+    "british": false,
+    "label": "Wau Airport (Sudan) (HSWW / WUU)"
+  },
+  {
+    "id": "HUE",
+    "british": false,
+    "label": "Humera Airport (Ethiopia) (HAHU / HUE)"
+  },
+  {
+    "id": "OYL",
+    "british": false,
+    "label": "Moyale Airport (Kenya) (HKMY / OYL)"
+  },
+  {
+    "id": "OZG",
+    "british": false,
+    "label": "Zagora Airport (Morocco) (GMAZ / OZG)"
+  },
+  {
+    "id": "WYE",
+    "british": false,
+    "label": "Yengema Airport (Sierra Leone) (GFYE / WYE)"
+  },
+  {
+    "id": "GBK",
+    "british": false,
+    "label": "Gbangbatok Airport (Sierra Leone) (GFGK / GBK)"
+  },
+  {
+    "id": "THX",
+    "british": false,
+    "label": "Turukhansk Airport (Russia) (UOTT / THX)"
+  },
+  {
+    "id": "TGP",
+    "british": false,
+    "label": "Podkamennaya Tunguska Airport (Russia) (UNIP / TGP)"
+  },
+  {
+    "id": "AFW",
+    "british": false,
+    "label": "Fort Worth Alliance Airport (United States) (KAFW / AFW)"
+  },
+  {
+    "id": "K57C",
+    "british": false,
+    "label": "East Troy Municipal Airport (United States) (K57C)"
+  },
+  {
+    "id": "UNLL",
+    "british": false,
+    "label": "Kolpashevo Airport (Russia) (UNLL)"
+  },
+  {
+    "id": "OKAS",
+    "british": false,
+    "label": "Ali Al Salem Air Base (Kuwait) (OKAS)"
+  },
+  {
+    "id": "RMK",
+    "british": false,
+    "label": "Renmark Airport (Australia) (YREN / RMK)"
+  },
+  {
+    "id": "LGH",
+    "british": false,
+    "label": "Leigh Creek Airport (Australia) (YLEC / LGH)"
+  },
+  {
+    "id": "YWBR",
+    "british": false,
+    "label": "Warburton Airport (Australia) (YWBR)"
+  },
+  {
+    "id": "YCUN",
+    "british": false,
+    "label": "Cunderdin Airport (Australia) (YCUN)"
+  },
+  {
+    "id": "RTS",
+    "british": false,
+    "label": "Rottnest Island Airport (Australia) (YRTI / RTS)"
+  },
+  {
+    "id": "FOS",
+    "british": false,
+    "label": "Forrest Airport (Australia) (YFRT / FOS)"
+  },
+  {
+    "id": "YBLT",
+    "british": false,
+    "label": "Ballarat Airport (Australia) (YBLT)"
+  },
+  {
+    "id": "KEW",
+    "british": false,
+    "label": "Keewaywin Airport (Canada) (CPV8 / KEW)"
+  },
+  {
+    "id": "YSP",
+    "british": false,
+    "label": "Marathon Airport (Canada) (CYSP / YSP)"
+  },
+  {
+    "id": "YHF",
+    "british": false,
+    "label": "Hearst René Fontaine Municipal Airport (Canada) (CYHF / YHF)"
+  },
+  {
+    "id": "YHN",
+    "british": false,
+    "label": "Hornepayne Municipal Airport (Canada) (CYHN / YHN)"
+  },
+  {
+    "id": "YKX",
+    "british": false,
+    "label": "Kirkland Lake Airport (Canada) (CYKX / YKX)"
+  },
+  {
+    "id": "YMG",
+    "british": false,
+    "label": "Manitouwadge Airport (Canada) (CYMG / YMG)"
+  },
+  {
+    "id": "YXZ",
+    "british": false,
+    "label": "Wawa Airport (Canada) (CYXZ / YXZ)"
+  },
+  {
+    "id": "YEM",
+    "british": false,
+    "label": "Manitoulin East Municipal Airport (Canada) (CYEM / YEM)"
+  },
+  {
+    "id": "CKD9",
+    "british": false,
+    "label": "Slate Falls Airport (Canada) (CKD9)"
+  },
+  {
+    "id": "CNY3",
+    "british": false,
+    "label": "Collingwood Airport (Canada) (CNY3)"
+  },
+  {
+    "id": "CYFD",
+    "british": false,
+    "label": "Brantford Municipal Airport (Canada) (CYFD)"
+  },
+  {
+    "id": "LWC",
+    "british": false,
+    "label": "Lawrence Municipal Airport (United States) (KLWC / LWC)"
+  },
+  {
+    "id": "KEGT",
+    "british": false,
+    "label": "Wellington Municipal Airport (United States) (KEGT)"
+  },
+  {
+    "id": "PPM",
+    "british": false,
+    "label": "Pompano Beach Airpark (United States) (KPMP / PPM)"
+  },
+  {
+    "id": "XMC",
+    "british": false,
+    "label": "Mallacoota Airport (Australia) (YMCO / XMC)"
+  },
+  {
+    "id": "ULH",
+    "british": false,
+    "label": "Majeed Bin Abdulaziz Airport (Saudi Arabia) (OEAO / ULH)"
+  },
+  {
+    "id": "KEET",
+    "british": false,
+    "label": "Shelby County Airport (United States) (KEET)"
+  },
+  {
+    "id": "YUE",
+    "british": false,
+    "label": "Yuendumu Airport (Australia) (YYND / YUE)"
+  },
+  {
+    "id": "18AZ",
+    "british": false,
+    "label": "Sky Ranch At Carefree Airport (United States) (18AZ)"
+  },
+  {
+    "id": "LOP",
+    "british": false,
+    "label": "Lombok International Airport (Indonesia) (WADL / LOP)"
+  },
+  {
+    "id": "CAV3",
+    "british": false,
+    "label": "One Hundred Mile House Airport (Canada) (CAV3)"
+  },
+  {
+    "id": "ZMH",
+    "british": false,
+    "label": "South Cariboo Region / 108 Mile Airport (Canada) (CZML / ZMH)"
+  },
+  {
+    "id": "EGEG",
+    "british": true,
+    "label": "Glasgow City Heliport (United Kingdom) (EGEG)"
+  },
+  {
+    "id": "YYRM",
+    "british": false,
+    "label": "Yarram Airport (Australia) (YYRM)"
+  },
+  {
+    "id": "HDG",
+    "british": false,
+    "label": "Handan Airport (China) (ZBHD / HDG)"
+  },
+  {
+    "id": "KUMP",
+    "british": false,
+    "label": "Indianapolis Metropolitan Airport (United States) (KUMP)"
+  },
+  {
+    "id": "LOZ",
+    "british": false,
+    "label": "London-Corbin Airport/Magee Field (United States) (KLOZ / LOZ)"
+  },
+  {
+    "id": "FBG",
+    "british": false,
+    "label": "Simmons Army Air Field (United States) (KFBG / FBG)"
+  },
+  {
+    "id": "WMI",
+    "british": false,
+    "label": "Modlin Airport (Poland) (EPMO / WMI)"
+  },
+  {
+    "id": "JXA",
+    "british": false,
+    "label": "Jixi Xingkaihu Airport (China) (ZYJX / JXA)"
+  },
+  {
+    "id": "JDG",
+    "british": false,
+    "label": "Jeongseok Airport (South Korea) (RKPD / JDG)"
+  },
+  {
+    "id": "YGM",
+    "british": false,
+    "label": "Gimli Industrial Park Airport (Canada) (CYGM / YGM)"
+  },
+  {
+    "id": "CJT2",
+    "british": false,
+    "label": "Matheson Island Airport (Canada) (CJT2)"
+  },
+  {
+    "id": "UNIT",
+    "british": false,
+    "label": "Tura Mountain Airport (Russia) (UNIT)"
+  },
+  {
+    "id": "EYK",
+    "british": false,
+    "label": "Beloyarskiy Airport (Russia) (USHY / EYK)"
+  },
+  {
+    "id": "RAC",
+    "british": false,
+    "label": "John H Batten Airport (United States) (KRAC / RAC)"
+  },
+  {
+    "id": "RZP",
+    "british": false,
+    "label": "Cesar Lim Rodriguez Airport (Philippines) (RPSD / RZP)"
+  },
+  {
+    "id": "EDAJ",
+    "british": false,
+    "label": "Gera-Leumnitz Airfield (Germany) (EDAJ)"
+  },
+  {
+    "id": "XLLN",
+    "british": false,
+    "label": "Kasimovo Airfield (Russia) (XLLN)"
+  },
+  {
+    "id": "EHTL",
+    "british": false,
+    "label": "Terlet Glider Field (Netherlands) (EHTL)"
+  },
+  {
+    "id": "RKZ",
+    "british": false,
+    "label": "Shigatse Air Base (China) (ZURK / RKZ)"
+  },
+  {
+    "id": "KREI",
+    "british": false,
+    "label": "Redlands Municipal Airport (United States) (KREI)"
+  },
+  {
+    "id": "KRIR",
+    "british": false,
+    "label": "Flabob Airport (United States) (KRIR)"
+  },
+  {
+    "id": "TIW",
+    "british": false,
+    "label": "Tacoma Narrows Airport (United States) (KTIW / TIW)"
+  },
+  {
+    "id": "EDLO",
+    "british": false,
+    "label": "Oerlinghausen Airport (Germany) (EDLO)"
+  },
+  {
+    "id": "GUF",
+    "british": false,
+    "label": "Jack Edwards Airport (United States) (KJKA / GUF)"
+  },
+  {
+    "id": "IBB",
+    "british": false,
+    "label": "General Villamil Airport (Ecuador) (SEII / IBB)"
+  },
+  {
+    "id": "LSXB",
+    "british": false,
+    "label": "Balzers Heliport (Switzerland) (LSXB)"
+  },
+  {
+    "id": "LOGG",
+    "british": false,
+    "label": "Flugplatz Punitz (Austria) (LOGG)"
+  },
+  {
+    "id": "HMJ",
+    "british": false,
+    "label": "Khmelnytskyi Airport (Ukraine) (UKLH / HMJ)"
+  },
+  {
+    "id": "HIW",
+    "british": false,
+    "label": "Hiroshimanishi Airport (Japan) (RJBH / HIW)"
+  },
+  {
+    "id": "KYI",
+    "british": false,
+    "label": "Yalata Mission Airport (Australia) (YYTA / KYI)"
+  },
+  {
+    "id": "HZL",
+    "british": false,
+    "label": "Hazleton Municipal Airport (United States) (KHZL / HZL)"
+  },
+  {
+    "id": "CBE",
+    "british": false,
+    "label": "Greater Cumberland Regional Airport (United States) (KCBE / CBE)"
+  },
+  {
+    "id": "7FA1",
+    "british": false,
+    "label": "Sugar Loaf Shores Airport (United States) (7FA1)"
+  },
+  {
+    "id": "WYN",
+    "british": false,
+    "label": "Wyndham Airport (Australia) (YWYM / WYN)"
+  },
+  {
+    "id": "YBO",
+    "british": false,
+    "label": "Bob Quinn Lake Airport (Canada) (CBW4 / YBO)"
+  },
+  {
+    "id": "HTMR",
+    "british": false,
+    "label": "Msembe Airport (Tanzania) (HTMR)"
+  },
+  {
+    "id": "KLF",
+    "british": false,
+    "label": "Grabtsevo Airport (Russia) (UUBC / KLF)"
+  },
+  {
+    "id": "LNR",
+    "british": false,
+    "label": "Tri-County Regional Airport (United States) (KLNR / LNR)"
+  },
+  {
+    "id": "KPBH",
+    "british": false,
+    "label": "Price County Airport (United States) (KPBH)"
+  },
+  {
+    "id": "KEFT",
+    "british": false,
+    "label": "Monroe Municipal Airport (United States) (KEFT)"
+  },
+  {
+    "id": "JOT",
+    "british": false,
+    "label": "Joliet Regional Airport (United States) (KJOT / JOT)"
+  },
+  {
+    "id": "VYS",
+    "british": false,
+    "label": "Illinois Valley Regional Airport-Walter A Duncan Field (United States) (KVYS / VYS)"
+  },
+  {
+    "id": "JXN",
+    "british": false,
+    "label": "Jackson County Reynolds Field (United States) (KJXN / JXN)"
+  },
+  {
+    "id": "EDAL",
+    "british": false,
+    "label": "Fuerstenwalde Airport (Germany) (EDAL)"
+  },
+  {
+    "id": "EDAV",
+    "british": false,
+    "label": "Eberswalde-Finow Airport (Germany) (EDAV)"
+  },
+  {
+    "id": "KVVS",
+    "british": false,
+    "label": "Joseph A. Hardy Connellsville Airport (United States) (KVVS)"
+  },
+  {
+    "id": "KHMZ",
+    "british": false,
+    "label": "Bedford County Airport (United States) (KHMZ)"
+  },
+  {
+    "id": "BBX",
+    "british": false,
+    "label": "Wings Field (United States) (KLOM / BBX)"
+  },
+  {
+    "id": "OBE",
+    "british": false,
+    "label": "Okeechobee County Airport (United States) (KOBE / OBE)"
+  },
+  {
+    "id": "SEF",
+    "british": false,
+    "label": "Sebring Regional Airport (United States) (KSEF / SEF)"
+  },
+  {
+    "id": "AVO",
+    "british": false,
+    "label": "Avon Park Executive Airport (United States) (KAVO / AVO)"
+  },
+  {
+    "id": "GIF",
+    "british": false,
+    "label": "Winter Haven Regional Airport - Gilbert Field (United States) (KGIF / GIF)"
+  },
+  {
+    "id": "ZPH",
+    "british": false,
+    "label": "Zephyrhills Municipal Airport (United States) (KZPH / ZPH)"
+  },
+  {
+    "id": "OCF",
+    "british": false,
+    "label": "Ocala International Airport - Jim Taylor Field (United States) (KOCF / OCF)"
+  },
+  {
+    "id": "KJES",
+    "british": false,
+    "label": "Jesup Wayne County Airport (United States) (KJES)"
+  },
+  {
+    "id": "K52A",
+    "british": false,
+    "label": "Madison Municipal Airport (United States) (K52A)"
+  },
+  {
+    "id": "KCCO",
+    "british": false,
+    "label": "Newnan Coweta County Airport (United States) (KCCO)"
+  },
+  {
+    "id": "KHQU",
+    "british": false,
+    "label": "Thomson-McDuffie County Airport (United States) (KHQU)"
+  },
+  {
+    "id": "AIK",
+    "british": false,
+    "label": "Aiken Regional Airport (United States) (KAIK / AIK)"
+  },
+  {
+    "id": "CDN",
+    "british": false,
+    "label": "Woodward Field (United States) (KCDN / CDN)"
+  },
+  {
+    "id": "LBT",
+    "british": false,
+    "label": "Lumberton Regional Airport (United States) (KLBT / LBT)"
+  },
+  {
+    "id": "SOP",
+    "british": false,
+    "label": "Moore County Airport (United States) (KSOP / SOP)"
+  },
+  {
+    "id": "KRCZ",
+    "british": false,
+    "label": "Richmond County Airport (United States) (KRCZ)"
+  },
+  {
+    "id": "KDLL",
+    "british": false,
+    "label": "Baraboo Wisconsin Dells Airport (United States) (KDLL)"
+  },
+  {
+    "id": "SVH",
+    "british": false,
+    "label": "Statesville Regional Airport (United States) (KSVH / SVH)"
+  },
+  {
+    "id": "KBUU",
+    "british": false,
+    "label": "Burlington Municipal Airport (United States) (KBUU)"
+  },
+  {
+    "id": "LHV",
+    "british": false,
+    "label": "William T. Piper Memorial Airport (United States) (KLHV / LHV)"
+  },
+  {
+    "id": "KPJC",
+    "british": false,
+    "label": "Zelienople Municipal Airport (United States) (KPJC)"
+  },
+  {
+    "id": "KLPR",
+    "british": false,
+    "label": "Lorain County Regional Airport (United States) (KLPR)"
+  },
+  {
+    "id": "BKL",
+    "british": false,
+    "label": "Burke Lakefront Airport (United States) (KBKL / BKL)"
+  },
+  {
+    "id": "DKK",
+    "british": false,
+    "label": "Chautauqua County-Dunkirk Airport (United States) (KDKK / DKK)"
+  },
+  {
+    "id": "LLY",
+    "british": false,
+    "label": "South Jersey Regional Airport (United States) (KVAY / LLY)"
+  },
+  {
+    "id": "LDJ",
+    "british": false,
+    "label": "Linden Airport (United States) (KLDJ / LDJ)"
+  },
+  {
+    "id": "ANQ",
+    "british": false,
+    "label": "Tri State Steuben County Airport (United States) (KANQ / ANQ)"
+  },
+  {
+    "id": "KASW",
+    "british": false,
+    "label": "Warsaw Municipal Airport (United States) (KASW)"
+  },
+  {
+    "id": "KVNW",
+    "british": false,
+    "label": "Van Wert County Airport (United States) (KVNW)"
+  },
+  {
+    "id": "KRMY",
+    "british": false,
+    "label": "Brooks Field (United States) (KRMY)"
+  },
+  {
+    "id": "KGVQ",
+    "british": false,
+    "label": "Genesee County Airport (United States) (KGVQ)"
+  },
+  {
+    "id": "CLW",
+    "british": false,
+    "label": "Clearwater Air Park (United States) (KCLW / CLW)"
+  },
+  {
+    "id": "FA08",
+    "british": true,
+    "label": "Orlampa Inc Airport (United Kingdom) (FA08)"
+  },
+  {
+    "id": "CGX",
+    "british": false,
+    "label": "Chicago Meigs Airport (United States) (KCGX / CGX)"
+  },
+  {
+    "id": "KJZP",
+    "british": false,
+    "label": "Pickens County Airport (United States) (KJZP)"
+  },
+  {
+    "id": "EDCS",
+    "british": false,
+    "label": "Saarmund Airport (Germany) (EDCS)"
+  },
+  {
+    "id": "CRE",
+    "british": false,
+    "label": "Grand Strand Airport (United States) (KCRE / CRE)"
+  },
+  {
+    "id": "KIGQ",
+    "british": false,
+    "label": "Lansing Municipal Airport (United States) (KIGQ)"
+  },
+  {
+    "id": "KRNM",
+    "british": false,
+    "label": "Ramona Airport (United States) (KRNM)"
+  },
+  {
+    "id": "LFGO",
+    "british": false,
+    "label": "Pont Sur Yonne Airfield (France) (LFGO)"
+  },
+  {
+    "id": "LFGP",
+    "british": false,
+    "label": "St Florentin Cheu Airfield (France) (LFGP)"
+  },
+  {
+    "id": "LFEW",
+    "british": false,
+    "label": "Saulieu Liernais Airfield (France) (LFEW)"
+  },
+  {
+    "id": "LSPO",
+    "british": false,
+    "label": "Olten Airport (Switzerland) (LSPO)"
+  },
+  {
+    "id": "BXO",
+    "british": false,
+    "label": "Buochs Airport (Switzerland) (LSZC / BXO)"
+  },
+  {
+    "id": "LSPM",
+    "british": false,
+    "label": "Ambri Airport (Switzerland) (LSPM)"
+  },
+  {
+    "id": "LSML",
+    "british": false,
+    "label": "Lodrino Air Base (Switzerland) (LSML)"
+  },
+  {
+    "id": "LKRO",
+    "british": false,
+    "label": "Roudnice Airport (Czech Republic) (LKRO)"
+  },
+  {
+    "id": "LKUL",
+    "british": false,
+    "label": "Usti Nad Labem Airfield (Czech Republic) (LKUL)"
+  },
+  {
+    "id": "LOSM",
+    "british": false,
+    "label": "Mauterndorf Airport (Austria) (LOSM)"
+  },
+  {
+    "id": "LOKN",
+    "british": false,
+    "label": "Nötsch Im Gailtal Airport (Austria) (LOKN)"
+  },
+  {
+    "id": "EDTK",
+    "british": false,
+    "label": "Sinsheim Airfield (Germany) (EDTK)"
+  },
+  {
+    "id": "EDGZ",
+    "british": false,
+    "label": "Weinheim/Bergstraße Airport (Germany) (EDGZ)"
+  },
+  {
+    "id": "LFPE",
+    "british": false,
+    "label": "Meaux Esbly Airport (France) (LFPE)"
+  },
+  {
+    "id": "LFFH",
+    "british": false,
+    "label": "Château-Thierry - Belleau Airfield (France) (LFFH)"
+  },
+  {
+    "id": "KOEB",
+    "british": false,
+    "label": "Branch County Memorial Airport (United States) (KOEB)"
+  },
+  {
+    "id": "WBW",
+    "british": false,
+    "label": "Wilkes Barre Wyoming Valley Airport (United States) (KWBW / WBW)"
+  },
+  {
+    "id": "LNN",
+    "british": false,
+    "label": "Willoughby Lost Nation Municipal Airport (United States) (KLNN / LNN)"
+  },
+  {
+    "id": "RCGM",
+    "british": false,
+    "label": "Taoyuan Air Base (Taiwan) (RCGM)"
+  },
+  {
+    "id": "UMD",
+    "british": false,
+    "label": "Uummannaq Heliport (Greenland) (BGUM / UMD)"
+  },
+  {
+    "id": "RLK",
+    "british": false,
+    "label": "Bayannur Tianjitai Airport (China) (ZBYZ / RLK)"
+  },
+  {
+    "id": "FFT",
+    "british": false,
+    "label": "Capital City Airport (United States) (KFFT / FFT)"
+  },
+  {
+    "id": "LEW",
+    "british": false,
+    "label": "Auburn Lewiston Municipal Airport (United States) (KLEW / LEW)"
+  },
+  {
+    "id": "EPIR",
+    "british": false,
+    "label": "Inowroclaw Military Air Base (Poland) (EPIR)"
+  },
+  {
+    "id": "EPPR",
+    "british": false,
+    "label": "Pruszcz Gdanski Air Base (Poland) (EPPR)"
+  },
+  {
+    "id": "KY72",
+    "british": false,
+    "label": "Bloyer Field (United States) (KY72)"
+  },
+  {
+    "id": "MRK",
+    "british": false,
+    "label": "Marco Island Executive Airport (United States) (KMKY / MRK)"
+  },
+  {
+    "id": "DRE",
+    "british": false,
+    "label": "Drummond Island Airport (United States) (KDRM / DRE)"
+  },
+  {
+    "id": "GDW",
+    "british": false,
+    "label": "Gladwin Zettel Memorial Airport (United States) (KGDW / GDW)"
+  },
+  {
+    "id": "KLWA",
+    "british": false,
+    "label": "South Haven Area Regional Airport (United States) (KLWA)"
+  },
+  {
+    "id": "MFI",
+    "british": false,
+    "label": "Marshfield Municipal Airport (United States) (KMFI / MFI)"
+  },
+  {
+    "id": "ISW",
+    "british": false,
+    "label": "Alexander Field South Wood County Airport (United States) (KISW / ISW)"
+  },
+  {
+    "id": "CWI",
+    "british": false,
+    "label": "Clinton Municipal Airport (United States) (KCWI / CWI)"
+  },
+  {
+    "id": "BVY",
+    "british": false,
+    "label": "Beverly Municipal Airport (United States) (KBVY / BVY)"
+  },
+  {
+    "id": "VI73",
+    "british": false,
+    "label": "Nagaur Airport (India) (VI73)"
+  },
+  {
+    "id": "OSF",
+    "british": false,
+    "label": "Ostafyevo International Airport (Russia) (UUMO / OSF)"
+  },
+  {
+    "id": "YRQ",
+    "british": false,
+    "label": "Trois-Rivières Airport (Canada) (CYRQ / YRQ)"
+  },
+  {
+    "id": "POF",
+    "british": false,
+    "label": "Poplar Bluff Municipal Airport (United States) (KPOF / POF)"
+  },
+  {
+    "id": "KSMQ",
+    "british": false,
+    "label": "Somerset Airport (United States) (KSMQ)"
+  },
+  {
+    "id": "KEPM",
+    "british": false,
+    "label": "Eastport Municipal Airport (United States) (KEPM)"
+  },
+  {
+    "id": "EOK",
+    "british": false,
+    "label": "Keokuk Municipal Airport (United States) (KEOK / EOK)"
+  },
+  {
+    "id": "PSL",
+    "british": true,
+    "label": "Perth/Scone Airport (United Kingdom) (EGPT / PSL)"
+  },
+  {
+    "id": "EGCK",
+    "british": true,
+    "label": "Caernarfon Airport (United Kingdom) (EGCK)"
+  },
+  {
+    "id": "EDLF",
+    "british": false,
+    "label": "Grefrath-Niershorst Airport (Germany) (EDLF)"
+  },
+  {
+    "id": "STP",
+    "british": false,
+    "label": "St Paul Downtown Holman Field (United States) (KSTP / STP)"
+  },
+  {
+    "id": "SOO",
+    "british": false,
+    "label": "Söderhamn Airport (Sweden) (ESNY / SOO)"
+  },
+  {
+    "id": "EINC",
+    "british": false,
+    "label": "Newcastle Aerodrome (Ireland) (EINC)"
+  },
+  {
+    "id": "VNA",
+    "british": false,
+    "label": "Saravane Airport (Laos) (VLSV / VNA)"
+  },
+  {
+    "id": "EDAI",
+    "british": false,
+    "label": "Segeletz Airport (Germany) (EDAI)"
+  },
+  {
+    "id": "LEFM",
+    "british": false,
+    "label": "Fuentemilanos Airport (Spain) (LEFM)"
+  },
+  {
+    "id": "RJOE",
+    "british": false,
+    "label": "Akeno Airport (Japan) (RJOE)"
+  },
+  {
+    "id": "UHPK",
+    "british": false,
+    "label": "Ust-Kamchatsk Airport (Russia) (UHPK)"
+  },
+  {
+    "id": "0WI8",
+    "british": false,
+    "label": "Oconomowoc Airport (United States) (0WI8)"
+  },
+  {
+    "id": "UHPO",
+    "british": false,
+    "label": "Kozyrevsk Airport (Russia) (UHPO)"
+  },
+  {
+    "id": "DKS",
+    "british": false,
+    "label": "Dikson Airport (Russia) (UODD / DKS)"
+  },
+  {
+    "id": "YBEE",
+    "british": false,
+    "label": "Beverley Airport (Australia) (YBEE)"
+  },
+  {
+    "id": "BYT",
+    "british": false,
+    "label": "Bantry Aerodrome (Ireland) (EIBN / BYT)"
+  },
+  {
+    "id": "FAAN",
+    "british": false,
+    "label": "Aliwal North Airport (South Africa) (FAAN)"
+  },
+  {
+    "id": "FACO",
+    "british": false,
+    "label": "Alkantpan Copper Airport (South Africa) (FACO)"
+  },
+  {
+    "id": "ADY",
+    "british": false,
+    "label": "Alldays Airport (South Africa) (FAAL / ADY)"
+  },
+  {
+    "id": "FABR",
+    "british": false,
+    "label": "Bredasdorp Airport (South Africa) (FABR)"
+  },
+  {
+    "id": "HAO",
+    "british": false,
+    "label": "Butler Co Regional Airport - Hogan Field (United States) (KHAO / HAO)"
+  },
+  {
+    "id": "HKBU",
+    "british": false,
+    "label": "Bungoma Airport (Kenya) (HKBU)"
+  },
+  {
+    "id": "HKBR",
+    "british": false,
+    "label": "Bura East Airport (Kenya) (HKBR)"
+  },
+  {
+    "id": "HKBA",
+    "british": false,
+    "label": "Busia Airport (Kenya) (HKBA)"
+  },
+  {
+    "id": "HKEM",
+    "british": false,
+    "label": "Embu Airport (Kenya) (HKEM)"
+  },
+  {
+    "id": "HKGT",
+    "british": false,
+    "label": "Garba Tula Airport (Kenya) (HKGT)"
+  },
+  {
+    "id": "GAS",
+    "british": false,
+    "label": "Garissa Airport (Kenya) (HKGA / GAS)"
+  },
+  {
+    "id": "HOA",
+    "british": false,
+    "label": "Hola Airport (Kenya) (HKHO / HOA)"
+  },
+  {
+    "id": "HKHB",
+    "british": false,
+    "label": "Homa Bay Airport (Kenya) (HKHB)"
+  },
+  {
+    "id": "HKIS",
+    "british": false,
+    "label": "Isiolo Airport (Kenya) (HKIS)"
+  },
+  {
+    "id": "KEY",
+    "british": false,
+    "label": "Kericho Airport (Kenya) (HKKR / KEY)"
+  },
+  {
+    "id": "ILU",
+    "british": false,
+    "label": "Kilaguni Airport (Kenya) (HKKL / ILU)"
+  },
+  {
+    "id": "ATJ",
+    "british": false,
+    "label": "Antsirabe Airport (Madagascar) (FMME / ATJ)"
+  },
+  {
+    "id": "OVA",
+    "british": false,
+    "label": "Bekily Airport (Madagascar) (FMSL / OVA)"
+  },
+  {
+    "id": "UTS",
+    "british": false,
+    "label": "Ust-Tsylma Airport (Russia) (UUYX / UTS)"
+  },
+  {
+    "id": "RGK",
+    "british": false,
+    "label": "Gorno-Altaysk Airport (Russia) (UNBG / RGK)"
+  },
+  {
+    "id": "FLD",
+    "british": false,
+    "label": "Fond du Lac County Airport (United States) (KFLD / FLD)"
+  },
+  {
+    "id": "KPCZ",
+    "british": false,
+    "label": "Waupaca Municipal Airport (United States) (KPCZ)"
+  },
+  {
+    "id": "STE",
+    "british": false,
+    "label": "Stevens Point Municipal Airport (United States) (KSTE / STE)"
+  },
+  {
+    "id": "UHMI",
+    "british": false,
+    "label": "Mys Shmidta Airport (Russia) (UHMI)"
+  },
+  {
+    "id": "MQJ",
+    "british": false,
+    "label": "Moma Airport (Russia) (UEMA / MQJ)"
+  },
+  {
+    "id": "KERY",
+    "british": false,
+    "label": "Luce County Airport (United States) (KERY)"
+  },
+  {
+    "id": "PEF",
+    "british": false,
+    "label": "Peenemünde Airport (Germany) (EDCP / PEF)"
+  },
+  {
+    "id": "EPGO",
+    "british": false,
+    "label": "Góraszka Airport (Poland) (EPGO)"
+  },
+  {
+    "id": "CJN",
+    "british": false,
+    "label": "Nusawiru Airport (Indonesia) (WI1A / CJN)"
+  },
+  {
+    "id": "GQQ",
+    "british": false,
+    "label": "Galion Municipal Airport (United States) (KGQQ / GQQ)"
+  },
+  {
+    "id": "TPN",
+    "british": false,
+    "label": "Tiputini Airport (Ecuador) (SETI / TPN)"
+  },
+  {
+    "id": "PTZ",
+    "british": false,
+    "label": "Rio Amazonas Airport (Ecuador) (SESM / PTZ)"
+  },
+  {
+    "id": "CKV",
+    "british": false,
+    "label": "Clarksville–Montgomery County Regional Airport (United States) (KCKV / CKV)"
+  },
+  {
+    "id": "LPC",
+    "british": false,
+    "label": "Lompoc Airport (United States) (KLPC / LPC)"
+  },
+  {
+    "id": "CTH",
+    "british": false,
+    "label": "Chester County G O Carlson Airport (United States) (KMQS / CTH)"
+  },
+  {
+    "id": "BST",
+    "british": false,
+    "label": "Bost Airport (Afghanistan) (OABT / BST)"
+  },
+  {
+    "id": "LLK",
+    "british": false,
+    "label": "Lankaran International Airport (Azerbaijan) (UBBL / LLK)"
+  },
+  {
+    "id": "GBB",
+    "british": false,
+    "label": "Gabala International Airport (Azerbaijan) (UBBQ / GBB)"
+  },
+  {
+    "id": "ZTU",
+    "british": false,
+    "label": "Zaqatala International Airport (Azerbaijan) (UBBY / ZTU)"
+  },
+  {
+    "id": "LKP",
+    "british": false,
+    "label": "Lake Placid Airport (United States) (KLKP / LKP)"
+  },
+  {
+    "id": "KDY",
+    "british": false,
+    "label": "Typliy Klyuch Airport (Russia) (UEMH / KDY)"
+  },
+  {
+    "id": "GYG",
+    "british": false,
+    "label": "Magan Airport (Russia) (UEMM / GYG)"
+  },
+  {
+    "id": "JIQ",
+    "british": false,
+    "label": "Qianjiang Wulingshan Airport (China) (ZUQJ / JIQ)"
+  },
+  {
+    "id": "YXCM",
+    "british": false,
+    "label": "Cooma Hospital Helipad (Russia) (YXCM)"
+  },
+  {
+    "id": "AOH",
+    "british": false,
+    "label": "Lima Allen County Airport (United States) (KAOH / AOH)"
+  },
+  {
+    "id": "DSO",
+    "british": false,
+    "label": "Sondok Airport (North Korea) (ZKSD / DSO)"
+  },
+  {
+    "id": "SSI",
+    "british": false,
+    "label": "Malcolm McKinnon Airport (United States) (KSSI / SSI)"
+  },
+  {
+    "id": "BFP",
+    "british": false,
+    "label": "Beaver County Airport (United States) (KBVI / BFP)"
+  },
+  {
+    "id": "GGE",
+    "british": false,
+    "label": "Georgetown County Airport (United States) (KGGE / GGE)"
+  },
+  {
+    "id": "HDI",
+    "british": false,
+    "label": "Hardwick Field (United States) (KHDI / HDI)"
+  },
+  {
+    "id": "RNT",
+    "british": false,
+    "label": "Renton Municipal Airport (United States) (KRNT / RNT)"
+  },
+  {
+    "id": "POC",
+    "british": false,
+    "label": "Brackett Field (United States) (KPOC / POC)"
+  },
+  {
+    "id": "CTY",
+    "british": false,
+    "label": "Cross City Airport (United States) (KCTY / CTY)"
+  },
+  {
+    "id": "CEU",
+    "british": false,
+    "label": "Oconee County Regional Airport (United States) (KCEU / CEU)"
+  },
+  {
+    "id": "BEC",
+    "british": false,
+    "label": "Beech Factory Airport (United States) (KBEC / BEC)"
+  },
+  {
+    "id": "WIMG",
+    "british": false,
+    "label": "Tabing Airport (Indonesia) (WIMG)"
+  },
+  {
+    "id": "KCZL",
+    "british": false,
+    "label": "Tom B. David Field (United States) (KCZL)"
+  },
+  {
+    "id": "KAJR",
+    "british": false,
+    "label": "Habersham County Airport (United States) (KAJR)"
+  },
+  {
+    "id": "KGTU",
+    "british": false,
+    "label": "Georgetown Municipal Airport (United States) (KGTU)"
+  },
+  {
+    "id": "NY94",
+    "british": false,
+    "label": "Old Rhinebeck Airport (United States) (NY94)"
+  },
+  {
+    "id": "QFO",
+    "british": true,
+    "label": "Duxford Aerodrome (United Kingdom) (EGSU / QFO)"
+  },
+  {
+    "id": "SNY",
+    "british": false,
+    "label": "Sidney Municipal-Lloyd W Carr Field (United States) (KSNY / SNY)"
+  },
+  {
+    "id": "GA46",
+    "british": false,
+    "label": "Newnan Hospital Heliport (Mali) (GA46)"
+  },
+  {
+    "id": "GKL",
+    "british": false,
+    "label": "Great Keppel Is Airport (Australia) (YGKL / GKL)"
+  },
+  {
+    "id": "RPB",
+    "british": false,
+    "label": "Roper Bar Airport (Australia) (YRRB / RPB)"
+  },
+  {
+    "id": "YMRT",
+    "british": false,
+    "label": "Mount Garnet Airport (Australia) (YMRT)"
+  },
+  {
+    "id": "IFL",
+    "british": false,
+    "label": "Innisfail Airport (Australia) (YIFL / IFL)"
+  },
+  {
+    "id": "JRF",
+    "british": false,
+    "label": "Kalaeloa Airport (United States) (PHJR / JRF)"
+  },
+  {
+    "id": "BIN",
+    "british": false,
+    "label": "Bamiyan Airport (Afghanistan) (OABN / BIN)"
+  },
+  {
+    "id": "NBS",
+    "british": false,
+    "label": "Changbaishan Airport (China) (ZYBS / NBS)"
+  },
+  {
+    "id": "RGO",
+    "british": false,
+    "label": "Orang Airport (North Korea) (ZKHM / RGO)"
+  },
+  {
+    "id": "MOO",
+    "british": false,
+    "label": "Moomba Airport (Australia) (YOOM / MOO)"
+  },
+  {
+    "id": "LUZ",
+    "british": false,
+    "label": "Lublin Airport (Poland) (EPLB / LUZ)"
+  },
+  {
+    "id": "ECA",
+    "british": false,
+    "label": "Iosco County Airport (United States) (K6D9 / ECA)"
+  },
+  {
+    "id": "KMDQ",
+    "british": false,
+    "label": "Madison County Executive Airport-Tom Sharp Jr Field (United States) (KMDQ)"
+  },
+  {
+    "id": "KJYO",
+    "british": false,
+    "label": "Leesburg Executive Airport (United States) (KJYO)"
+  },
+  {
+    "id": "KANE",
+    "british": false,
+    "label": "Anoka County-Blaine (Janes Field) Airport (United States) (KANE)"
+  },
+  {
+    "id": "SCIR",
+    "british": false,
+    "label": "Robinson Crusoe Airport (Chile) (SCIR)"
+  },
+  {
+    "id": "VAM",
+    "british": false,
+    "label": "Villa Airport (Maldives) (VRMV / VAM)"
+  },
+  {
+    "id": "LLF",
+    "british": false,
+    "label": "Lingling Airport (China) (ZGLG / LLF)"
+  },
+  {
+    "id": "LSZ",
+    "british": false,
+    "label": "Lošinj Island Airport (Croatia) (LDLO / LSZ)"
+  },
+  {
+    "id": "ONS",
+    "british": false,
+    "label": "Onslow Airport (Australia) (YOLW / ONS)"
+  },
+  {
+    "id": "TDR",
+    "british": false,
+    "label": "Theodore Airport (Australia) (YTDR / TDR)"
+  },
+  {
+    "id": "KSDC",
+    "british": false,
+    "label": "Williamson Sodus Airport (United States) (KSDC)"
+  },
+  {
+    "id": "EGTF",
+    "british": true,
+    "label": "Fairoaks Airport (United Kingdom) (EGTF)"
+  },
+  {
+    "id": "WBU",
+    "british": false,
+    "label": "Boulder Municipal Airport (United States) (KBDU / WBU)"
+  },
+  {
+    "id": "EDAN",
+    "british": false,
+    "label": "Neustadt-Glewe Airport (Germany) (EDAN)"
+  },
+  {
+    "id": "EBTN",
+    "british": false,
+    "label": "Goetsenhoven Air Base (Belgium) (EBTN)"
+  },
+  {
+    "id": "EDUW",
+    "british": false,
+    "label": "Tutow Airport (Germany) (EDUW)"
+  },
+  {
+    "id": "EDTG",
+    "british": false,
+    "label": "Bremgarten Airport (Germany) (EDTG)"
+  },
+  {
+    "id": "BBJ",
+    "british": false,
+    "label": "Bitburg Airport (Germany) (EDRB / BBJ)"
+  },
+  {
+    "id": "PAO",
+    "british": false,
+    "label": "Palo Alto Airport of Santa Clara County (United States) (KPAO / PAO)"
+  },
+  {
+    "id": "USR",
+    "british": false,
+    "label": "Ust-Nera Airport (Russia) (UEMT / USR)"
+  },
+  {
+    "id": "LKVM",
+    "british": false,
+    "label": "Letiště Vysoké Mýto (Czech Republic) (LKVM)"
+  },
+  {
+    "id": "EBSP",
+    "british": false,
+    "label": "Spa (la Sauvenière) Airfield (Belgium) (EBSP)"
+  },
+  {
+    "id": "MSC",
+    "british": false,
+    "label": "Falcon Field (United States) (KFFZ / MSC)"
+  },
+  {
+    "id": "KP08",
+    "british": false,
+    "label": "Coolidge Municipal Airport (United States) (KP08)"
+  },
+  {
+    "id": "KP52",
+    "british": false,
+    "label": "Cottonwood Airport (United States) (KP52)"
+  },
+  {
+    "id": "EBNM",
+    "british": false,
+    "label": "Namur-Suarlée Airfield (Belgium) (EBNM)"
+  },
+  {
+    "id": "EBZH",
+    "british": false,
+    "label": "Kiewit Airfield Hasselt (Belgium) (EBZH)"
+  },
+  {
+    "id": "KA39",
+    "british": false,
+    "label": "Ak-Chin Regional Airport (United States) (KA39)"
+  },
+  {
+    "id": "KE25",
+    "british": false,
+    "label": "Wickenburg Municipal Airport (United States) (KE25)"
+  },
+  {
+    "id": "YTY",
+    "british": false,
+    "label": "Yangzhou Taizhou Airport (China) (ZSYA / YTY)"
+  },
+  {
+    "id": "PTK",
+    "british": false,
+    "label": "Oakland County International Airport (United States) (KPTK / PTK)"
+  },
+  {
+    "id": "KSI",
+    "british": false,
+    "label": "Kissidougou Airport (Guinea) (GUKU / KSI)"
+  },
+  {
+    "id": "EEN",
+    "british": false,
+    "label": "Dillant Hopkins Airport (United States) (KEEN / EEN)"
+  },
+  {
+    "id": "THQ",
+    "british": false,
+    "label": "Tianshui Maijishan Airport (China) (ZLTS / THQ)"
+  },
+  {
+    "id": "VRO",
+    "british": false,
+    "label": "Kawama Airport (Cuba) (MUKW / VRO)"
+  },
+  {
+    "id": "GKK",
+    "british": false,
+    "label": "Kooddoo Airport (Maldives) (VRMO / GKK)"
+  },
+  {
+    "id": "07MT",
+    "british": false,
+    "label": "Glasgow Industrial Airport (United States) (07MT)"
+  },
+  {
+    "id": "RCS",
+    "british": true,
+    "label": "Rochester Airport (United Kingdom) (EGTO / RCS)"
+  },
+  {
+    "id": "RHD",
+    "british": false,
+    "label": "Termas de Río Hondo international Airport (Argentina) (SANR / RHD)"
+  },
+  {
+    "id": "KMP",
+    "british": false,
+    "label": "Keetmanshoop Airport (Namibia) (FYKT / KMP)"
+  },
+  {
+    "id": "KGT",
+    "british": false,
+    "label": "Kangding Airport (China) (ZUKD / KGT)"
+  },
+  {
+    "id": "VUS",
+    "british": false,
+    "label": "Velikiy Ustyug Airport (Russia) (ULWU / VUS)"
+  },
+  {
+    "id": "IOW",
+    "british": false,
+    "label": "Iowa City Municipal Airport (United States) (KIOW / IOW)"
+  },
+  {
+    "id": "TLQ",
+    "british": false,
+    "label": "Turpan Jiaohe Airport (China) (ZWTP / TLQ)"
+  },
+  {
+    "id": "SNCL",
+    "british": false,
+    "label": "Lorenzo Airport (Brazil) (SNCL)"
+  },
+  {
+    "id": "KMWM",
+    "british": false,
+    "label": "Windom Municipal Airport (United States) (KMWM)"
+  },
+  {
+    "id": "OG39",
+    "british": false,
+    "label": "Longview Ranch Airport (United States) (OG39)"
+  },
+  {
+    "id": "EGAR",
+    "british": true,
+    "label": "Rothera Research Station (United Kingdom) (EGAR)"
+  },
+  {
+    "id": "ULPW",
+    "british": false,
+    "label": "Sortavala Airport (Russia) (ULPW)"
+  },
+  {
+    "id": "ANP",
+    "british": false,
+    "label": "Lee Airport (United States) (KANP / ANP)"
+  },
+  {
+    "id": "FXO",
+    "british": false,
+    "label": "Cuamba Airport (Mozambique) (FQCB / FXO)"
+  },
+  {
+    "id": "ODO",
+    "british": false,
+    "label": "Bodaybo Airport (Russia) (UIKB / ODO)"
+  },
+  {
+    "id": "ZTR",
+    "british": false,
+    "label": "Zhytomyr Airport (Ukraine) (UKKV / ZTR)"
+  },
+  {
+    "id": "EYVP",
+    "british": false,
+    "label": "Paluknys Airport (Lithuania) (EYVP)"
+  },
+  {
+    "id": "HRI",
+    "british": false,
+    "label": "Mattala Rajapaksa International Airport (Sri Lanka) (VCRI / HRI)"
+  },
+  {
+    "id": "PEQ",
+    "british": false,
+    "label": "Pecos Municipal Airport (United States) (KPEQ / PEQ)"
+  },
+  {
+    "id": "HBG",
+    "british": false,
+    "label": "Hattiesburg Bobby L Chain Municipal Airport (United States) (KHBG / HBG)"
+  },
+  {
+    "id": "QCJ",
+    "british": false,
+    "label": "Botucatu - Tancredo de Almeida Neves Airport (Brazil) (SDBK / QCJ)"
+  },
+  {
+    "id": "SBAN",
+    "british": false,
+    "label": "Base Aérea Airport (Brazil) (SBAN)"
+  },
+  {
+    "id": "QSC",
+    "british": false,
+    "label": "Mário Pereira Lopes–São Carlos Airport (Brazil) (SDSC / QSC)"
+  },
+  {
+    "id": "YKN",
+    "british": false,
+    "label": "Chan Gurney Municipal Airport (United States) (KYKN / YKN)"
+  },
+  {
+    "id": "XSB",
+    "british": false,
+    "label": "Sir Bani Yas Airport (United Arab Emirates) (OMBY / XSB)"
+  },
+  {
+    "id": "ZBM",
+    "british": false,
+    "label": "Bromont (Roland Desourdy) Airport (Canada) (CZBM / ZBM)"
+  },
+  {
+    "id": "EGSM",
+    "british": true,
+    "label": "Beccles Airport (United Kingdom) (EGSM)"
+  },
+  {
+    "id": "KTI",
+    "british": false,
+    "label": "Kratie Airport (Cambodia) (VDKT / KTI)"
+  },
+  {
+    "id": "SCCL",
+    "british": false,
+    "label": "Caldera Airport (Chile) (SCCL)"
+  },
+  {
+    "id": "SCPE",
+    "british": false,
+    "label": "San Pedro de Atacama Airport (Chile) (SCPE)"
+  },
+  {
+    "id": "SLCC",
+    "british": false,
+    "label": "Copacabana Airport (Bolivia) (SLCC)"
+  },
+  {
+    "id": "GYU",
+    "british": false,
+    "label": "Guyuan Liupanshan Airport (China) (ZLGY / GYU)"
+  },
+  {
+    "id": "EGDA",
+    "british": true,
+    "label": "RAF Brawdy (United Kingdom) (EGDA)"
+  },
+  {
+    "id": "CNI",
+    "british": false,
+    "label": "Changhai Airport (China) (ZYCH / CNI)"
+  },
+  {
+    "id": "KRH",
+    "british": true,
+    "label": "Redhill Aerodrome (United Kingdom) (EGKR / KRH)"
+  },
+  {
+    "id": "JGD",
+    "british": false,
+    "label": "Jiagedaqi Airport (China) (ZYJD / JGD)"
+  },
+  {
+    "id": "CCL",
+    "british": false,
+    "label": "Chinchilla Airport (Australia) (YCCA / CCL)"
+  },
+  {
+    "id": "HWD",
+    "british": false,
+    "label": "Hayward Executive Airport (United States) (KHWD / HWD)"
+  },
+  {
+    "id": "MZP",
+    "british": false,
+    "label": "Motueka Airport (New Zealand) (NZMK / MZP)"
+  },
+  {
+    "id": "JHQ",
+    "british": false,
+    "label": "Shute Harbour Airport (Australia) (YSHR / JHQ)"
+  },
+  {
+    "id": "EGTN",
+    "british": true,
+    "label": "Enstone Aerodrome (United Kingdom) (EGTN)"
+  },
+  {
+    "id": "ARB",
+    "british": false,
+    "label": "Ann Arbor Municipal Airport (United States) (KARB / ARB)"
+  },
+  {
+    "id": "SHT",
+    "british": false,
+    "label": "Shepparton Airport (Australia) (YSHT / SHT)"
+  },
+  {
+    "id": "TEM",
+    "british": false,
+    "label": "Temora Airport (Australia) (YTEM / TEM)"
+  },
+  {
+    "id": "GAH",
+    "british": false,
+    "label": "Gayndah Airport (Australia) (YGAY / GAH)"
+  },
+  {
+    "id": "WIO",
+    "british": false,
+    "label": "Wilcannia Airport (Australia) (YWCA / WIO)"
+  },
+  {
+    "id": "YIVO",
+    "british": false,
+    "label": "Ivanhoe Airport (Australia) (YIVO)"
+  },
+  {
+    "id": "YMED",
+    "british": false,
+    "label": "Menindee Airport (Australia) (YMED)"
+  },
+  {
+    "id": "YPCE",
+    "british": false,
+    "label": "Pooncarie Airport (Australia) (YPCE)"
+  },
+  {
+    "id": "YTLP",
+    "british": false,
+    "label": "Tilpa Airport (Australia) (YTLP)"
+  },
+  {
+    "id": "LSGR",
+    "british": false,
+    "label": "Reichenbach Air Base (Switzerland) (LSGR)"
+  },
+  {
+    "id": "BFJ",
+    "british": false,
+    "label": "Bijie Feixiong Airport (China) (ZUBJ / BFJ)"
+  },
+  {
+    "id": "ULK",
+    "british": false,
+    "label": "Lensk Airport (Russia) (UERL / ULK)"
+  },
+  {
+    "id": "KVR",
+    "british": false,
+    "label": "Kavalerovo Airport (Russia) (UHWK / KVR)"
+  },
+  {
+    "id": "IGD",
+    "british": false,
+    "label": "Iğdır Airport (Turkey) (LTCT / IGD)"
+  },
+  {
+    "id": "GNY",
+    "british": false,
+    "label": "Şanlıurfa GAP Airport (Turkey) (LTCS / GNY)"
+  },
+  {
+    "id": "KZR",
+    "british": false,
+    "label": "Zafer Airport (Turkey) (LTBZ / KZR)"
+  },
+  {
+    "id": "VLU",
+    "british": false,
+    "label": "Velikiye Luki Airport (Russia) (ULOL / VLU)"
+  },
+  {
+    "id": "VOYK",
+    "british": false,
+    "label": "Yelahanka Air Force Station (India) (VOYK)"
+  },
+  {
+    "id": "UNNE",
+    "british": false,
+    "label": "Yeltsovka Airport (Russia) (UNNE)"
+  },
+  {
+    "id": "UNKI",
+    "british": false,
+    "label": "Kodinsk Airport (Russia) (UNKI)"
+  },
+  {
+    "id": "BEO",
+    "british": false,
+    "label": "Lake Macquarie Airport (Australia) (YPEC / BEO)"
+  },
+  {
+    "id": "K4A7",
+    "british": false,
+    "label": "Henry County Airport (United States) (K4A7)"
+  },
+  {
+    "id": "BMP",
+    "british": false,
+    "label": "Brampton Island Airport (Australia) (YBPI / BMP)"
+  },
+  {
+    "id": "NGZ",
+    "british": false,
+    "label": "Alameda Naval Air Station (United States) (KNGZ / NGZ)"
+  },
+  {
+    "id": "EKEL",
+    "british": false,
+    "label": "Endelave Flyveplads (Denmark) (EKEL)"
+  },
+  {
+    "id": "LOIJ",
+    "british": false,
+    "label": "St. Johann In Tirol Airport (Austria) (LOIJ)"
+  },
+  {
+    "id": "EDPW",
+    "british": false,
+    "label": "Thalmässing-Waizenhofen Airport (Germany) (EDPW)"
+  },
+  {
+    "id": "YCN",
+    "british": false,
+    "label": "Cochrane Airport (Canada) (CYCN / YCN)"
+  },
+  {
+    "id": "BJP",
+    "british": false,
+    "label": "Estadual Arthur Siqueira Airport (Brazil) (SBBP / BJP)"
+  },
+  {
+    "id": "BQB",
+    "british": false,
+    "label": "Busselton Regional Airport (Australia) (YBLN / BQB)"
+  },
+  {
+    "id": "SEK",
+    "british": false,
+    "label": "Srednekolymsk Airport (Russia) (UESK / SEK)"
+  },
+  {
+    "id": "SLCR",
+    "british": false,
+    "label": "Comarapa Airport (United States) (SLCR)"
+  },
+  {
+    "id": "IVR",
+    "british": false,
+    "label": "Inverell Airport (Australia) (YIVL / IVR)"
+  },
+  {
+    "id": "GLI",
+    "british": false,
+    "label": "Glen Innes Airport (Australia) (YGLI / GLI)"
+  },
+  {
+    "id": "EDQF",
+    "british": false,
+    "label": "Ansbach-Petersdorf Airport (Germany) (EDQF)"
+  },
+  {
+    "id": "IMM",
+    "british": false,
+    "label": "Immokalee Regional Airport (United States) (KIMM / IMM)"
+  },
+  {
+    "id": "TQQ",
+    "british": false,
+    "label": "Maranggo Airport (Indonesia) (WA44 / TQQ)"
+  },
+  {
+    "id": "66CA",
+    "british": false,
+    "label": "Rancho San Simeon Airport (United States) (66CA)"
+  },
+  {
+    "id": "YIC",
+    "british": false,
+    "label": "Yichun Mingyueshan Airport (China) (ZSYC / YIC)"
+  },
+  {
+    "id": "PTB",
+    "british": false,
+    "label": "Dinwiddie County Airport (United States) (KPTB / PTB)"
+  },
+  {
+    "id": "FZOK",
+    "british": false,
+    "label": "Kasongo Airport (Congo (Kinshasa)) (FZOK)"
+  },
+  {
+    "id": "NZPG",
+    "british": false,
+    "label": "McMurdo Station Pegasus Field (Antarctica) (NZPG)"
+  },
+  {
+    "id": "LKKT",
+    "british": false,
+    "label": "Klatovy Airport (Czech Republic) (LKKT)"
+  },
+  {
+    "id": "SBM",
+    "british": false,
+    "label": "Sheboygan County Memorial Airport (United States) (KSBM / SBM)"
+  },
+  {
+    "id": "KFE",
+    "british": false,
+    "label": "Fortescue - Dave Forrest Aerodrome (Australia) (YFDF / KFE)"
+  },
+  {
+    "id": "VNKL",
+    "british": false,
+    "label": "Kangel Danda Airport (Nepal) (VNKL)"
+  },
+  {
+    "id": "BJU",
+    "british": false,
+    "label": "Bajura Airport (Nepal) (VNBR / BJU)"
+  },
+  {
+    "id": "UIAR",
+    "british": false,
+    "label": "Chara Airport (Russia) (UIAR)"
+  },
+  {
+    "id": "EKHG",
+    "british": false,
+    "label": "Herning Airport (Denmark) (EKHG)"
+  },
+  {
+    "id": "EDNX",
+    "british": false,
+    "label": "Oberschleißheim Airfield (Germany) (EDNX)"
+  },
+  {
+    "id": "MZJ",
+    "british": false,
+    "label": "Pinal Airpark (United States) (KMZJ / MZJ)"
+  },
+  {
+    "id": "KGEU",
+    "british": false,
+    "label": "Glendale Municipal Airport (United States) (KGEU)"
+  },
+  {
+    "id": "SAD",
+    "british": false,
+    "label": "Safford Regional Airport (United States) (KSAD / SAD)"
+  },
+  {
+    "id": "EDWV",
+    "british": false,
+    "label": "Verden-Scharnhorst Airfield (Germany) (EDWV)"
+  },
+  {
+    "id": "SLJ",
+    "british": false,
+    "label": "Solomon Airport (Australia) (YSOL / SLJ)"
+  },
+  {
+    "id": "EDNM",
+    "british": false,
+    "label": "Nittenau-Bruck Airport (Germany) (EDNM)"
+  },
+  {
+    "id": "KJP",
+    "british": false,
+    "label": "Kerama Airport (Japan) (ROKR / KJP)"
+  },
+  {
+    "id": "SDAI",
+    "british": false,
+    "label": "Americana Airport (Brazil) (SDAI)"
+  },
+  {
+    "id": "EKB",
+    "british": false,
+    "label": "Ekibastuz Airport (Kazakhstan) (UASB / EKB)"
+  },
+  {
+    "id": "UWOD",
+    "british": false,
+    "label": "Adamovka (Russia) (UWOD)"
+  },
+  {
+    "id": "UWOH",
+    "british": false,
+    "label": "Kvarkeno (Russia) (UWOH)"
+  },
+  {
+    "id": "SIK",
+    "british": false,
+    "label": "Sikeston Memorial Municipal Airport (United States) (KSIK / SIK)"
+  },
+  {
+    "id": "TTI",
+    "british": false,
+    "label": "Tetiaroa Airport (French Polynesia) (NTTE / TTI)"
+  },
+  {
+    "id": "GFL",
+    "british": false,
+    "label": "Floyd Bennett Memorial Airport (United States) (KGFL / GFL)"
+  },
+  {
+    "id": "K5B2",
+    "british": false,
+    "label": "Saratoga County Airport (United States) (K5B2)"
+  },
+  {
+    "id": "KCGC",
+    "british": false,
+    "label": "Crystal River Airport (United States) (KCGC)"
+  },
+  {
+    "id": "MTN",
+    "british": false,
+    "label": "Martin State Airport (United States) (KMTN / MTN)"
+  },
+  {
+    "id": "KLHM",
+    "british": false,
+    "label": "Lincoln Regional Karl Harder Field (United States) (KLHM)"
+  },
+  {
+    "id": "KFZI",
+    "british": false,
+    "label": "Fostoria Metropolitan Airport (United States) (KFZI)"
+  },
+  {
+    "id": "FRY",
+    "british": false,
+    "label": "Eastern Slopes Regional Airport (United States) (KIZG / FRY)"
+  },
+  {
+    "id": "FA54",
+    "british": false,
+    "label": "Coral Creek Airport (United States) (FA54)"
+  },
+  {
+    "id": "NEW",
+    "british": false,
+    "label": "Lakefront Airport (United States) (KNEW / NEW)"
+  },
+  {
+    "id": "COE",
+    "british": false,
+    "label": "Coeur D'Alene - Pappy Boyington Field (United States) (KCOE / COE)"
+  },
+  {
+    "id": "BMT",
+    "british": false,
+    "label": "Beaumont Municipal Airport (United States) (KBMT / BMT)"
+  },
+  {
+    "id": "DNV",
+    "british": false,
+    "label": "Vermilion Regional Airport (United States) (KDNV / DNV)"
+  },
+  {
+    "id": "COJ",
+    "british": false,
+    "label": "Coonabarabran Airport (Australia) (YCBB / COJ)"
+  },
+  {
+    "id": "TIX",
+    "british": false,
+    "label": "Space Coast Regional Airport (United States) (KTIX / TIX)"
+  },
+  {
+    "id": "BZH",
+    "british": false,
+    "label": "Bumi Airport (Zimbabwe) (FVBM / BZH)"
+  },
+  {
+    "id": "YWVA",
+    "british": false,
+    "label": "Warnervale Airport (Australia) (YWVA)"
+  },
+  {
+    "id": "UAR",
+    "british": false,
+    "label": "Bouarfa Airport (Morocco) (GMFB / UAR)"
+  },
+  {
+    "id": "NYE",
+    "british": false,
+    "label": "Nyeri Airport (Kenya) (HKNI / NYE)"
+  },
+  {
+    "id": "AAP",
+    "british": false,
+    "label": "Andrau Airpark (United States) (KAAP / AAP)"
+  },
+  {
+    "id": "FCM",
+    "british": false,
+    "label": "Flying Cloud Airport (United States) (KFCM / FCM)"
+  },
+  {
+    "id": "LIX",
+    "british": false,
+    "label": "Likoma Island Airport (Malawi) (FWLK / LIX)"
+  },
+  {
+    "id": "OJC",
+    "british": false,
+    "label": "Johnson County Executive Airport (United States) (KOJC / OJC)"
+  },
+  {
+    "id": "GIU",
+    "british": false,
+    "label": "Sigiriya Air Force Base (Sri Lanka) (VCCS / GIU)"
+  },
+  {
+    "id": "EUM",
+    "british": false,
+    "label": "Neumünster Airport (Germany) (EDHN / EUM)"
+  },
+  {
+    "id": "TKT",
+    "british": false,
+    "label": "Tak Airport (Thailand) (VTPT / TKT)"
+  },
+  {
+    "id": "YLK",
+    "british": false,
+    "label": "Barrie-Orillia (Lake Simcoe Regional Airport) (Canada) (CYLS / YLK)"
+  },
+  {
+    "id": "CYEE",
+    "british": false,
+    "label": "Huronia Airport (Canada) (CYEE)"
+  },
+  {
+    "id": "CNU8",
+    "british": false,
+    "label": "Markham Airport (Canada) (CNU8)"
+  },
+  {
+    "id": "CND4",
+    "british": false,
+    "label": "Stanhope Municipal Airport (Canada) (CND4)"
+  },
+  {
+    "id": "CNF4",
+    "british": false,
+    "label": "Kawartha Lakes (Lindsay) Airport (Canada) (CNF4)"
+  },
+  {
+    "id": "YCM",
+    "british": false,
+    "label": "Niagara District Airport (Canada) (CYSN / YCM)"
+  },
+  {
+    "id": "CNV8",
+    "british": false,
+    "label": "Edenvale Aerodrome (Canada) (CNV8)"
+  },
+  {
+    "id": "CNJ4",
+    "british": false,
+    "label": "Orillia Airport (Canada) (CNJ4)"
+  },
+  {
+    "id": "CLA4",
+    "british": false,
+    "label": "Holland Landing Airpark (Canada) (CLA4)"
+  },
+  {
+    "id": "YPD",
+    "british": false,
+    "label": "Parry Sound Area Municipal Airport (Canada) (CNK4 / YPD)"
+  },
+  {
+    "id": "CYHS",
+    "british": false,
+    "label": "Hanover / Saugeen Municipal Airport (Canada) (CYHS)"
+  },
+  {
+    "id": "KOQN",
+    "british": false,
+    "label": "Brandywine Airport (United States) (KOQN)"
+  },
+  {
+    "id": "MNZ",
+    "british": false,
+    "label": "Manassas Regional Airport/Harry P. Davis Field (United States) (KHEF / MNZ)"
+  },
+  {
+    "id": "LJN",
+    "british": false,
+    "label": "Texas Gulf Coast Regional Airport (United States) (KLBX / LJN)"
+  },
+  {
+    "id": "LKBU",
+    "british": false,
+    "label": "Bubovice Airport (Czech Republic) (LKBU)"
+  },
+  {
+    "id": "ENRK",
+    "british": false,
+    "label": "Rakkestad Astorp Airport (Norway) (ENRK)"
+  },
+  {
+    "id": "BGG",
+    "british": false,
+    "label": "Bingöl Çeltiksuyu Airport (Turkey) (LTCU / BGG)"
+  },
+  {
+    "id": "KFS",
+    "british": false,
+    "label": "Kastamonu Airport (Turkey) (LTAL / KFS)"
+  },
+  {
+    "id": "EGTR",
+    "british": true,
+    "label": "Elstree Airfield (United Kingdom) (EGTR)"
+  },
+  {
+    "id": "EGCF",
+    "british": true,
+    "label": "Sandtoft Airfield (United Kingdom) (EGCF)"
+  },
+  {
+    "id": "HSTR",
+    "british": false,
+    "label": "Torit Airport (South Sudan) (HSTR)"
+  },
+  {
+    "id": "K2H0",
+    "british": false,
+    "label": "Shelby County Airport (United States) (K2H0)"
+  },
+  {
+    "id": "LLV",
+    "british": false,
+    "label": "Lüliang Airport (China) (ZBLL / LLV)"
+  },
+  {
+    "id": "DCY",
+    "british": false,
+    "label": "Daocheng Yading Airport (China) (ZUDC / DCY)"
+  },
+  {
+    "id": "GXH",
+    "british": false,
+    "label": "Gannan Xiahe Airport (China) (ZLXH / GXH)"
+  },
+  {
+    "id": "ESSZ",
+    "british": false,
+    "label": "Vängsö Airport (Sweden) (ESSZ)"
+  },
+  {
+    "id": "CIY",
+    "british": false,
+    "label": "Comiso Airport (Italy) (LICB / CIY)"
+  },
+  {
+    "id": "WA77",
+    "british": false,
+    "label": "Enumclaw Airport (United States) (WA77)"
+  },
+  {
+    "id": "KVM",
+    "british": false,
+    "label": "Markovo Airport (Russia) (UHMO / KVM)"
+  },
+  {
+    "id": "UHMS",
+    "british": false,
+    "label": "Seymchan Airport (Russia) (UHMS)"
+  },
+  {
+    "id": "ZKP",
+    "british": false,
+    "label": "Zyryanka Airport (Russia) (UESU / ZKP)"
+  },
+  {
+    "id": "UHMH",
+    "british": false,
+    "label": "Susuman Airport (Russia) (UHMH)"
+  },
+  {
+    "id": "UMS",
+    "british": false,
+    "label": "Ust-Maya Airport (Russia) (UEMU / UMS)"
+  },
+  {
+    "id": "ADH",
+    "british": false,
+    "label": "Aldan Airport (Russia) (UEEA / ADH)"
+  },
+  {
+    "id": "OLZ",
+    "british": false,
+    "label": "Olyokminsk Airport (Russia) (UEMO / OLZ)"
+  },
+  {
+    "id": "UERT",
+    "british": false,
+    "label": "Vitim Airport (Russia) (UERT)"
+  },
+  {
+    "id": "EDHP",
+    "british": false,
+    "label": "Pellworm Field (Germany) (EDHP)"
+  },
+  {
+    "id": "NLT",
+    "british": false,
+    "label": "Xinyuan Nalati Airport (China) (ZWNL / NLT)"
+  },
+  {
+    "id": "PTA",
+    "british": false,
+    "label": "Port Alsworth Airport (United States) (PALJ / PTA)"
+  },
+  {
+    "id": "BOR",
+    "british": false,
+    "label": "Fontaine Airport (France) (LFSQ / BOR)"
+  },
+  {
+    "id": "KFDW",
+    "british": false,
+    "label": "Fairfield County Airport (United States) (KFDW)"
+  },
+  {
+    "id": "OBC",
+    "british": false,
+    "label": "Obock Airport (Djibouti) (HDOB / OBC)"
+  },
+  {
+    "id": "TDJ",
+    "british": false,
+    "label": "Tadjoura Airport (Djibouti) (HDTJ / TDJ)"
+  },
+  {
+    "id": "AQB",
+    "british": false,
+    "label": "Santa Cruz del Quiche Airport (Guatemala) (MGQC / AQB)"
+  },
+  {
+    "id": "NOR",
+    "british": false,
+    "label": "Norðfjörður Airport (Iceland) (BINF / NOR)"
+  },
+  {
+    "id": "BTZ",
+    "british": false,
+    "label": "Bursa Airport (Turkey) (LTBE / BTZ)"
+  },
+  {
+    "id": "KDAW",
+    "british": false,
+    "label": "Skyhaven Airport (United States) (KDAW)"
+  },
+  {
+    "id": "WAR",
+    "british": false,
+    "label": "Waris Airport (Indonesia) (WAJR / WAR)"
+  },
+  {
+    "id": "EWK",
+    "british": false,
+    "label": "Newton City-County Airport (United States) (KEWK / EWK)"
+  },
+  {
+    "id": "LFFQ",
+    "british": false,
+    "label": "La Ferté Alais Airfield (France) (LFFQ)"
+  },
+  {
+    "id": "BSJ",
+    "british": false,
+    "label": "Bairnsdale Airport (Australia) (YBNS / BSJ)"
+  },
+  {
+    "id": "TZR",
+    "british": false,
+    "label": "Taszár Air Base (United States) (LHTA / TZR)"
+  },
+  {
+    "id": "FBR",
+    "british": false,
+    "label": "Fort Bridger Airport (United States) (KFBR / FBR)"
+  },
+  {
+    "id": "KS40",
+    "british": false,
+    "label": "Prosser Airport (United States) (KS40)"
+  },
+  {
+    "id": "CLS",
+    "british": false,
+    "label": "Chehalis Centralia Airport (United States) (KCLS / CLS)"
+  },
+  {
+    "id": "KM94",
+    "british": false,
+    "label": "Desert Aire Regional Airport (United States) (KM94)"
+  },
+  {
+    "id": "EVW",
+    "british": false,
+    "label": "Evanston-Uinta County Airport-Burns Field (United States) (KEVW / EVW)"
+  },
+  {
+    "id": "KK83",
+    "british": false,
+    "label": "Sabetha Municipal Airport (United States) (KK83)"
+  },
+  {
+    "id": "KLRO",
+    "british": false,
+    "label": "Mt Pleasant Regional-Faison field (United States) (KLRO)"
+  },
+  {
+    "id": "KACJ",
+    "british": false,
+    "label": "Jimmy Carter Regional Airport (United States) (KACJ)"
+  },
+  {
+    "id": "EUF",
+    "british": false,
+    "label": "Weedon Field (United States) (KEUF / EUF)"
+  },
+  {
+    "id": "K6J4",
+    "british": false,
+    "label": "Saluda County Airport (United States) (K6J4)"
+  },
+  {
+    "id": "MEO",
+    "british": false,
+    "label": "Dare County Regional Airport (United States) (KMQI / MEO)"
+  },
+  {
+    "id": "AUO",
+    "british": false,
+    "label": "Auburn University Regional Airport (United States) (KAUO / AUO)"
+  },
+  {
+    "id": "KCZG",
+    "british": false,
+    "label": "Tri Cities Airport (United States) (KCZG)"
+  },
+  {
+    "id": "KEKY",
+    "british": false,
+    "label": "Bessemer Airport (United States) (KEKY)"
+  },
+  {
+    "id": "KA50",
+    "british": false,
+    "label": "Colorado Springs East Airport (United States) (KA50)"
+  },
+  {
+    "id": "KMIC",
+    "british": false,
+    "label": "Crystal Airport (United States) (KMIC)"
+  },
+  {
+    "id": "K23M",
+    "british": false,
+    "label": "Clarke County Airport (United States) (K23M)"
+  },
+  {
+    "id": "DBN",
+    "british": false,
+    "label": "W H 'Bud' Barron Airport (United States) (KDBN / DBN)"
+  },
+  {
+    "id": "PUK",
+    "british": false,
+    "label": "Pukarua Airport (French Polynesia) (NTGQ / PUK)"
+  },
+  {
+    "id": "HUKB",
+    "british": false,
+    "label": "Kabale Airport (Uganda) (HUKB)"
+  },
+  {
+    "id": "MRGT",
+    "british": false,
+    "label": "Guatuso Airport (France) (MRGT)"
+  },
+  {
+    "id": "SVSJ",
+    "british": false,
+    "label": "Central Bolívar Airport (Spain) (SVSJ)"
+  },
+  {
+    "id": "CVO",
+    "british": false,
+    "label": "Corvallis Municipal Airport (United States) (KCVO / CVO)"
+  },
+  {
+    "id": "LRTZ",
+    "british": false,
+    "label": "Tuzla Romania Airport (Romania) (LRTZ)"
+  },
+  {
+    "id": "SCRT",
+    "british": false,
+    "label": "El Almendro Airport (United States) (SCRT)"
+  },
+  {
+    "id": "MRST",
+    "british": false,
+    "label": "San Agustin Airport (United States) (MRST)"
+  },
+  {
+    "id": "SDNS",
+    "british": false,
+    "label": "Samambaia Heliport (Reunion) (SDNS)"
+  },
+  {
+    "id": "SNKV",
+    "british": false,
+    "label": "Fazenda Campo Verde Airport (Cambodia) (SNKV)"
+  },
+  {
+    "id": "PXH",
+    "british": false,
+    "label": "Prominent Hill Airport (Australia) (YPMH / PXH)"
+  },
+  {
+    "id": "CWT",
+    "british": false,
+    "label": "Cowra Airport (Australia) (YCWR / CWT)"
+  },
+  {
+    "id": "YCOY",
+    "british": false,
+    "label": "Coral Bay Airport (Australia) (YCOY)"
+  },
+  {
+    "id": "OGD",
+    "british": false,
+    "label": "Ogden Hinckley Airport (United States) (KOGD / OGD)"
+  },
+  {
+    "id": "KW63",
+    "british": false,
+    "label": "Lake Country Regional Airport (United Arab Emirates) (KW63)"
+  },
+  {
+    "id": "KRKR",
+    "british": false,
+    "label": "Robert S Kerr Airport (United States) (KRKR)"
+  },
+  {
+    "id": "AKO",
+    "british": false,
+    "label": "Colorado Plains Regional Airport (United States) (KAKO / AKO)"
+  },
+  {
+    "id": "SHN",
+    "british": false,
+    "label": "Sanderson Field (United States) (KSHN / SHN)"
+  },
+  {
+    "id": "WNA",
+    "british": false,
+    "label": "Napakiak Airport (United States) (PANA / WNA)"
+  },
+  {
+    "id": "PKA",
+    "british": false,
+    "label": "Napaskiak Airport (United States) (PAPK / PKA)"
+  },
+  {
+    "id": "PATJ",
+    "british": false,
+    "label": "Tok Airport (United States) (PATJ)"
+  },
+  {
+    "id": "YBW",
+    "british": false,
+    "label": "Bedwell Harbour Seaplane Base (Canada) (CAB3 / YBW)"
+  },
+  {
+    "id": "WSO",
+    "british": false,
+    "label": "Washabo Airport (Suriname) (SMWS / WSO)"
+  },
+  {
+    "id": "EGHP",
+    "british": true,
+    "label": "Popham Airfield (United Kingdom) (EGHP)"
+  },
+  {
+    "id": "K2A5",
+    "british": false,
+    "label": "Causey Airport (United States) (K2A5)"
+  },
+  {
+    "id": "WKR",
+    "british": false,
+    "label": "Abaco I Walker C Airport (Bahamas) (MYAW / WKR)"
+  },
+  {
+    "id": "MYEB",
+    "british": false,
+    "label": "Black Point Airstrip (Bahamas) (MYEB)"
+  },
+  {
+    "id": "GFO",
+    "british": false,
+    "label": "Bartica A Airport (Guyana) (SYBT / GFO)"
+  },
+  {
+    "id": "DYL",
+    "british": false,
+    "label": "Doylestown Airport (United States) (KDYL / DYL)"
+  },
+  {
+    "id": "FADW",
+    "british": false,
+    "label": "Cape Town Waterfort Heliport (South Africa) (FADW)"
+  },
+  {
+    "id": "TGI",
+    "british": false,
+    "label": "Tingo Maria Airport (Peru) (SPGM / TGI)"
+  },
+  {
+    "id": "TJL",
+    "british": false,
+    "label": "Plínio Alarcom Airport (Brazil) (SSTL / TJL)"
+  },
+  {
+    "id": "YZY",
+    "british": false,
+    "label": "Zhangye Ganzhou Airport (China) (ZLZY / YZY)"
+  },
+  {
+    "id": "OAL",
+    "british": false,
+    "label": "Cacoal Airport (Brazil) (SSKW / OAL)"
+  },
+  {
+    "id": "OCW",
+    "british": false,
+    "label": "Warren Field (United States) (KOCW / OCW)"
+  },
+  {
+    "id": "K7W6",
+    "british": false,
+    "label": "Hyde County Airport (United States) (K7W6)"
+  },
+  {
+    "id": "MHC",
+    "british": false,
+    "label": "Mocopulli Airport (Chile) (SCPQ / MHC)"
+  },
+  {
+    "id": "SWO",
+    "british": false,
+    "label": "Stillwater Regional Airport (United States) (KSWO / SWO)"
+  },
+  {
+    "id": "OKM",
+    "british": false,
+    "label": "Okmulgee Regional Airport (United States) (KOKM / OKM)"
+  },
+  {
+    "id": "CUH",
+    "british": false,
+    "label": "Cushing Municipal Airport (United States) (KCUH / CUH)"
+  },
+  {
+    "id": "CSM",
+    "british": false,
+    "label": "Clinton Sherman Airport (United States) (KCSM / CSM)"
+  },
+  {
+    "id": "WLD",
+    "british": false,
+    "label": "Strother Field (United States) (KWLD / WLD)"
+  },
+  {
+    "id": "PWA",
+    "british": false,
+    "label": "Wiley Post Airport (United States) (KPWA / PWA)"
+  },
+  {
+    "id": "DTN",
+    "british": false,
+    "label": "Shreveport Downtown Airport (United States) (KDTN / DTN)"
+  },
+  {
+    "id": "SEP",
+    "british": false,
+    "label": "Stephenville Clark Regional Airport (United States) (KSEP / SEP)"
+  },
+  {
+    "id": "KF22",
+    "british": false,
+    "label": "Perry Municipal Airport (United States) (KF22)"
+  },
+  {
+    "id": "KMNZ",
+    "british": false,
+    "label": "Hamilton Municipal Airport (United States) (KMNZ)"
+  },
+  {
+    "id": "ADT",
+    "british": false,
+    "label": "Ada Regional Airport (United States) (KADH / ADT)"
+  },
+  {
+    "id": "KHQZ",
+    "british": false,
+    "label": "Mesquite Metro Airport (United States) (KHQZ)"
+  },
+  {
+    "id": "KDTO",
+    "british": false,
+    "label": "Denton Municipal Airport (United States) (KDTO)"
+  },
+  {
+    "id": "KEDC",
+    "british": false,
+    "label": "Austin Executive Airport (United States) (KEDC)"
+  },
+  {
+    "id": "KRYW",
+    "british": false,
+    "label": "Lago Vista Tx Rusty Allen Airport (United States) (KRYW)"
+  },
+  {
+    "id": "K11R",
+    "british": false,
+    "label": "Brenham Municipal Airport (United States) (K11R)"
+  },
+  {
+    "id": "K3R9",
+    "british": false,
+    "label": "Lakeway Airpark (United States) (K3R9)"
+  },
+  {
+    "id": "IRB",
+    "british": false,
+    "label": "Iraan Municipal Airport (United States) (K2F0 / IRB)"
+  },
+  {
+    "id": "K1T7",
+    "british": false,
+    "label": "Kestrel Airpark (United States) (K1T7)"
+  },
+  {
+    "id": "YEL",
+    "british": false,
+    "label": "Elliot Lake Municipal Airport (Canada) (CYEL / YEL)"
+  },
+  {
+    "id": "IKB",
+    "british": false,
+    "label": "Wilkes County Airport (United States) (KUKF / IKB)"
+  },
+  {
+    "id": "KJZI",
+    "british": false,
+    "label": "Charleston Executive Airport (United States) (KJZI)"
+  },
+  {
+    "id": "DAN",
+    "british": false,
+    "label": "Danville Regional Airport (United States) (KDAN / DAN)"
+  },
+  {
+    "id": "K0V4",
+    "british": false,
+    "label": "Brookneal/Campbell County Airport (United States) (K0V4)"
+  },
+  {
+    "id": "ERG",
+    "british": false,
+    "label": "Yerbogachen Airport (Russia) (UIKE / ERG)"
+  },
+  {
+    "id": "HCW",
+    "british": false,
+    "label": "Cheraw Municipal Airport/Lynch Bellinger Field (United States) (KCQW / HCW)"
+  },
+  {
+    "id": "KCHN",
+    "british": false,
+    "label": "Wauchula Municipal Airport (United States) (KCHN)"
+  },
+  {
+    "id": "YLIL",
+    "british": false,
+    "label": "Lilydale Airport (Australia) (YLIL)"
+  },
+  {
+    "id": "BEM",
+    "british": false,
+    "label": "Beni Mellal Airport (Morocco) (GMMD / BEM)"
+  },
+  {
+    "id": "NKT",
+    "british": false,
+    "label": "Şırnak Şerafettin Elçi Airport (Turkey) (LTCV / NKT)"
+  },
+  {
+    "id": "SUY",
+    "british": false,
+    "label": "Suntar Airport (Russia) (UENS / SUY)"
+  },
+  {
+    "id": "OUZ",
+    "british": false,
+    "label": "Tazadit Airport (Mauritania) (GQPZ / OUZ)"
+  },
+  {
+    "id": "ABB",
+    "british": false,
+    "label": "Asaba International Airport (Nigeria) (DNAS / ABB)"
+  },
+  {
+    "id": "QUO",
+    "british": false,
+    "label": "Akwa Ibom International Airport (Nigeria) (DNAI / QUO)"
+  },
+  {
+    "id": "KAA",
+    "british": false,
+    "label": "Kasama Airport (Zambia) (FLKS / KAA)"
+  },
+  {
+    "id": "HTMB",
+    "british": false,
+    "label": "Mbeya Airport (Tanzania) (HTMB)"
+  },
+  {
+    "id": "HTMP",
+    "british": false,
+    "label": "Mpanda Airport (Tanzania) (HTMP)"
+  },
+  {
+    "id": "SGX",
+    "british": false,
+    "label": "Songea Airport (Tanzania) (HTSO / SGX)"
+  },
+  {
+    "id": "HTMG",
+    "british": false,
+    "label": "Morogoro Airport (Tanzania) (HTMG)"
+  },
+  {
+    "id": "JUH",
+    "british": false,
+    "label": "Jiuhuashan Airport (China) (ZSJH / JUH)"
+  },
+  {
+    "id": "AOG",
+    "british": false,
+    "label": "Anshan Air Base (China) (ZYAS / AOG)"
+  },
+  {
+    "id": "DQA",
+    "british": false,
+    "label": "Saertu Airport (China) (ZYDQ / DQA)"
+  },
+  {
+    "id": "ZYI",
+    "british": false,
+    "label": "Zunyi Xinzhou Airport (China) (ZUZY / ZYI)"
+  },
+  {
+    "id": "KHYW",
+    "british": false,
+    "label": "Conway Horry County Airport (United States) (KHYW)"
+  },
+  {
+    "id": "LDS",
+    "british": false,
+    "label": "Lindu Airport (China) (ZYLD / LDS)"
+  },
+  {
+    "id": "AVA",
+    "british": false,
+    "label": "Anshun Huangguoshu Airport (China) (ZUAS / AVA)"
+  },
+  {
+    "id": "KSS",
+    "british": false,
+    "label": "Sikasso Airport (Mali) (GASK / KSS)"
+  },
+  {
+    "id": "WTB",
+    "british": false,
+    "label": "Toowoomba Wellcamp Airport (Australia) (YBWW / WTB)"
+  },
+  {
+    "id": "TNH",
+    "british": false,
+    "label": "Tonghua Sanyuanpu Airport (China) (ZYTN / TNH)"
+  },
+  {
+    "id": "SZV",
+    "british": false,
+    "label": "Suzhou Guangfu Airport (China) (ZSSZ / SZV)"
+  },
+  {
+    "id": "EGCB",
+    "british": true,
+    "label": "City Airport Manchester (United Kingdom) (EGCB)"
+  },
+  {
+    "id": "EGCV",
+    "british": true,
+    "label": "Sleap Airport (United Kingdom) (EGCV)"
+  },
+  {
+    "id": "EGBM",
+    "british": true,
+    "label": "Tatenhill Airfield (United Kingdom) (EGBM)"
+  },
+  {
+    "id": "EGNU",
+    "british": true,
+    "label": "Full Sutton Airfield (United Kingdom) (EGNU)"
+  },
+  {
+    "id": "EGCJ",
+    "british": true,
+    "label": "Sherburn-In-Elmet Airfield (United Kingdom) (EGCJ)"
+  },
+  {
+    "id": "WAOM",
+    "british": false,
+    "label": "Beringin Airport (Indonesia) (WAOM)"
+  },
+  {
+    "id": "LII",
+    "british": false,
+    "label": "Mulia Airport (Indonesia) (WAJM / LII)"
+  },
+  {
+    "id": "NTI",
+    "british": false,
+    "label": "Stenkol Airport (Indonesia) (WASB / NTI)"
+  },
+  {
+    "id": "WSR",
+    "british": false,
+    "label": "Wasior Airport (Indonesia) (WASW / WSR)"
+  },
+  {
+    "id": "DTB",
+    "british": false,
+    "label": "Silangit Airport (Indonesia) (WIMN / DTB)"
+  },
+  {
+    "id": "WITG",
+    "british": false,
+    "label": "Lasikin Airport (Indonesia) (WITG)"
+  },
+  {
+    "id": "MEQ",
+    "british": false,
+    "label": "Seunagan Airport (Indonesia) (WITC / MEQ)"
+  },
+  {
+    "id": "BUW",
+    "british": false,
+    "label": "Betoambari Airport (Indonesia) (WAWB / BUW)"
+  },
+  {
+    "id": "KAZ",
+    "british": false,
+    "label": "Kao Airport (Indonesia) (WAMK / KAZ)"
+  },
+  {
+    "id": "MNA",
+    "british": false,
+    "label": "Melangguane Airport (Indonesia) (WAMN / MNA)"
+  },
+  {
+    "id": "SGQ",
+    "british": false,
+    "label": "Sanggata/Sangkimah Airport (Indonesia) (WRLA / SGQ)"
+  },
+  {
+    "id": "BUU",
+    "british": false,
+    "label": "Muara Bungo Airport (Indonesia) (WIPI / BUU)"
+  },
+  {
+    "id": "WAWH",
+    "british": false,
+    "label": "Selayar/Aroepala Airport (Indonesia) (WAWH)"
+  },
+  {
+    "id": "ILA",
+    "british": false,
+    "label": "Illaga Airport (Indonesia) (WABL / ILA)"
+  },
+  {
+    "id": "OKL",
+    "british": false,
+    "label": "Oksibil Airport (Indonesia) (WAJO / OKL)"
+  },
+  {
+    "id": "KOX",
+    "british": false,
+    "label": "Kokonau Airport (Indonesia) (WABN / KOX)"
+  },
+  {
+    "id": "CMQ",
+    "british": false,
+    "label": "Clermont Airport (Australia) (YCMT / CMQ)"
+  },
+  {
+    "id": "WMB",
+    "british": false,
+    "label": "Warrnambool Airport (Australia) (YWBL / WMB)"
+  },
+  {
+    "id": "RCM",
+    "british": false,
+    "label": "Richmond Airport (Australia) (YRMD / RCM)"
+  },
+  {
+    "id": "DCN",
+    "british": false,
+    "label": "RAAF Base Curtin (Australia) (YCIN / DCN)"
+  },
+  {
+    "id": "KNO",
+    "british": false,
+    "label": "Kualanamu International Airport (Indonesia) (WIMM / KNO)"
+  },
+  {
+    "id": "AMN",
+    "british": false,
+    "label": "Gratiot Community Airport (Canada) (KAMN / AMN)"
+  },
+  {
+    "id": "KHBI",
+    "british": false,
+    "label": "Asheboro Regional Airport (United States) (KHBI)"
+  },
+  {
+    "id": "HMY",
+    "british": false,
+    "label": "Seosan Air Base (South Korea) (RKTP / HMY)"
+  },
+  {
+    "id": "KACZ",
+    "british": false,
+    "label": "Henderson Field (United States) (KACZ)"
+  },
+  {
+    "id": "KEMV",
+    "british": false,
+    "label": "Emporia Greensville Regional Airport (United States) (KEMV)"
+  },
+  {
+    "id": "EMT",
+    "british": false,
+    "label": "San Gabriel Valley Airport (United States) (KEMT / EMT)"
+  },
+  {
+    "id": "FAH",
+    "british": false,
+    "label": "Farah Airport (Afghanistan) (OAFR / FAH)"
+  },
+  {
+    "id": "IXT",
+    "british": false,
+    "label": "Pasighat Airport (India) (VEPG / IXT)"
+  },
+  {
+    "id": "KI16",
+    "british": false,
+    "label": "Kee Field (United States) (KI16)"
+  },
+  {
+    "id": "KRQ",
+    "british": false,
+    "label": "Kramatorsk Airport (Ukraine) (UKCK / KRQ)"
+  },
+  {
+    "id": "QKX",
+    "british": false,
+    "label": "Kautokeino Air Base (Norway) (ENKA / QKX)"
+  },
+  {
+    "id": "LFQO",
+    "british": false,
+    "label": "Lille/Marcq-en-Baroeul Airport (France) (LFQO)"
+  },
+  {
+    "id": "GUKR",
+    "british": false,
+    "label": "Kawass Airport (Guinea) (GUKR)"
+  },
+  {
+    "id": "SSF",
+    "british": false,
+    "label": "Stinson Municipal Airport (United States) (KSSF / SSF)"
+  },
+  {
+    "id": "KJSV",
+    "british": false,
+    "label": "Sallisaw Municipal Airport (United States) (KJSV)"
+  },
+  {
+    "id": "JAS",
+    "british": false,
+    "label": "Jasper County Airport-Bell Field (United States) (KJAS / JAS)"
+  },
+  {
+    "id": "K87K",
+    "british": false,
+    "label": "El Dorado Springs Memorial Airport (United States) (K87K)"
+  },
+  {
+    "id": "MRF",
+    "british": false,
+    "label": "Marfa Municipal Airport (United States) (KMRF / MRF)"
+  },
+  {
+    "id": "ALE",
+    "british": false,
+    "label": "Alpine Casparis Municipal Airport (United States) (KE38 / ALE)"
+  },
+  {
+    "id": "BQE",
+    "british": false,
+    "label": "Bubaque Airport (Guinea-Bissau) (GGBU / BQE)"
+  },
+  {
+    "id": "CZA",
+    "british": false,
+    "label": "Chichen Itza International Airport (Mexico) (MMCT / CZA)"
+  },
+  {
+    "id": "BUY",
+    "british": false,
+    "label": "Bunbury Airport (Australia) (YBUN / BUY)"
+  },
+  {
+    "id": "CCB",
+    "british": false,
+    "label": "Cable Airport (United States) (KCCB / CCB)"
+  },
+  {
+    "id": "KIOB",
+    "british": false,
+    "label": "Mount Sterling Montgomery County Airport (United States) (KIOB)"
+  },
+  {
+    "id": "EKI",
+    "british": false,
+    "label": "Elkhart Municipal Airport (United States) (KEKM / EKI)"
+  },
+  {
+    "id": "KC03",
+    "british": false,
+    "label": "Nappanee Municipal Airport (United States) (KC03)"
+  },
+  {
+    "id": "CUB",
+    "british": false,
+    "label": "Jim Hamilton L.B. Owens Airport (United States) (KCUB / CUB)"
+  },
+  {
+    "id": "KGMJ",
+    "british": false,
+    "label": "Grove Municipal Airport (United States) (KGMJ)"
+  },
+  {
+    "id": "KMPR",
+    "british": false,
+    "label": "Mc Pherson Airport (United States) (KMPR)"
+  },
+  {
+    "id": "GDC",
+    "british": false,
+    "label": "Donaldson Field Airport (United States) (KGYH / GDC)"
+  },
+  {
+    "id": "KPXE",
+    "british": false,
+    "label": "Perry Houston County Airport (United States) (KPXE)"
+  },
+  {
+    "id": "HVS",
+    "british": false,
+    "label": "Hartsville Regional Airport (United States) (KHVS / HVS)"
+  },
+  {
+    "id": "KIGX",
+    "british": false,
+    "label": "Horace Williams Airport (United States) (KIGX)"
+  },
+  {
+    "id": "SZT",
+    "british": false,
+    "label": "San Cristobal de las Casas Airport (Mexico) (MMSC / SZT)"
+  },
+  {
+    "id": "DU9",
+    "british": false,
+    "label": "Dunnville Airport (Canada) (CDU9 / DU9)"
+  },
+  {
+    "id": "KSUT",
+    "british": false,
+    "label": "Brunswick County Airport (United States) (KSUT)"
+  },
+  {
+    "id": "KFCI",
+    "british": false,
+    "label": "Chesterfield County Airport (United States) (KFCI)"
+  },
+  {
+    "id": "YATN",
+    "british": false,
+    "label": "Atherton Airport (Australia) (YATN)"
+  },
+  {
+    "id": "UIUB",
+    "british": false,
+    "label": "Bagdarin Airport (Russia) (UIUB)"
+  },
+  {
+    "id": "RIH",
+    "british": false,
+    "label": "Scarlett Martinez International Airport (Panama) (MPRH / RIH)"
+  },
+  {
+    "id": "KHNZ",
+    "british": false,
+    "label": "Henderson Oxford Airport (United States) (KHNZ)"
+  },
+  {
+    "id": "LEE",
+    "british": false,
+    "label": "Leesburg International Airport (United States) (KLEE / LEE)"
+  },
+  {
+    "id": "UUBL",
+    "british": false,
+    "label": "Semyazino Airport (Russia) (UUBL)"
+  },
+  {
+    "id": "FATW",
+    "british": false,
+    "label": "Witberg Tswalu Airport (South Africa) (FATW)"
+  },
+  {
+    "id": "FVMN",
+    "british": false,
+    "label": "Mana Pools Airport (Zimbabwe) (FVMN)"
+  },
+  {
+    "id": "PPY",
+    "british": false,
+    "label": "Pouso Alegre Airport (Brazil) (SNZA / PPY)"
+  },
+  {
+    "id": "DIQ",
+    "british": false,
+    "label": "Brigadeiro Cabral Airport (Brazil) (SNDV / DIQ)"
+  },
+  {
+    "id": "EIK",
+    "british": false,
+    "label": "Yeysk Airport (Russia) (URKE / EIK)"
+  },
+  {
+    "id": "ERD",
+    "british": false,
+    "label": "Berdyansk Airport (Ukraine) (UKDB / ERD)"
+  },
+  {
+    "id": "BWX",
+    "british": false,
+    "label": "Blimbingsari Airport (Indonesia) (WARB / BWX)"
+  },
+  {
+    "id": "ERL",
+    "british": false,
+    "label": "Erenhot Saiwusu International Airport (China) (ZBER / ERL)"
+  },
+  {
+    "id": "EGBS",
+    "british": true,
+    "label": "Shobdon Aerodrome (United Kingdom) (EGBS)"
+  },
+  {
+    "id": "CNO",
+    "british": false,
+    "label": "Chino Airport (United States) (KCNO / CNO)"
+  },
+  {
+    "id": "RJDK",
+    "british": false,
+    "label": "Kamigoto Airport (Japan) (RJDK)"
+  },
+  {
+    "id": "RJDO",
+    "british": false,
+    "label": "Ojika Airport (Japan) (RJDO)"
+  },
+  {
+    "id": "RJTF",
+    "british": false,
+    "label": "Chofu Airport (Japan) (RJTF)"
+  },
+  {
+    "id": "HTR",
+    "british": false,
+    "label": "Hateruma Airport (Japan) (RORH / HTR)"
+  },
+  {
+    "id": "KUYF",
+    "british": false,
+    "label": "Madison County Airport (United States) (KUYF)"
+  },
+  {
+    "id": "BWW",
+    "british": false,
+    "label": "Las Brujas Airport (Cuba) (MUBR / BWW)"
+  },
+  {
+    "id": "CDG2",
+    "british": false,
+    "label": "Digby (General Hospital) Heliport (France) (CDG2)"
+  },
+  {
+    "id": "LSZW",
+    "british": false,
+    "label": "Thun Airport (Switzerland) (LSZW)"
+  },
+  {
+    "id": "UHML",
+    "british": false,
+    "label": "Lavrentiya Airport (Russia) (UHML)"
+  },
+  {
+    "id": "PRB",
+    "british": false,
+    "label": "Paso Robles Municipal Airport (United States) (KPRB / PRB)"
+  },
+  {
+    "id": "RKDU",
+    "british": false,
+    "label": "N 104 Helipad (South Korea) (RKDU)"
+  },
+  {
+    "id": "PKX",
+    "british": false,
+    "label": "Beijing Daxing International Airport (China) (ZBAD / PKX)"
+  },
+  {
+    "id": "EFKY",
+    "british": false,
+    "label": "Kymi Airport (Finland) (EFKY)"
+  },
+  {
+    "id": "HAF",
+    "british": false,
+    "label": "Half Moon Bay Airport (United States) (KHAF / HAF)"
+  },
+  {
+    "id": "HCJ",
+    "british": false,
+    "label": "Hechi Jinchengjiang Airport (China) (ZGHC / HCJ)"
+  },
+  {
+    "id": "YKDI",
+    "british": false,
+    "label": "Kadina Airport (Australia) (YKDI)"
+  },
+  {
+    "id": "WJF",
+    "british": false,
+    "label": "General WM J Fox Airfield (United States) (KWJF / WJF)"
+  },
+  {
+    "id": "CJF",
+    "british": false,
+    "label": "Coondewanna Airport (Australia) (YCWA / CJF)"
+  },
+  {
+    "id": "GUZ",
+    "british": false,
+    "label": "Guarapari Airport (Brazil) (SNGA / GUZ)"
+  },
+  {
+    "id": "UBT",
+    "british": false,
+    "label": "Ubatuba Airport (Brazil) (SDUB / UBT)"
+  },
+  {
+    "id": "ORTL",
+    "british": false,
+    "label": "Ali Air Base (Iraq) (ORTL)"
+  },
+  {
+    "id": "LPOT",
+    "british": false,
+    "label": "Ota Air Base (Portugal) (LPOT)"
+  },
+  {
+    "id": "BOX",
+    "british": false,
+    "label": "Borroloola Airport (Australia) (YBRL / BOX)"
+  },
+  {
+    "id": "EDNF",
+    "british": false,
+    "label": "Elsenthal Grafe Airport (Germany) (EDNF)"
+  },
+  {
+    "id": "EGAD",
+    "british": true,
+    "label": "Newtownards Airport (United Kingdom) (EGAD)"
+  },
+  {
+    "id": "EGKH",
+    "british": true,
+    "label": "Lashenden (Headcorn) Airfield (United Kingdom) (EGKH)"
+  },
+  {
+    "id": "EGLG",
+    "british": true,
+    "label": "Panshanger Aerodrome (United Kingdom) (EGLG)"
+  },
+  {
+    "id": "EGMT",
+    "british": true,
+    "label": "Thurrock Airfield (United Kingdom) (EGMT)"
+  },
+  {
+    "id": "EGSG",
+    "british": true,
+    "label": "Stapleford Aerodrome (United Kingdom) (EGSG)"
+  },
+  {
+    "id": "VOBG",
+    "british": false,
+    "label": "HAL Airport (India) (VOBG)"
+  },
+  {
+    "id": "QUG",
+    "british": true,
+    "label": "Chichester/Goodwood Airport (United Kingdom) (EGHR / QUG)"
+  },
+  {
+    "id": "NZOA",
+    "british": false,
+    "label": "Omarama Glider Airport (New Zealand) (NZOA)"
+  },
+  {
+    "id": "NZHT",
+    "british": false,
+    "label": "Haast Aerodrome (New Zealand) (NZHT)"
+  },
+  {
+    "id": "EDKM",
+    "british": false,
+    "label": "Meschede-Schüren Airport (Germany) (EDKM)"
+  },
+  {
+    "id": "TNW",
+    "british": false,
+    "label": "Jumandy Airport (Ecuador) (SEJD / TNW)"
+  },
+  {
+    "id": "SDHU",
+    "british": false,
+    "label": "Morro da Urca Heliport (Brazil) (SDHU)"
+  },
+  {
+    "id": "FYJ",
+    "british": false,
+    "label": "Dongji Aiport (China) (ZYFY / FYJ)"
+  },
+  {
+    "id": "EKSY",
+    "british": false,
+    "label": "Skúvoy Heliport (Faroe Islands) (EKSY)"
+  },
+  {
+    "id": "EKSR",
+    "british": false,
+    "label": "Stóra Dímun Heliport (Faroe Islands) (EKSR)"
+  },
+  {
+    "id": "EKFA",
+    "british": false,
+    "label": "Frooba Heliport (Faroe Islands) (EKFA)"
+  },
+  {
+    "id": "KTDF",
+    "british": false,
+    "label": "Person County Airport (United States) (KTDF)"
+  },
+  {
+    "id": "PZL",
+    "british": false,
+    "label": "Zulu Inyala Airport (South Africa) (FADQ / PZL)"
+  },
+  {
+    "id": "LPF",
+    "british": false,
+    "label": "Liupanshui Yuezhao Airport (China) (ZUPS / LPF)"
+  },
+  {
+    "id": "KJH",
+    "british": false,
+    "label": "Kaili Airport (China) (ZUKJ / KJH)"
+  },
+  {
+    "id": "HPG",
+    "british": false,
+    "label": "Shennongjia Hongping Airport (China) (ZHSN / HPG)"
+  },
+  {
+    "id": "ZQZ",
+    "british": false,
+    "label": "Zhangjiakou Ningyuan Airport (China) (ZBZJ / ZQZ)"
+  },
+  {
+    "id": "YIE",
+    "british": false,
+    "label": "Arxan Yi'ershi Airport (China) (ZBES / YIE)"
+  },
+  {
+    "id": "HNY",
+    "british": false,
+    "label": "Hengyang Nanyue Airport (China) (ZGHY / HNY)"
+  },
+  {
+    "id": "AHJ",
+    "british": false,
+    "label": "Hongyuan Airport (China) (ZUHY / AHJ)"
+  },
+  {
+    "id": "WOS",
+    "british": false,
+    "label": "Wonsan Kalma International Airport (North Korea) (ZKWS / WOS)"
+  },
+  {
+    "id": "UGMS",
+    "british": false,
+    "label": "Mestia Queen Tamar Airport (Georgia) (UGMS)"
+  },
+  {
+    "id": "IGT",
+    "british": false,
+    "label": "Magas Airport (Russia) (URMS / IGT)"
+  },
+  {
+    "id": "ASN",
+    "british": false,
+    "label": "Talladega Municipal Airport (United States) (KASN / ASN)"
+  },
+  {
+    "id": "GMU",
+    "british": false,
+    "label": "Greenville Downtown Airport (United States) (KGMU / GMU)"
+  },
+  {
+    "id": "KMKT",
+    "british": false,
+    "label": "Mankato Regional Airport (United States) (KMKT)"
+  },
+  {
+    "id": "NGD",
+    "british": false,
+    "label": "Captain Auguste George Airport (British Virgin Islands) (TUPA / NGD)"
+  },
+  {
+    "id": "TOI",
+    "british": false,
+    "label": "Troy Municipal Airport at N Kenneth Campbell Field (United States) (KTOI / TOI)"
+  },
+  {
+    "id": "KSCD",
+    "british": false,
+    "label": "Merkel Field Sylacauga Municipal Airport (United States) (KSCD)"
+  },
+  {
+    "id": "ETS",
+    "british": false,
+    "label": "Enterprise Municipal Airport (United States) (KEDN / ETS)"
+  },
+  {
+    "id": "KRYN",
+    "british": false,
+    "label": "Ryan Field (United States) (KRYN)"
+  },
+  {
+    "id": "EFG",
+    "british": false,
+    "label": "Efogi Airport (Papua New Guinea) (AYEF / EFG)"
+  },
+  {
+    "id": "KGW",
+    "british": false,
+    "label": "Kagi Airport (Papua New Guinea) (AYKQ / KGW)"
+  },
+  {
+    "id": "NDN",
+    "british": false,
+    "label": "Nadunumu Airport (Papua New Guinea) (AYNC / NDN)"
+  },
+  {
+    "id": "BNM",
+    "british": false,
+    "label": "Bodinumu Airport (Papua New Guinea) (AYBD / BNM)"
+  },
+  {
+    "id": "ALX",
+    "british": false,
+    "label": "Thomas C Russell Field (United States) (KALX / ALX)"
+  },
+  {
+    "id": "PKT",
+    "british": false,
+    "label": "Port Keats Airport (Australia) (YPKT / PKT)"
+  },
+  {
+    "id": "GPN",
+    "british": false,
+    "label": "Garden Point Airport (Australia) (YGPT / GPN)"
+  },
+  {
+    "id": "EDHS",
+    "british": false,
+    "label": "Stade Airport (Germany) (EDHS)"
+  },
+  {
+    "id": "KMMK",
+    "british": false,
+    "label": "Meriden Markham Municipal Airport (United States) (KMMK)"
+  },
+  {
+    "id": "YFLS",
+    "british": false,
+    "label": "Flinders Island Airport (Australia) (YFLS)"
+  },
+  {
+    "id": "LSZO",
+    "british": false,
+    "label": "Luzern-Beromunster Airport (Switzerland) (LSZO)"
+  },
+  {
+    "id": "LFTN",
+    "british": false,
+    "label": "La Grand'combe Airport (France) (LFTN)"
+  },
+  {
+    "id": "DOH",
+    "british": false,
+    "label": "Hamad International Airport (Qatar) (OTHH / DOH)"
+  },
+  {
+    "id": "HZP",
+    "british": false,
+    "label": "Fort Mackay / Horizon Airport (Canada) (CYNR / HZP)"
+  },
+  {
+    "id": "CEW9",
+    "british": false,
+    "label": "Canmore Municipal Heliport (Canada) (CEW9)"
+  },
+  {
+    "id": "UIAE",
+    "british": false,
+    "label": "Krasnokamensk Airport (Russia) (UIAE)"
+  },
+  {
+    "id": "KRJD",
+    "british": false,
+    "label": "Ridgely Airpark (United States) (KRJD)"
+  },
+  {
+    "id": "KUWL",
+    "british": false,
+    "label": "New Castle Henry Co. Municipal Airport (United States) (KUWL)"
+  },
+  {
+    "id": "KTQK",
+    "british": false,
+    "label": "Scott City Municipal Airport (United States) (KTQK)"
+  },
+  {
+    "id": "HDE",
+    "british": false,
+    "label": "Brewster Field (United States) (KHDE / HDE)"
+  },
+  {
+    "id": "PTT",
+    "british": false,
+    "label": "Pratt Regional Airport (United States) (KPTT / PTT)"
+  },
+  {
+    "id": "UAON",
+    "british": false,
+    "label": "Yubileyniy Airfield (Kazakhstan) (UAON)"
+  },
+  {
+    "id": "KAHQ",
+    "british": false,
+    "label": "Wahoo Municipal Airport (United States) (KAHQ)"
+  },
+  {
+    "id": "LXN",
+    "british": false,
+    "label": "Jim Kelly Field (United States) (KLXN / LXN)"
+  },
+  {
+    "id": "K19S",
+    "british": false,
+    "label": "Sublette Municipal Airport (United States) (K19S)"
+  },
+  {
+    "id": "CBF",
+    "british": false,
+    "label": "Council Bluffs Municipal Airport (United States) (KCBF / CBF)"
+  },
+  {
+    "id": "OKK",
+    "british": false,
+    "label": "Kokomo Municipal Airport (United States) (KOKK / OKK)"
+  },
+  {
+    "id": "K2K7",
+    "british": false,
+    "label": "Neodesha Municipal Airport (United States) (K2K7)"
+  },
+  {
+    "id": "AK59",
+    "british": false,
+    "label": "King Ranch Airport (United States) (AK59)"
+  },
+  {
+    "id": "KEHA",
+    "british": false,
+    "label": "Elkhart Morton County Airport (United States) (KEHA)"
+  },
+  {
+    "id": "KFTG",
+    "british": false,
+    "label": "Front Range Airport (United States) (KFTG)"
+  },
+  {
+    "id": "GBG",
+    "british": false,
+    "label": "Galesburg Municipal Airport (United States) (KGBG / GBG)"
+  },
+  {
+    "id": "GUY",
+    "british": false,
+    "label": "Guymon Municipal Airport (United States) (KGUY / GUY)"
+  },
+  {
+    "id": "KMEJ",
+    "british": false,
+    "label": "Meade Municipal Airport (United States) (KMEJ)"
+  },
+  {
+    "id": "MO00",
+    "british": false,
+    "label": "Turkey Mountain Estates Airport (United States) (MO00)"
+  },
+  {
+    "id": "KULS",
+    "british": false,
+    "label": "Ulysses Airport (United States) (KULS)"
+  },
+  {
+    "id": "CO00",
+    "british": false,
+    "label": "Flagler Aerial Spraying Inc Airport (United States) (CO00)"
+  },
+  {
+    "id": "IDP",
+    "british": false,
+    "label": "Independence Municipal Airport (United States) (KIDP / IDP)"
+  },
+  {
+    "id": "K3AU",
+    "british": false,
+    "label": "Augusta Municipal Airport (United States) (K3AU)"
+  },
+  {
+    "id": "KLQR",
+    "british": false,
+    "label": "Larned Pawnee County Airport (United States) (KLQR)"
+  },
+  {
+    "id": "KLZZ",
+    "british": false,
+    "label": "Lampasas Airport (United States) (KLZZ)"
+  },
+  {
+    "id": "BBC",
+    "british": false,
+    "label": "Bay City Municipal Airport (United States) (KBYY / BBC)"
+  },
+  {
+    "id": "PRX",
+    "british": false,
+    "label": "Cox Field (United States) (KPRX / PRX)"
+  },
+  {
+    "id": "CFV",
+    "british": false,
+    "label": "Coffeyville Municipal Airport (United States) (KCFV / CFV)"
+  },
+  {
+    "id": "24SC",
+    "british": false,
+    "label": "The Farm Airport (United States) (24SC)"
+  },
+  {
+    "id": "GXY",
+    "british": false,
+    "label": "Greeley–Weld County Airport (United States) (KGXY / GXY)"
+  },
+  {
+    "id": "KM01",
+    "british": false,
+    "label": "General Dewitt Spain Airport (United States) (KM01)"
+  },
+  {
+    "id": "OEL",
+    "british": false,
+    "label": "Oryol Yuzhny Airport (United States) (UUOR / OEL)"
+  },
+  {
+    "id": "FET",
+    "british": false,
+    "label": "Fremont Municipal Airport (United States) (KFET / FET)"
+  },
+  {
+    "id": "LGD",
+    "british": false,
+    "label": "La Grande/Union County Airport (United States) (KLGD / LGD)"
+  },
+  {
+    "id": "SZY",
+    "british": false,
+    "label": "Olsztyn-Mazury Airport (Poland) (EPSY / SZY)"
+  },
+  {
+    "id": "MPO",
+    "british": false,
+    "label": "Pocono Mountains Municipal Airport (United States) (KMPO / MPO)"
+  },
+  {
+    "id": "UKT",
+    "british": false,
+    "label": "Quakertown Airport (United States) (KUKT / UKT)"
+  },
+  {
+    "id": "YBA",
+    "british": false,
+    "label": "Banff Airport (Canada) (CYBA / YBA)"
+  },
+  {
+    "id": "EKNB",
+    "british": false,
+    "label": "Nordborg Flyveplads (Denmark) (EKNB)"
+  },
+  {
+    "id": "BNG",
+    "british": false,
+    "label": "Banning Municipal Airport (United States) (KBNG / BNG)"
+  },
+  {
+    "id": "EDFL",
+    "british": false,
+    "label": "Gießen-Lützellinden Airport (Germany) (EDFL)"
+  },
+  {
+    "id": "LHTL",
+    "british": false,
+    "label": "Tököl Airport (Hungary) (LHTL)"
+  },
+  {
+    "id": "OFK",
+    "british": false,
+    "label": "Karl Stefan Memorial Airport (United States) (KOFK / OFK)"
+  },
+  {
+    "id": "HUKO",
+    "british": false,
+    "label": "Kotido Airport (Uganda) (HUKO)"
+  },
+  {
+    "id": "HUKJ",
+    "british": false,
+    "label": "Kajjansi Airfield (Uganda) (HUKJ)"
+  },
+  {
+    "id": "KAWO",
+    "british": false,
+    "label": "Arlington Municipal Airport (United States) (KAWO)"
+  },
+  {
+    "id": "SNZR",
+    "british": false,
+    "label": "Paracatu Airport (Brazil) (SNZR)"
+  },
+  {
+    "id": "SNKF",
+    "british": false,
+    "label": "Das Bandeirinhas Airport (Brazil) (SNKF)"
+  },
+  {
+    "id": "SNAP",
+    "british": false,
+    "label": "Janaúba Airport (Brazil) (SNAP)"
+  },
+  {
+    "id": "TFL",
+    "british": false,
+    "label": "Juscelino Kubitscheck Airport (Brazil) (SNTO / TFL)"
+  },
+  {
+    "id": "SNBM",
+    "british": false,
+    "label": "Cristiano Ferreira Varella Airport (Brazil) (SNBM)"
+  },
+  {
+    "id": "TPF",
+    "british": false,
+    "label": "Peter O Knight Airport (United States) (KTPF / TPF)"
+  },
+  {
+    "id": "LFYL",
+    "british": false,
+    "label": "Lure Malbouhans Air Base (France) (LFYL)"
+  },
+  {
+    "id": "SDTK",
+    "british": false,
+    "label": "Parati Airport (Brazil) (SDTK)"
+  },
+  {
+    "id": "BZC",
+    "british": false,
+    "label": "Umberto Modiano Airport (Brazil) (SBBZ / BZC)"
+  },
+  {
+    "id": "SDAG",
+    "british": false,
+    "label": "Angra dos Reis Airport (Brazil) (SDAG)"
+  },
+  {
+    "id": "ITP",
+    "british": false,
+    "label": "Itaperuna Airport (Brazil) (SDUN / ITP)"
+  },
+  {
+    "id": "SDMC",
+    "british": false,
+    "label": "Maricá Airport (Brazil) (SDMC)"
+  },
+  {
+    "id": "REZ",
+    "british": false,
+    "label": "Resende Airport (Brazil) (SDRS / REZ)"
+  },
+  {
+    "id": "SDSK",
+    "british": false,
+    "label": "Saquarema Airport (Brazil) (SDSK)"
+  },
+  {
+    "id": "CEG4",
+    "british": false,
+    "label": "Drumheller Municipal Airport (Canada) (CEG4)"
+  },
+  {
+    "id": "FZWE",
+    "british": false,
+    "label": "Mwene-Ditu Airport (Congo (Kinshasa)) (FZWE)"
+  },
+  {
+    "id": "KBN",
+    "british": false,
+    "label": "Tunta Airport (Congo (Kinshasa)) (FZWT / KBN)"
+  },
+  {
+    "id": "IKL",
+    "british": false,
+    "label": "Ikela Airport (Congo (Kinshasa)) (FZGV / IKL)"
+  },
+  {
+    "id": "AIR",
+    "british": false,
+    "label": "Aripuanã Airport (Brazil) (SWRP / AIR)"
+  },
+  {
+    "id": "JRN",
+    "british": false,
+    "label": "Juruena Airport (Brazil) (SWJU / JRN)"
+  },
+  {
+    "id": "JIA",
+    "british": false,
+    "label": "Juína Airport (Brazil) (SWJN / JIA)"
+  },
+  {
+    "id": "VLP",
+    "british": false,
+    "label": "Vila Rica Airport (Brazil) (SWVC / VLP)"
+  },
+  {
+    "id": "JUA",
+    "british": false,
+    "label": "Inácio Luís do Nascimento Airport (Brazil) (SIZX / JUA)"
+  },
+  {
+    "id": "CCX",
+    "british": false,
+    "label": "Cáceres Airport (Brazil) (SWKC / CCX)"
+  },
+  {
+    "id": "SWPL",
+    "british": false,
+    "label": "Posto Leonardo Vilas Boas Airport (Brazil) (SWPL)"
+  },
+  {
+    "id": "TGQ",
+    "british": false,
+    "label": "Tangará da Serra Airport (Brazil) (SWTS / TGQ)"
+  },
+  {
+    "id": "CQA",
+    "british": false,
+    "label": "Canarana Airport (Brazil) (SWEK / CQA)"
+  },
+  {
+    "id": "MTG",
+    "british": false,
+    "label": "Vila Bela da Santíssima Trindade Airport (Brazil) (SWVB / MTG)"
+  },
+  {
+    "id": "BMB",
+    "british": false,
+    "label": "Bumbar Airport (Congo (Kinshasa)) (FZFU / BMB)"
+  },
+  {
+    "id": "SNOB",
+    "british": false,
+    "label": "Sobral Airport (Brazil) (SNOB)"
+  },
+  {
+    "id": "APQ",
+    "british": false,
+    "label": "Arapiraca Airport (Brazil) (SNAL / APQ)"
+  },
+  {
+    "id": "FLB",
+    "british": false,
+    "label": "Cangapara Airport (Brazil) (SNQG / FLB)"
+  },
+  {
+    "id": "PCS",
+    "british": false,
+    "label": "Picos Airport (Brazil) (SNPC / PCS)"
+  },
+  {
+    "id": "BNC",
+    "british": false,
+    "label": "Beni Airport (Congo (Kinshasa)) (FZNP / BNC)"
+  },
+  {
+    "id": "BNB",
+    "british": false,
+    "label": "Boende Airport (Congo (Kinshasa)) (FZGN / BNB)"
+  },
+  {
+    "id": "MTP",
+    "british": false,
+    "label": "Montauk Airport (United States) (KMTP / MTP)"
+  },
+  {
+    "id": "VPZ",
+    "british": false,
+    "label": "Porter County Municipal Airport (United States) (KVPZ / VPZ)"
+  },
+  {
+    "id": "DRV",
+    "british": false,
+    "label": "Dharavandhoo Airport (Maldives) (VRMD / DRV)"
+  },
+  {
+    "id": "SXK",
+    "british": false,
+    "label": "Saumlaki/Olilit Airport (Indonesia) (WAPI / SXK)"
+  },
+  {
+    "id": "MLZ",
+    "british": false,
+    "label": "Cerro Largo International Airport (Uruguay) (SUMO / MLZ)"
+  },
+  {
+    "id": "PDU",
+    "british": false,
+    "label": "Tydeo Larre Borges Airport (Uruguay) (SUPU / PDU)"
+  },
+  {
+    "id": "ATI",
+    "british": false,
+    "label": "Artigas International Airport (Uruguay) (SUAG / ATI)"
+  },
+  {
+    "id": "YMBD",
+    "british": false,
+    "label": "Murray Bridge Airport (Australia) (YMBD)"
+  },
+  {
+    "id": "HSM",
+    "british": false,
+    "label": "Horsham Airport (Australia) (YHSM / HSM)"
+  },
+  {
+    "id": "SWH",
+    "british": false,
+    "label": "Swan Hill Airport (Australia) (YSWH / SWH)"
+  },
+  {
+    "id": "TTL",
+    "british": false,
+    "label": "Turtle Island Seaplane Base (Fiji) (NFUL / TTL)"
+  },
+  {
+    "id": "KWB",
+    "british": false,
+    "label": "Dewadaru - Kemujan Island (Indonesia) (WARU / KWB)"
+  },
+  {
+    "id": "KOO",
+    "british": false,
+    "label": "Kongolo Airport (Congo (Kinshasa)) (FZRQ / KOO)"
+  },
+  {
+    "id": "AOU",
+    "british": false,
+    "label": "Attopeu Airport (Laos) (VLAP / AOU)"
+  },
+  {
+    "id": "FZCF",
+    "british": false,
+    "label": "Kahemba Airport (Congo (Kinshasa)) (FZCF)"
+  },
+  {
+    "id": "SVFM",
+    "british": false,
+    "label": "Francisco de Miranda Airport (Venezuela) (SVFM)"
+  },
+  {
+    "id": "SQX",
+    "british": false,
+    "label": "São Miguel do Oeste Airport (Brazil) (SSOE / SQX)"
+  },
+  {
+    "id": "LDM",
+    "british": false,
+    "label": "Mason County Airport (United States) (KLDM / LDM)"
+  },
+  {
+    "id": "RHV",
+    "british": false,
+    "label": "Reid-Hillview Airport of Santa Clara County (United States) (KRHV / RHV)"
+  },
+  {
+    "id": "OHS",
+    "british": false,
+    "label": "Sohar Airport (Oman) (OOSH / OHS)"
+  },
+  {
+    "id": "KCF",
+    "british": false,
+    "label": "Kadanwari Airport (Pakistan) (OPKW / KCF)"
+  },
+  {
+    "id": "RZS",
+    "british": false,
+    "label": "Sawan Airport (Pakistan) (OPSW / RZS)"
+  },
+  {
+    "id": "VNTH",
+    "british": false,
+    "label": "Thamkharka Airport (Nepal) (VNTH)"
+  },
+  {
+    "id": "TMF",
+    "british": false,
+    "label": "Thimarafushi Airport (Maldives) (VRNT / TMF)"
+  },
+  {
+    "id": "IFU",
+    "british": false,
+    "label": "Ifuru Airport (Maldives) (VREI / IFU)"
+  },
+  {
+    "id": "KZF",
+    "british": false,
+    "label": "Kaintiba Airport (Papua New Guinea) (AYKT / KZF)"
+  },
+  {
+    "id": "OGU",
+    "british": false,
+    "label": "Ordu Giresun Airport (Turkey) (LTCB / OGU)"
+  },
+  {
+    "id": "YKO",
+    "british": false,
+    "label": "Hakkari Yüksekova Airport (Turkey) (LTCW / YKO)"
+  },
+  {
+    "id": "EPJG",
+    "british": false,
+    "label": "Jelenia Góra Glider Airport (Poland) (EPJG)"
+  },
+  {
+    "id": "BUT",
+    "british": false,
+    "label": "Bathpalathang Airport (Bhutan) (VQBT / BUT)"
+  },
+  {
+    "id": "TLI",
+    "british": false,
+    "label": "Sultan Bantilan Airport (Indonesia) (WAMI / TLI)"
+  },
+  {
+    "id": "UUYK",
+    "british": false,
+    "label": "Vuktyl Airport (Russia) (UUYK)"
+  },
+  {
+    "id": "USPT",
+    "british": false,
+    "label": "Berezniki Airport (Russia) (USPT)"
+  },
+  {
+    "id": "SCSS",
+    "british": false,
+    "label": "San Sebastián Airport (Chile) (SCSS)"
+  },
+  {
+    "id": "SAWL",
+    "british": false,
+    "label": "Tolwin Observatory Airport (Argentina) (SAWL)"
+  },
+  {
+    "id": "TQL",
+    "british": false,
+    "label": "Tarko-Sale Airport (Russia) (USDS / TQL)"
+  },
+  {
+    "id": "KCMA",
+    "british": false,
+    "label": "Camarillo Airport (United States) (KCMA)"
+  },
+  {
+    "id": "EBLE",
+    "british": false,
+    "label": "Leopoldsburg Airfield (Belgium) (EBLE)"
+  },
+  {
+    "id": "JIC",
+    "british": false,
+    "label": "Jinchuan Airport (China) (ZLJC / JIC)"
+  },
+  {
+    "id": "MNLP",
+    "british": false,
+    "label": "Omtepe Airport (Nicaragua) (MNLP)"
+  },
+  {
+    "id": "BPL",
+    "british": false,
+    "label": "Alashankou Bole (Bortala) airport (China) (ZWAX / BPL)"
+  },
+  {
+    "id": "FYN",
+    "british": false,
+    "label": "Fuyun Koktokay Airport (China) (ZWFY / FYN)"
+  },
+  {
+    "id": "ACS",
+    "british": false,
+    "label": "Achinsk Airport (Russia) (UNKS / ACS)"
+  },
+  {
+    "id": "LFQ",
+    "british": false,
+    "label": "Linfen Qiaoli Airport (China) (ZBLF / LFQ)"
+  },
+  {
+    "id": "YJP",
+    "british": false,
+    "label": "Hinton/Jasper-Hinton Airport (Canada) (CEC4 / YJP)"
+  },
+  {
+    "id": "WVI",
+    "british": false,
+    "label": "Watsonville Municipal Airport (United States) (KWVI / WVI)"
+  },
+  {
+    "id": "GLU",
+    "british": false,
+    "label": "Gelephu Airport (Bhutan) (VQGP / GLU)"
+  },
+  {
+    "id": "HLI",
+    "british": false,
+    "label": "Hollister Municipal Airport (United States) (KCVH / HLI)"
+  },
+  {
+    "id": "KJGG",
+    "british": false,
+    "label": "Williamsburg Jamestown Airport (United States) (KJGG)"
+  },
+  {
+    "id": "DLK",
+    "british": false,
+    "label": "Dulkaninna Airport (Australia) (YDLK / DLK)"
+  },
+  {
+    "id": "YWMC",
+    "british": false,
+    "label": "William Creek Airport (Australia) (YWMC)"
+  },
+  {
+    "id": "CJM9",
+    "british": false,
+    "label": "Kenora Seaplane Base (Canada) (CJM9)"
+  },
+  {
+    "id": "EVRC",
+    "british": false,
+    "label": "Rumbula Air Base (Latvia) (EVRC)"
+  },
+  {
+    "id": "RPVZ",
+    "british": false,
+    "label": "Siquijor Airport (Philippines) (RPVZ)"
+  },
+  {
+    "id": "YBS",
+    "british": false,
+    "label": "Opapimiskan Lake Airport (Canada) (CKM8 / YBS)"
+  },
+  {
+    "id": "RIZ",
+    "british": false,
+    "label": "Rizhao Shanzihe Airport (China) (ZSRZ / RIZ)"
+  },
+  {
+    "id": "SQJ",
+    "british": false,
+    "label": "Shaxian Airport (China) (ZSSM / SQJ)"
+  },
+  {
+    "id": "XTO",
+    "british": false,
+    "label": "Taroom Airport (Australia) (YTAM / XTO)"
+  },
+  {
+    "id": "EDFG",
+    "british": false,
+    "label": "Gelnhausen Airport (Germany) (EDFG)"
+  },
+  {
+    "id": "EKAE",
+    "british": false,
+    "label": "Ærø Airport (Denmark) (EKAE)"
+  },
+  {
+    "id": "EDFT",
+    "british": false,
+    "label": "Lauterbach Airport (Germany) (EDFT)"
+  },
+  {
+    "id": "EDFC",
+    "british": false,
+    "label": "Aschaffenburg Airport (Germany) (EDFC)"
+  },
+  {
+    "id": "YSE",
+    "british": false,
+    "label": "Squamish Airport (Canada) (CYSE / YSE)"
+  },
+  {
+    "id": "EDFB",
+    "british": false,
+    "label": "Reichelsheim Airport (Germany) (EDFB)"
+  },
+  {
+    "id": "EDFN",
+    "british": false,
+    "label": "Marburg-Schönstadt Airport (Germany) (EDFN)"
+  },
+  {
+    "id": "EDHU",
+    "british": false,
+    "label": "Lauenbrück Airport (Germany) (EDHU)"
+  },
+  {
+    "id": "EDXU",
+    "british": false,
+    "label": "Hüttenbusch Airport (Germany) (EDXU)"
+  },
+  {
+    "id": "LDPV",
+    "british": false,
+    "label": "Vrsar Crljenka Airport (Croatia) (LDPV)"
+  },
+  {
+    "id": "KMRT",
+    "british": false,
+    "label": "Union County Airport (United States) (KMRT)"
+  },
+  {
+    "id": "YAH",
+    "british": false,
+    "label": "La Grande-4 Airport (Canada) (CYAH / YAH)"
+  },
+  {
+    "id": "YAL",
+    "british": false,
+    "label": "Alert Bay Airport (Canada) (CYAL / YAL)"
+  },
+  {
+    "id": "CYAU",
+    "british": false,
+    "label": "Liverpool South Shore Regional Airport (Canada) (CYAU)"
+  },
+  {
+    "id": "CYBU",
+    "british": false,
+    "label": "Nipawin Airport (Canada) (CYBU)"
+  },
+  {
+    "id": "YCE",
+    "british": false,
+    "label": "Centralia / James T. Field Memorial Aerodrome (Canada) (CYCE / YCE)"
+  },
+  {
+    "id": "CYCP",
+    "british": false,
+    "label": "Blue River Airport (Canada) (CYCP)"
+  },
+  {
+    "id": "YCQ",
+    "british": false,
+    "label": "Chetwynd Airport (Canada) (CYCQ / YCQ)"
+  },
+  {
+    "id": "XRR",
+    "british": false,
+    "label": "Ross River Airport (Canada) (CYDM / XRR)"
+  },
+  {
+    "id": "YDO",
+    "british": false,
+    "label": "Dolbeau St Felicien Airport (Canada) (CYDO / YDO)"
+  },
+  {
+    "id": "YEY",
+    "british": false,
+    "label": "Amos/Magny Airport (Canada) (CYEY / YEY)"
+  },
+  {
+    "id": "CYGD",
+    "british": false,
+    "label": "Goderich Airport (Canada) (CYGD)"
+  },
+  {
+    "id": "YHE",
+    "british": false,
+    "label": "Hope Airport (Canada) (CYHE / YHE)"
+  },
+  {
+    "id": "YHT",
+    "british": false,
+    "label": "Haines Junction Airport (Canada) (CYHT / YHT)"
+  },
+  {
+    "id": "YDG",
+    "british": false,
+    "label": "Digby / Annapolis Regional Airport (Canada) (CYID / YDG)"
+  },
+  {
+    "id": "YJF",
+    "british": false,
+    "label": "Fort Liard Airport (Canada) (CYJF / YJF)"
+  },
+  {
+    "id": "YKJ",
+    "british": false,
+    "label": "Key Lake Airport (Canada) (CYKJ / YKJ)"
+  },
+  {
+    "id": "YLR",
+    "british": false,
+    "label": "Leaf Rapids Airport (Canada) (CYLR / YLR)"
+  },
+  {
+    "id": "YME",
+    "british": false,
+    "label": "Matane Airport (Canada) (CYME / YME)"
+  },
+  {
+    "id": "YML",
+    "british": false,
+    "label": "Charlevoix Airport (Canada) (CYML / YML)"
+  },
+  {
+    "id": "CYNN",
+    "british": false,
+    "label": "Nejanilini Lake Airport (Canada) (CYNN)"
+  },
+  {
+    "id": "YOS",
+    "british": false,
+    "label": "Owen Sound / Billy Bishop Regional Airport (Canada) (CYOS / YOS)"
+  },
+  {
+    "id": "YPS",
+    "british": false,
+    "label": "Port Hawkesbury Airport (Canada) (CYPD / YPS)"
+  },
+  {
+    "id": "YQS",
+    "british": false,
+    "label": "St Thomas Municipal Airport (Canada) (CYQS / YQS)"
+  },
+  {
+    "id": "YRO",
+    "british": false,
+    "label": "Ottawa / Rockcliffe Airport (Canada) (CYRO / YRO)"
+  },
+  {
+    "id": "CYRP",
+    "british": false,
+    "label": "Ottawa / Carp Airport (Canada) (CYRP)"
+  },
+  {
+    "id": "YSH",
+    "british": false,
+    "label": "Smiths Falls-Montague (Russ Beach) Airport (Canada) (CYSH / YSH)"
+  },
+  {
+    "id": "YSL",
+    "british": false,
+    "label": "St Leonard Airport (Canada) (CYSL / YSL)"
+  },
+  {
+    "id": "CYVD",
+    "british": false,
+    "label": "Virden/R.J. (Bob) Andrew Field Regional Aerodrome (Canada) (CYVD)"
+  },
+  {
+    "id": "YVE",
+    "british": false,
+    "label": "Vernon Airport (Canada) (CYVK / YVE)"
+  },
+  {
+    "id": "YXQ",
+    "british": false,
+    "label": "Beaver Creek Airport (Canada) (CYXQ / YXQ)"
+  },
+  {
+    "id": "YSN",
+    "british": false,
+    "label": "Shuswap Regional Airport (Canada) (CZAM / YSN)"
+  },
+  {
+    "id": "KES",
+    "british": false,
+    "label": "Kelsey Airport (Canada) (CZEE / KES)"
+  },
+  {
+    "id": "XPK",
+    "british": false,
+    "label": "Pukatawagan Airport (Canada) (CZFG / XPK)"
+  },
+  {
+    "id": "ZGF",
+    "british": false,
+    "label": "Grand Forks Airport (Canada) (CZGF / ZGF)"
+  },
+  {
+    "id": "ZJG",
+    "british": false,
+    "label": "Jenpeg Airport (Canada) (CZJG / ZJG)"
+  },
+  {
+    "id": "YTD",
+    "british": false,
+    "label": "Thicket Portage Airport (Canada) (CZLQ / YTD)"
+  },
+  {
+    "id": "PIW",
+    "british": false,
+    "label": "Pikwitonei Airport (Canada) (CZMN / PIW)"
+  },
+  {
+    "id": "XPP",
+    "british": false,
+    "label": "Poplar River Airport (Canada) (CZNG / XPP)"
+  },
+  {
+    "id": "WPC",
+    "british": false,
+    "label": "Pincher Creek Airport (Canada) (CZPC / WPC)"
+  },
+  {
+    "id": "ZST",
+    "british": false,
+    "label": "Stewart Airport (Canada) (CZST / ZST)"
+  },
+  {
+    "id": "ZUC",
+    "british": false,
+    "label": "Ignace Municipal Airport (Canada) (CZUC / ZUC)"
+  },
+  {
+    "id": "FNB",
+    "british": false,
+    "label": "Neubrandenburg Airport (Germany) (EDBN / FNB)"
+  },
+  {
+    "id": "EDQA",
+    "british": false,
+    "label": "Airport Bamberg-Breitenau (Germany) (EDQA)"
+  },
+  {
+    "id": "EDUZ",
+    "british": false,
+    "label": "Zerbst Airport (Germany) (EDUZ)"
+  },
+  {
+    "id": "EGOM",
+    "british": true,
+    "label": "RAF Spadeadam (United Kingdom) (EGOM)"
+  },
+  {
+    "id": "FSS",
+    "british": true,
+    "label": "RAF Kinloss (United Kingdom) (EGQK / FSS)"
+  },
+  {
+    "id": "BXP",
+    "british": false,
+    "label": "Biała Podlaska Airfield (Poland) (EPBP / BXP)"
+  },
+  {
+    "id": "EPCE",
+    "british": false,
+    "label": "Cewice Air Base (Poland) (EPCE)"
+  },
+  {
+    "id": "EPDE",
+    "british": false,
+    "label": "Deblin Military Air Base (Poland) (EPDE)"
+  },
+  {
+    "id": "EPLY",
+    "british": false,
+    "label": "Leczyca Military Air Base (Poland) (EPLY)"
+  },
+  {
+    "id": "EPMM",
+    "british": false,
+    "label": "Minsk Mazowiecki Military Air Base (Poland) (EPMM)"
+  },
+  {
+    "id": "EPPW",
+    "british": false,
+    "label": "Powidz Military Air Base (Poland) (EPPW)"
+  },
+  {
+    "id": "EPTM",
+    "british": false,
+    "label": "Tomaszow Mazowiecki Military Air Base (Poland) (EPTM)"
+  },
+  {
+    "id": "ESKX",
+    "british": false,
+    "label": "Björkvik Air Base (Sweden) (ESKX)"
+  },
+  {
+    "id": "ESTL",
+    "british": false,
+    "label": "Ljungbyhed Airport (Sweden) (ESTL)"
+  },
+  {
+    "id": "DGP",
+    "british": false,
+    "label": "Daugavpils Intrenational Airport (Latvia) (EVDA / DGP)"
+  },
+  {
+    "id": "EVKA",
+    "british": false,
+    "label": "Jēkabpils Air Base (Latvia) (EVKA)"
+  },
+  {
+    "id": "EVTA",
+    "british": false,
+    "label": "Jūrmala Airport (Latvia) (EVTA)"
+  },
+  {
+    "id": "EYKD",
+    "british": false,
+    "label": "Kėdainiai Air Base (Lithuania) (EYKD)"
+  },
+  {
+    "id": "LMR",
+    "british": false,
+    "label": "Lime Acres Finsch Mine Airport (South Africa) (FALC / LMR)"
+  },
+  {
+    "id": "SXN",
+    "british": false,
+    "label": "Sua Pan Airport (Botswana) (FBSN / SXN)"
+  },
+  {
+    "id": "FLLC",
+    "british": false,
+    "label": "Lusaka City Airport (Zambia) (FLLC)"
+  },
+  {
+    "id": "NDD",
+    "british": false,
+    "label": "Sumbe Airport (Angola) (FNSU / NDD)"
+  },
+  {
+    "id": "MAI",
+    "british": false,
+    "label": "Mangochi Airport (Malawi) (FWMG / MAI)"
+  },
+  {
+    "id": "ADI",
+    "british": false,
+    "label": "Arandis Airport (Namibia) (FYAR / ADI)"
+  },
+  {
+    "id": "FYML",
+    "british": false,
+    "label": "Mariental Airport (Namibia) (FYML)"
+  },
+  {
+    "id": "HEAZ",
+    "british": false,
+    "label": "Almaza Air Force Base (Egypt) (HEAZ)"
+  },
+  {
+    "id": "HEBS",
+    "british": false,
+    "label": "Beni Suef Air Base (Egypt) (HEBS)"
+  },
+  {
+    "id": "HEGS",
+    "british": false,
+    "label": "Jiyanklis Air Base (Egypt) (HEGS)"
+  },
+  {
+    "id": "MWE",
+    "british": false,
+    "label": "Merowe New Airport (Sudan) (HSMN / MWE)"
+  },
+  {
+    "id": "ALN",
+    "british": false,
+    "label": "St Louis Regional Airport (United States) (KALN / ALN)"
+  },
+  {
+    "id": "AXN",
+    "british": false,
+    "label": "Chandler Field (United States) (KAXN / AXN)"
+  },
+  {
+    "id": "CLU",
+    "british": false,
+    "label": "Columbus Municipal Airport (United States) (KBAK / CLU)"
+  },
+  {
+    "id": "BBD",
+    "british": false,
+    "label": "Curtis Field (United States) (KBBD / BBD)"
+  },
+  {
+    "id": "BIH",
+    "british": false,
+    "label": "Eastern Sierra Regional Airport (United States) (KBIH / BIH)"
+  },
+  {
+    "id": "BKE",
+    "british": false,
+    "label": "Baker City Municipal Airport (United States) (KBKE / BKE)"
+  },
+  {
+    "id": "BPI",
+    "british": false,
+    "label": "Miley Memorial Field (United States) (KBPI / BPI)"
+  },
+  {
+    "id": "WMH",
+    "british": false,
+    "label": "Ozark Regional Airport (United States) (KBPK / WMH)"
+  },
+  {
+    "id": "BTL",
+    "british": false,
+    "label": "W K Kellogg Airport (United States) (KBTL / BTL)"
+  },
+  {
+    "id": "BYI",
+    "british": false,
+    "label": "Burley Municipal Airport (United States) (KBYI / BYI)"
+  },
+  {
+    "id": "CCY",
+    "british": false,
+    "label": "Northeast Iowa Regional Airport (United States) (KCCY / CCY)"
+  },
+  {
+    "id": "CNU",
+    "british": false,
+    "label": "Chanute Martin Johnson Airport (United States) (KCNU / CNU)"
+  },
+  {
+    "id": "CRG",
+    "british": false,
+    "label": "Jacksonville Executive at Craig Airport (United States) (KCRG / CRG)"
+  },
+  {
+    "id": "CSV",
+    "british": false,
+    "label": "Crossville Memorial Whitson Field (United States) (KCSV / CSV)"
+  },
+  {
+    "id": "DAA",
+    "british": false,
+    "label": "Davison Army Air Field (United States) (KDAA / DAA)"
+  },
+  {
+    "id": "DAG",
+    "british": false,
+    "label": "Barstow Daggett Airport (United States) (KDAG / DAG)"
+  },
+  {
+    "id": "DMN",
+    "british": false,
+    "label": "Deming Municipal Airport (United States) (KDMN / DMN)"
+  },
+  {
+    "id": "DRA",
+    "british": false,
+    "label": "Desert Rock Airport (United States) (KDRA / DRA)"
+  },
+  {
+    "id": "EED",
+    "british": false,
+    "label": "Needles Airport (United States) (KEED / EED)"
+  },
+  {
+    "id": "EGI",
+    "british": false,
+    "label": "Duke Field (United States) (KEGI / EGI)"
+  },
+  {
+    "id": "EKA",
+    "british": false,
+    "label": "Murray Field (United States) (KEKA / EKA)"
+  },
+  {
+    "id": "KHYI",
+    "british": false,
+    "label": "San Marcos Regional Airport (United States) (KHYI)"
+  },
+  {
+    "id": "HYR",
+    "british": false,
+    "label": "Sawyer County Airport (United States) (KHYR / HYR)"
+  },
+  {
+    "id": "JCT",
+    "british": false,
+    "label": "Kimble County Airport (United States) (KJCT / JCT)"
+  },
+  {
+    "id": "KLLQ",
+    "british": false,
+    "label": "Monticello Municipal Ellis Field (United States) (KLLQ)"
+  },
+  {
+    "id": "LOL",
+    "british": false,
+    "label": "Derby Field (United States) (KLOL / LOL)"
+  },
+  {
+    "id": "MBG",
+    "british": false,
+    "label": "Mobridge Municipal Airport (United States) (KMBG / MBG)"
+  },
+  {
+    "id": "MCB",
+    "british": false,
+    "label": "Mc Comb/Pike County Airport/John E Lewis Field (United States) (KMCB / MCB)"
+  },
+  {
+    "id": "MDH",
+    "british": false,
+    "label": "Southern Illinois Airport (United States) (KMDH / MDH)"
+  },
+  {
+    "id": "MMT",
+    "british": false,
+    "label": "Mc Entire Joint National Guard Base (United States) (KMMT / MMT)"
+  },
+  {
+    "id": "NHZ",
+    "british": false,
+    "label": "Brunswick Executive Airport (United States) (KNHZ / NHZ)"
+  },
+  {
+    "id": "NRB",
+    "british": false,
+    "label": "Naval Station Mayport (Admiral David L. Mcdonald Field) (United States) (KNRB / NRB)"
+  },
+  {
+    "id": "OGB",
+    "british": false,
+    "label": "Orangeburg Municipal Airport (United States) (KOGB / OGB)"
+  },
+  {
+    "id": "KOLU",
+    "british": false,
+    "label": "Columbus Municipal Airport (United States) (KOLU)"
+  },
+  {
+    "id": "OTM",
+    "british": false,
+    "label": "Ottumwa Regional Airport (United States) (KOTM / OTM)"
+  },
+  {
+    "id": "OZR",
+    "british": false,
+    "label": "Cairns AAF (Fort Rucker) Air Field (United States) (KOZR / OZR)"
+  },
+  {
+    "id": "PWY",
+    "british": false,
+    "label": "Ralph Wenz Field (United States) (KPNA / PWY)"
+  },
+  {
+    "id": "POU",
+    "british": false,
+    "label": "Dutchess County Airport (United States) (KPOU / POU)"
+  },
+  {
+    "id": "KRNH",
+    "british": false,
+    "label": "New Richmond Regional Airport (United States) (KRNH)"
+  },
+  {
+    "id": "RSL",
+    "british": false,
+    "label": "Russell Municipal Airport (United States) (KRSL / RSL)"
+  },
+  {
+    "id": "RWF",
+    "british": false,
+    "label": "Redwood Falls Municipal Airport (United States) (KRWF / RWF)"
+  },
+  {
+    "id": "SNS",
+    "british": false,
+    "label": "Salinas Municipal Airport (United States) (KSNS / SNS)"
+  },
+  {
+    "id": "KSOA",
+    "british": false,
+    "label": "Sonora Municipal Airport (United States) (KSOA)"
+  },
+  {
+    "id": "KSUZ",
+    "british": false,
+    "label": "Saline County Regional Airport (United States) (KSUZ)"
+  },
+  {
+    "id": "TPH",
+    "british": false,
+    "label": "Tonopah Airport (United States) (KTPH / TPH)"
+  },
+  {
+    "id": "KUAO",
+    "british": false,
+    "label": "Aurora State Airport (United States) (KUAO)"
+  },
+  {
+    "id": "UKI",
+    "british": false,
+    "label": "Ukiah Municipal Airport (United States) (KUKI / UKI)"
+  },
+  {
+    "id": "UOX",
+    "british": false,
+    "label": "University Oxford Airport (United States) (KUOX / UOX)"
+  },
+  {
+    "id": "HTV",
+    "british": false,
+    "label": "Huntsville Regional Airport (United States) (KUTS / HTV)"
+  },
+  {
+    "id": "VTN",
+    "british": false,
+    "label": "Miller Field (United States) (KVTN / VTN)"
+  },
+  {
+    "id": "WMC",
+    "british": false,
+    "label": "Winnemucca Municipal Airport (United States) (KWMC / WMC)"
+  },
+  {
+    "id": "WWR",
+    "british": false,
+    "label": "West Woodward Airport (United States) (KWWR / WWR)"
+  },
+  {
+    "id": "KXMR",
+    "british": false,
+    "label": "Cape Canaveral AFS Skid Strip (United States) (KXMR)"
+  },
+  {
+    "id": "KXTA",
+    "british": false,
+    "label": "Homey (Area 51) Airport (United States) (KXTA)"
+  },
+  {
+    "id": "ZZV",
+    "british": false,
+    "label": "Zanesville Municipal Airport (United States) (KZZV / ZZV)"
+  },
+  {
+    "id": "LAGJ",
+    "british": false,
+    "label": "Gjadër Air Base (Albania) (LAGJ)"
+  },
+  {
+    "id": "LAKU",
+    "british": false,
+    "label": "Kukës Airport (Albania) (LAKU)"
+  },
+  {
+    "id": "LAKV",
+    "british": false,
+    "label": "Kuçovë Air Base (Albania) (LAKV)"
+  },
+  {
+    "id": "LAVL",
+    "british": false,
+    "label": "Vlorë Air Base (Albania) (LAVL)"
+  },
+  {
+    "id": "LBHS",
+    "british": false,
+    "label": "Haskovo Malevo Airport (Bulgaria) (LBHS)"
+  },
+  {
+    "id": "LBMG",
+    "british": false,
+    "label": "Gabrovnitsa Air Base (Bulgaria) (LBMG)"
+  },
+  {
+    "id": "LBPG",
+    "british": false,
+    "label": "Graf Ignatievo Air Base (Bulgaria) (LBPG)"
+  },
+  {
+    "id": "LBPL",
+    "british": false,
+    "label": "Dolna Mitropoliya Air Base (Bulgaria) (LBPL)"
+  },
+  {
+    "id": "LBWB",
+    "british": false,
+    "label": "Balchik Air Base (Bulgaria) (LBWB)"
+  },
+  {
+    "id": "ECV",
+    "british": false,
+    "label": "Cuatro Vientos Airport (Spain) (LECU / ECV)"
+  },
+  {
+    "id": "CDT",
+    "british": false,
+    "label": "Castellón-Costa Azahar Airport (Spain) (LEDS / CDT)"
+  },
+  {
+    "id": "TEV",
+    "british": false,
+    "label": "Teruel Airport (Spain) (LETL / TEV)"
+  },
+  {
+    "id": "LFOQ",
+    "british": false,
+    "label": "Blois-Le Breuil Airport (France) (LFOQ)"
+  },
+  {
+    "id": "LIDT",
+    "british": false,
+    "label": "Trento-Mattarello Airport (Italy) (LIDT)"
+  },
+  {
+    "id": "LILA",
+    "british": false,
+    "label": "Alessandria Airport (Italy) (LILA)"
+  },
+  {
+    "id": "LILE",
+    "british": false,
+    "label": "Biella-Cerrione Airport (Italy) (LILE)"
+  },
+  {
+    "id": "LILI",
+    "british": false,
+    "label": "Vercelli Airport (Italy) (LILI)"
+  },
+  {
+    "id": "LILM",
+    "british": false,
+    "label": "Casale Monferrato Airport (Italy) (LILM)"
+  },
+  {
+    "id": "LILN",
+    "british": false,
+    "label": "Varese-Venegono Airport (Italy) (LILN)"
+  },
+  {
+    "id": "LIMR",
+    "british": false,
+    "label": "Novi Ligure Airport (Italy) (LIMR)"
+  },
+  {
+    "id": "QLP",
+    "british": false,
+    "label": "Sarzana-Luni Air Base (Italy) (LIQW / QLP)"
+  },
+  {
+    "id": "LRCT",
+    "british": false,
+    "label": "Câmpia Turzii Air Base (Romania) (LRCT)"
+  },
+  {
+    "id": "LUBM",
+    "british": false,
+    "label": "Mărculeşti International Airport (Moldova) (LUBM)"
+  },
+  {
+    "id": "LUCH",
+    "british": false,
+    "label": "Cahul International Airport (Moldova) (LUCH)"
+  },
+  {
+    "id": "LUTR",
+    "british": false,
+    "label": "Tiraspol Airport (Moldova) (LUTR)"
+  },
+  {
+    "id": "BJY",
+    "british": false,
+    "label": "Batajnica Air Base (Serbia) (LYBT / BJY)"
+  },
+  {
+    "id": "RUV",
+    "british": false,
+    "label": "Rubelsanto Airport (Guatemala) (MGRB / RUV)"
+  },
+  {
+    "id": "XPL",
+    "british": false,
+    "label": "Coronel Enrique Soto Cano Air Base (Honduras) (MHSC / XPL)"
+  },
+  {
+    "id": "UPL",
+    "british": false,
+    "label": "Upala Airport (Costa Rica) (MRUP / UPL)"
+  },
+  {
+    "id": "QSN",
+    "british": false,
+    "label": "San Nicolas De Bari Airport (Cuba) (MUNB / QSN)"
+  },
+  {
+    "id": "SNJ",
+    "british": false,
+    "label": "San Julian Air Base (Cuba) (MUSJ / SNJ)"
+  },
+  {
+    "id": "DWD",
+    "british": false,
+    "label": "King Salman Abdulaziz Airport (Saudi Arabia) (OEDM / DWD)"
+  },
+  {
+    "id": "KMX",
+    "british": false,
+    "label": "King Khaled Air Base (Saudi Arabia) (OEKM / KMX)"
+  },
+  {
+    "id": "XXN",
+    "british": false,
+    "label": "Riyadh Air Base (Saudi Arabia) (OERY / XXN)"
+  },
+  {
+    "id": "KNR",
+    "british": false,
+    "label": "Jam Airport (Iran) (OIBJ / KNR)"
+  },
+  {
+    "id": "OIHS",
+    "british": false,
+    "label": "Hamadan Air Base (Iran) (OIHS)"
+  },
+  {
+    "id": "PYK",
+    "british": false,
+    "label": "Payam International Airport (Iran) (OIIP / PYK)"
+  },
+  {
+    "id": "XIJ",
+    "british": false,
+    "label": "Ahmed Al Jaber Air Base (Kuwait) (OKAJ / XIJ)"
+  },
+  {
+    "id": "OLRA",
+    "british": false,
+    "label": "Rayak Air Base (Lebanon) (OLRA)"
+  },
+  {
+    "id": "OPMK",
+    "british": false,
+    "label": "Mirpur Khas Air Base (Pakistan) (OPMK)"
+  },
+  {
+    "id": "ATG",
+    "british": false,
+    "label": "Minhas Air Base (Pakistan) (OPMS / ATG)"
+  },
+  {
+    "id": "OPRQ",
+    "british": false,
+    "label": "Rafiqui Air Base (Pakistan) (OPRQ)"
+  },
+  {
+    "id": "OPSF",
+    "british": false,
+    "label": "Faisal Air Base (Pakistan) (OPSF)"
+  },
+  {
+    "id": "SGI",
+    "british": false,
+    "label": "Mushaf Air Base (Pakistan) (OPSR / SGI)"
+  },
+  {
+    "id": "RQW",
+    "british": false,
+    "label": "Qayyarah West Airport (Iraq) (ORQW / RQW)"
+  },
+  {
+    "id": "ORSH",
+    "british": false,
+    "label": "Al Sahra Army Air Field (Iraq) (ORSH)"
+  },
+  {
+    "id": "ORTF",
+    "british": false,
+    "label": "Tall Afar Army Air Field (Iraq) (ORTF)"
+  },
+  {
+    "id": "ORTI",
+    "british": false,
+    "label": "Al Taji Army Air Field (Iraq) (ORTI)"
+  },
+  {
+    "id": "ORUB",
+    "british": false,
+    "label": "Ubaydah Bin Al Jarrah Airport (Iraq) (ORUB)"
+  },
+  {
+    "id": "ENN",
+    "british": false,
+    "label": "Nenana Municipal Airport (United States) (PANN / ENN)"
+  },
+  {
+    "id": "WWA",
+    "british": false,
+    "label": "Wasilla Airport (United States) (PAWS / WWA)"
+  },
+  {
+    "id": "RCAY",
+    "british": false,
+    "label": "Gangshan Air Force Base (Taiwan) (RCAY)"
+  },
+  {
+    "id": "RJCA",
+    "british": false,
+    "label": "Asahikawa Airfield (Japan) (RJCA)"
+  },
+  {
+    "id": "IWK",
+    "british": false,
+    "label": "Iwakuni Marine Corps Air Station (Japan) (RJOI / IWK)"
+  },
+  {
+    "id": "RJTU",
+    "british": false,
+    "label": "Utsunomiya Airport (Japan) (RJTU)"
+  },
+  {
+    "id": "RKTI",
+    "british": false,
+    "label": "Jungwon Air Base/Chungju Airport (South Korea) (RKTI)"
+  },
+  {
+    "id": "IEJ",
+    "british": false,
+    "label": "Ie Jima Airport (Japan) (RORE / IEJ)"
+  },
+  {
+    "id": "AAV",
+    "british": false,
+    "label": "Allah Valley Airport (Philippines) (RPMA / AAV)"
+  },
+  {
+    "id": "BPH",
+    "british": false,
+    "label": "Bislig Airport (Philippines) (RPMF / BPH)"
+  },
+  {
+    "id": "MXI",
+    "british": false,
+    "label": "Mati National Airport (Philippines) (RPMQ / MXI)"
+  },
+  {
+    "id": "SAOV",
+    "british": false,
+    "label": "Presidente Néstor Kirchner Regionsl Airport (Argentina) (SAOV)"
+  },
+  {
+    "id": "BAT",
+    "british": false,
+    "label": "Chafei Amsei Airport (Brazil) (SBBT / BAT)"
+  },
+  {
+    "id": "QHP",
+    "british": false,
+    "label": "Base de Aviação de Taubaté Airport (Brazil) (SBTA / QHP)"
+  },
+  {
+    "id": "TOQ",
+    "british": false,
+    "label": "Barriles Airport (Chile) (SCBE / TOQ)"
+  },
+  {
+    "id": "SCHR",
+    "british": false,
+    "label": "Schroeder's field (Chile) (SCHR)"
+  },
+  {
+    "id": "CNR",
+    "british": false,
+    "label": "Chañaral Airport (Chile) (SCRA / CNR)"
+  },
+  {
+    "id": "TLX",
+    "british": false,
+    "label": "Panguilemo Airport (Chile) (SCTL / TLX)"
+  },
+  {
+    "id": "ZIC",
+    "british": false,
+    "label": "Victoria Airport (Chile) (SCTO / ZIC)"
+  },
+  {
+    "id": "TTC",
+    "british": false,
+    "label": "Las Breas Airport (Chile) (SCTT / TTC)"
+  },
+  {
+    "id": "API",
+    "british": false,
+    "label": "Gomez Nino Apiay Air Base (Colombia) (SKAP / API)"
+  },
+  {
+    "id": "CVE",
+    "british": false,
+    "label": "Coveñas Airport (Colombia) (SKCV / CVE)"
+  },
+  {
+    "id": "PAL",
+    "british": false,
+    "label": "German Olano Air Base (Colombia) (SKPQ / PAL)"
+  },
+  {
+    "id": "PZA",
+    "british": false,
+    "label": "Paz De Ariporo Airport (Colombia) (SKPZ / PZA)"
+  },
+  {
+    "id": "SKTJ",
+    "british": false,
+    "label": "Tunja Airport (Colombia) (SKTJ)"
+  },
+  {
+    "id": "TQS",
+    "british": false,
+    "label": "Tres Esquinas Air Base (Colombia) (SKTQ / TQS)"
+  },
+  {
+    "id": "SKUA",
+    "british": false,
+    "label": "Marandúa Air Base (Colombia) (SKUA)"
+  },
+  {
+    "id": "RIJ",
+    "british": false,
+    "label": "Juan Simons Vela Airport (Peru) (SPJA / RIJ)"
+  },
+  {
+    "id": "JAE",
+    "british": false,
+    "label": "Shumba Airport (Peru) (SPJE / JAE)"
+  },
+  {
+    "id": "SVMP",
+    "british": false,
+    "label": "Metropolitano Airport (Venezuela) (SVMP)"
+  },
+  {
+    "id": "IKU",
+    "british": false,
+    "label": "Issyk-Kul International Airport (Kyrgyzstan) (UAFL / IKU)"
+  },
+  {
+    "id": "UAFW",
+    "british": false,
+    "label": "Kant Air Base (Kyrgyzstan) (UAFW)"
+  },
+  {
+    "id": "UASA",
+    "british": false,
+    "label": "Ayaguz Airport (Kazakhstan) (UASA)"
+  },
+  {
+    "id": "UATR",
+    "british": false,
+    "label": "Chelkar Airport (Kazakhstan) (UATR)"
+  },
+  {
+    "id": "UENK",
+    "british": false,
+    "label": "Kyzyl-Syr Airport (Russia) (UENK)"
+  },
+  {
+    "id": "VYI",
+    "british": false,
+    "label": "Vilyuisk Airport (Russia) (UENW / VYI)"
+  },
+  {
+    "id": "BGN",
+    "british": false,
+    "label": "Belaya Gora Airport (Russia) (UESG / BGN)"
+  },
+  {
+    "id": "UGEJ",
+    "british": false,
+    "label": "Dzhermuk Airport (Armenia) (UGEJ)"
+  },
+  {
+    "id": "UHKG",
+    "british": false,
+    "label": "Kamenny Ruchey Naval Air Base (Russia) (UHKG)"
+  },
+  {
+    "id": "GVN",
+    "british": false,
+    "label": "Maygatka Airport. (Russia) (UHKM / GVN)"
+  },
+  {
+    "id": "UHMF",
+    "british": false,
+    "label": "Omsukchan Airport (Russia) (UHMF)"
+  },
+  {
+    "id": "UHMG",
+    "british": false,
+    "label": "Chaybukha Airport (Russia) (UHMG)"
+  },
+  {
+    "id": "UHMK",
+    "british": false,
+    "label": "Keperveem Airport (Russia) (UHMK)"
+  },
+  {
+    "id": "UHMT",
+    "british": false,
+    "label": "Magadan-13 Airport (Russia) (UHMT)"
+  },
+  {
+    "id": "NLI",
+    "british": false,
+    "label": "Nikolayevsk-na-Amure Airport (Russia) (UHNN / NLI)"
+  },
+  {
+    "id": "UHPL",
+    "british": false,
+    "label": "Palana Airport (Russia) (UHPL)"
+  },
+  {
+    "id": "UIBV",
+    "british": false,
+    "label": "Zheleznogorsk Airport (Russia) (UIBV)"
+  },
+  {
+    "id": "UKFG",
+    "british": false,
+    "label": "Gvardeyskoe Air Base (Ukraine) (UKFG)"
+  },
+  {
+    "id": "UKFI",
+    "british": false,
+    "label": "Saki Air Base (Ukraine) (UKFI)"
+  },
+  {
+    "id": "UKFY",
+    "british": false,
+    "label": "Dzhankoy Airport (Ukraine) (UKFY)"
+  },
+  {
+    "id": "UKKO",
+    "british": false,
+    "label": "Ozerne Air Base (Ukraine) (UKKO)"
+  },
+  {
+    "id": "ULAK",
+    "british": false,
+    "label": "Severomorsk-1 Naval Air Base (Russia) (ULAK)"
+  },
+  {
+    "id": "ULLP",
+    "british": false,
+    "label": "Pushkin Airport (Russia) (ULLP)"
+  },
+  {
+    "id": "ULLS",
+    "british": false,
+    "label": "Siversky Air Base (Russia) (ULLS)"
+  },
+  {
+    "id": "ULNR",
+    "british": false,
+    "label": "Staraya Russa Air Base (Russia) (ULNR)"
+  },
+  {
+    "id": "ULPP",
+    "british": false,
+    "label": "Peski Airport (Russia) (ULPP)"
+  },
+  {
+    "id": "UMMA",
+    "british": false,
+    "label": "Baranavichi Air Base (Belarus) (UMMA)"
+  },
+  {
+    "id": "UMNB",
+    "british": false,
+    "label": "Babruisk Air Base (Belarus) (UMNB)"
+  },
+  {
+    "id": "UNIS",
+    "british": false,
+    "label": "Severo-Eniseysk Airport (Russia) (UNIS)"
+  },
+  {
+    "id": "UNKO",
+    "british": false,
+    "label": "Sharypovo Airport (Russia) (UNKO)"
+  },
+  {
+    "id": "UNOS",
+    "british": false,
+    "label": "Omsk Severny Airport (Russia) (UNOS)"
+  },
+  {
+    "id": "UODN",
+    "british": false,
+    "label": "Nagurskoye (Russia) (UODN)"
+  },
+  {
+    "id": "UOIG",
+    "british": false,
+    "label": "Svetlogorsk Airport (Russia) (UOIG)"
+  },
+  {
+    "id": "UOOW",
+    "british": false,
+    "label": "Valek Airport (Russia) (UOOW)"
+  },
+  {
+    "id": "URKH",
+    "british": false,
+    "label": "Khanskaya Air Base (Russia) (URKH)"
+  },
+  {
+    "id": "UROD",
+    "british": false,
+    "label": "Dudinka Airport (Russia) (UROD)"
+  },
+  {
+    "id": "VLK",
+    "british": false,
+    "label": "Volgodonsk Airport (Russia) (URRY / VLK)"
+  },
+  {
+    "id": "UTTP",
+    "british": false,
+    "label": "Tashkent East Airport (Uzbekistan) (UTTP)"
+  },
+  {
+    "id": "UUBM",
+    "british": false,
+    "label": "Myachkovo Airport (Russia) (UUBM)"
+  },
+  {
+    "id": "UUMT",
+    "british": false,
+    "label": "Tretyakovo Airport (Russia) (UUMT)"
+  },
+  {
+    "id": "UUWE",
+    "british": false,
+    "label": "Yermolino Airport (Russia) (UUWE)"
+  },
+  {
+    "id": "INA",
+    "british": false,
+    "label": "Inta Airport (Russia) (UUYI / INA)"
+  },
+  {
+    "id": "UUYV",
+    "british": false,
+    "label": "Izhma Airport (Russia) (UUYV)"
+  },
+  {
+    "id": "UWKG",
+    "british": false,
+    "label": "Borisoglebskoye Airport (Russia) (UWKG)"
+  },
+  {
+    "id": "ZIX",
+    "british": false,
+    "label": "Zhigansk Airport (Russia) (UWKV / ZIX)"
+  },
+  {
+    "id": "UWUM",
+    "british": false,
+    "label": "Maksimovka Airport (Russia) (UWUM)"
+  },
+  {
+    "id": "UWWB",
+    "british": false,
+    "label": "Buguruslan Severny Airport (Russia) (UWWB)"
+  },
+  {
+    "id": "UWWG",
+    "british": false,
+    "label": "Bezymyanka Airfield (Russia) (UWWG)"
+  },
+  {
+    "id": "RTC",
+    "british": false,
+    "label": "Ratnagiri Airport (India) (VARG / RTC)"
+  },
+  {
+    "id": "HIM",
+    "british": false,
+    "label": "Hingurakgoda Air Force Base (Sri Lanka) (VCCH / HIM)"
+  },
+  {
+    "id": "RDP",
+    "british": false,
+    "label": "Kazi Nazrul Islam Airport (India) (VEDG / RDP)"
+  },
+  {
+    "id": "VIAM",
+    "british": false,
+    "label": "Ambala Air Force Station (India) (VIAM)"
+  },
+  {
+    "id": "VISA",
+    "british": false,
+    "label": "Sirsa Air Force Station (India) (VISA)"
+  },
+  {
+    "id": "VIUX",
+    "british": false,
+    "label": "Udhampur Air Force Station (India) (VIUX)"
+  },
+  {
+    "id": "PUT",
+    "british": false,
+    "label": "Sri Sathya Sai Airport (India) (VOPN / PUT)"
+  },
+  {
+    "id": "VYML",
+    "british": false,
+    "label": "Meiktila Air Base (Burma) (VYML)"
+  },
+  {
+    "id": "WSAC",
+    "british": false,
+    "label": "Changi Air Base (East) (Singapore) (WSAC)"
+  },
+  {
+    "id": "XLLL",
+    "british": false,
+    "label": "Soltsy-2 Air Base (Russia) (XLLL)"
+  },
+  {
+    "id": "XLMV",
+    "british": false,
+    "label": "Severomorsk-3 Naval Air Base (Russia) (XLMV)"
+  },
+  {
+    "id": "XLWF",
+    "british": false,
+    "label": "Fedotovo Naval Air Base (Russia) (XLWF)"
+  },
+  {
+    "id": "XRWL",
+    "british": false,
+    "label": "Lebyazhye Air Base (Russia) (XRWL)"
+  },
+  {
+    "id": "LNX",
+    "british": false,
+    "label": "Smolensk North Airport (Russia) (XUBS / LNX)"
+  },
+  {
+    "id": "XWPR",
+    "british": false,
+    "label": "Rtishchevo Air Base (Russia) (XWPR)"
+  },
+  {
+    "id": "ABH",
+    "british": false,
+    "label": "Alpha Airport (Australia) (YAPH / ABH)"
+  },
+  {
+    "id": "ARY",
+    "british": false,
+    "label": "Ararat Airport (Australia) (YARA / ARY)"
+  },
+  {
+    "id": "BLN",
+    "british": false,
+    "label": "Benalla Airport (Australia) (YBLA / BLN)"
+  },
+  {
+    "id": "BZD",
+    "british": false,
+    "label": "Balranald Airport (Australia) (YBRN / BZD)"
+  },
+  {
+    "id": "BWQ",
+    "british": false,
+    "label": "Brewarrina Airport (Australia) (YBRW / BWQ)"
+  },
+  {
+    "id": "CVC",
+    "british": false,
+    "label": "Cleve Airport (Australia) (YCEE / CVC)"
+  },
+  {
+    "id": "CWW",
+    "british": false,
+    "label": "Corowa Airport (Australia) (YCOR / CWW)"
+  },
+  {
+    "id": "CYG",
+    "british": false,
+    "label": "Corryong Airport (Australia) (YCRG / CYG)"
+  },
+  {
+    "id": "CMD",
+    "british": false,
+    "label": "Cootamundra Airport (Australia) (YCTM / CMD)"
+  },
+  {
+    "id": "DRN",
+    "british": false,
+    "label": "Dirranbandi Airport (Australia) (YDBI / DRN)"
+  },
+  {
+    "id": "DNQ",
+    "british": false,
+    "label": "Deniliquin Airport (Australia) (YDLQ / DNQ)"
+  },
+  {
+    "id": "DYA",
+    "british": false,
+    "label": "Dysart Airport (Australia) (YDYS / DYA)"
+  },
+  {
+    "id": "ECH",
+    "british": false,
+    "label": "Echuca Airport (Australia) (YECH / ECH)"
+  },
+  {
+    "id": "FRB",
+    "british": false,
+    "label": "Forbes Airport (Australia) (YFBS / FRB)"
+  },
+  {
+    "id": "GUH",
+    "british": false,
+    "label": "Gunnedah Airport (Australia) (YGDH / GUH)"
+  },
+  {
+    "id": "HXX",
+    "british": false,
+    "label": "Hay Airport (Australia) (YHAY / HXX)"
+  },
+  {
+    "id": "HTU",
+    "british": false,
+    "label": "Hopetoun Airport (Australia) (YHPN / HTU)"
+  },
+  {
+    "id": "KRA",
+    "british": false,
+    "label": "Kerang Airport (Australia) (YKER / KRA)"
+  },
+  {
+    "id": "KPS",
+    "british": false,
+    "label": "Kempsey Airport (Australia) (YKMP / KPS)"
+  },
+  {
+    "id": "KGY",
+    "british": false,
+    "label": "Kingaroy Airport (Australia) (YKRY / KGY)"
+  },
+  {
+    "id": "TGN",
+    "british": false,
+    "label": "Latrobe Valley Airport (Australia) (YLTV / TGN)"
+  },
+  {
+    "id": "MRG",
+    "british": false,
+    "label": "Mareeba Airport (Australia) (YMBA / MRG)"
+  },
+  {
+    "id": "RPM",
+    "british": false,
+    "label": "Ngukurr Airport (Australia) (YNGU / RPM)"
+  },
+  {
+    "id": "QRM",
+    "british": false,
+    "label": "Narromine Airport (Australia) (YNRM / QRM)"
+  },
+  {
+    "id": "PPI",
+    "british": false,
+    "label": "Port Pirie Airport (Australia) (YPIR / PPI)"
+  },
+  {
+    "id": "SIO",
+    "british": false,
+    "label": "Smithton Airport (Australia) (YSMI / SIO)"
+  },
+  {
+    "id": "SNB",
+    "british": false,
+    "label": "Snake Bay Airport (Australia) (YSNB / SNB)"
+  },
+  {
+    "id": "SWC",
+    "british": false,
+    "label": "Stawell Airport (Australia) (YSWL / SWC)"
+  },
+  {
+    "id": "TYB",
+    "british": false,
+    "label": "Tibooburra Airport (Australia) (YTIB / TYB)"
+  },
+  {
+    "id": "TUM",
+    "british": false,
+    "label": "Tumut Airport (Australia) (YTMU / TUM)"
+  },
+  {
+    "id": "WGT",
+    "british": false,
+    "label": "Wangaratta Airport (Australia) (YWGT / WGT)"
+  },
+  {
+    "id": "WKB",
+    "british": false,
+    "label": "Warracknabeal Airport (Australia) (YWKB / WKB)"
+  },
+  {
+    "id": "QRR",
+    "british": false,
+    "label": "Warren Airport (Australia) (YWRN / QRR)"
+  },
+  {
+    "id": "SXE",
+    "british": false,
+    "label": "West Sale Airport (Australia) (YWSL / SXE)"
+  },
+  {
+    "id": "WWY",
+    "british": false,
+    "label": "West Wyalong Airport (Australia) (YWWL / WWY)"
+  },
+  {
+    "id": "NGA",
+    "british": false,
+    "label": "Young Airport (Australia) (YYNG / NGA)"
+  },
+  {
+    "id": "LHK",
+    "british": false,
+    "label": "Guangzhou MR Air Base (China) (ZHGH / LHK)"
+  },
+  {
+    "id": "WDS",
+    "british": false,
+    "label": "Shiyan Wudangshan Airport (China) (ZHSY / WDS)"
+  },
+  {
+    "id": "ZKSC",
+    "british": false,
+    "label": "Sunchon Air Base (North Korea) (ZKSC)"
+  },
+  {
+    "id": "HTT",
+    "british": false,
+    "label": "Huatugou Airport (China) (ZLHX / HTT)"
+  },
+  {
+    "id": "UUN",
+    "british": false,
+    "label": "Baruun Urt Airport (Mongolia) (ZMBU / UUN)"
+  },
+  {
+    "id": "BFU",
+    "british": false,
+    "label": "Bengbu Airport (China) (ZSBB / BFU)"
+  },
+  {
+    "id": "RUG",
+    "british": false,
+    "label": "Rugao Air Base (China) (ZSRG / RUG)"
+  },
+  {
+    "id": "WHU",
+    "british": false,
+    "label": "Wuhu Air Base (China) (ZSWU / WHU)"
+  },
+  {
+    "id": "SXJ",
+    "british": false,
+    "label": "Shanshan Airport (China) (ZWSS / SXJ)"
+  },
+  {
+    "id": "YKH",
+    "british": false,
+    "label": "Yingkou Lanqi Airport (China) (ZYYK / YKH)"
+  },
+  {
+    "id": "ZYYY",
+    "british": false,
+    "label": "Shenyang Dongta Airport (China) (ZYYY)"
+  },
+  {
+    "id": "BQG",
+    "british": false,
+    "label": "Bogorodskoye Airport (Russia) (UHNB / BQG)"
+  },
+  {
+    "id": "SSYT",
+    "british": false,
+    "label": "Itapiranga Airport (Brazil) (SSYT)"
+  },
+  {
+    "id": "SPAT",
+    "british": false,
+    "label": "Aguas Calientes Airport (Peru) (SPAT)"
+  },
+  {
+    "id": "HYD",
+    "british": false,
+    "label": "Rajiv Gandhi International Airport (India) (VOHS / HYD)"
+  },
+  {
+    "id": "CAM9",
+    "british": false,
+    "label": "Vancouver International Seaplane Base (Canada) (CAM9)"
+  },
+  {
+    "id": "LSZQ",
+    "british": false,
+    "label": "Bressaucourt Airport (Switzerland) (LSZQ)"
+  },
+  {
+    "id": "PKO",
+    "british": false,
+    "label": "Parakou Airport (Benin) (DBBP / PKO)"
+  },
+  {
+    "id": "KDC",
+    "british": false,
+    "label": "Kandi Airport (Benin) (DBBK / KDC)"
+  },
+  {
+    "id": "DXSK",
+    "british": false,
+    "label": "Sokodé Airport (Togo) (DXSK)"
+  },
+  {
+    "id": "DXMG",
+    "british": false,
+    "label": "Sansanné-Mango Airport (Togo) (DXMG)"
+  },
+  {
+    "id": "EDNB",
+    "british": false,
+    "label": "Arnbruck Airport (Germany) (EDNB)"
+  },
+  {
+    "id": "SBJR",
+    "british": false,
+    "label": "Jacarepaguá - Roberto Marinho Airport (Brazil) (SBJR)"
+  },
+  {
+    "id": "SKAG",
+    "british": false,
+    "label": "Hacaritama Airport (Colombia) (SKAG)"
+  },
+  {
+    "id": "HMG",
+    "british": false,
+    "label": "Hermannsburg Airport (Australia) (YHMB / HMG)"
+  },
+  {
+    "id": "YMDV",
+    "british": false,
+    "label": "Mount Davies Airport (Australia) (YMDV)"
+  },
+  {
+    "id": "YARN",
+    "british": false,
+    "label": "Areyonga Airport (Australia) (YARN)"
+  },
+  {
+    "id": "KTCY",
+    "british": false,
+    "label": "Tracy Municipal Airport (United States) (KTCY)"
+  },
+  {
+    "id": "YMNA",
+    "british": false,
+    "label": "Mount Allan Airport (Australia) (YMNA)"
+  },
+  {
+    "id": "YEVP",
+    "british": false,
+    "label": "Everard Park Airport (Australia) (YEVP)"
+  },
+  {
+    "id": "YWBI",
+    "british": false,
+    "label": "Warrabri Airport (Australia) (YWBI)"
+  },
+  {
+    "id": "EDLK",
+    "british": false,
+    "label": "Krefeld-Egelsberg Airport (Germany) (EDLK)"
+  },
+  {
+    "id": "BIB",
+    "british": false,
+    "label": "Baidoa Airport (Somalia) (HCMB / BIB)"
+  },
+  {
+    "id": "YAMJ",
+    "british": false,
+    "label": "Ampilatwatja Airport (Australia) (YAMJ)"
+  },
+  {
+    "id": "KCS",
+    "british": false,
+    "label": "Kings Creek Airport (Australia) (YKCS / KCS)"
+  },
+  {
+    "id": "YHTS",
+    "british": false,
+    "label": "Harts Range Airport (Australia) (YHTS)"
+  },
+  {
+    "id": "YELL",
+    "british": false,
+    "label": "Elliott Airport (Australia) (YELL)"
+  },
+  {
+    "id": "YPAY",
+    "british": false,
+    "label": "Papunya Airport (Australia) (YPAY)"
+  },
+  {
+    "id": "YFRG",
+    "british": false,
+    "label": "Fregon Airport (Australia) (YFRG)"
+  },
+  {
+    "id": "YLBG",
+    "british": false,
+    "label": "Mount Liebig Airport (Australia) (YLBG)"
+  },
+  {
+    "id": "KTZR",
+    "british": false,
+    "label": "Bolton Field (United States) (KTZR)"
+  },
+  {
+    "id": "BMR",
+    "british": false,
+    "label": "Baltrum Airport (Germany) (EDWZ / BMR)"
+  },
+  {
+    "id": "MVW",
+    "british": false,
+    "label": "Skagit Regional Airport (United States) (KBVS / MVW)"
+  },
+  {
+    "id": "GOO",
+    "british": false,
+    "label": "Goondiwindi Airport (Australia) (YGDI / GOO)"
+  },
+  {
+    "id": "UKOE",
+    "british": false,
+    "label": "Liman Airfield (Ukraine) (UKOE)"
+  },
+  {
+    "id": "LFPL",
+    "british": false,
+    "label": "Lognes Emerainville Airport (France) (LFPL)"
+  },
+  {
+    "id": "APT",
+    "british": false,
+    "label": "Marion County Brown Field (United States) (KAPT / APT)"
+  },
+  {
+    "id": "KGZH",
+    "british": false,
+    "label": "Evergreen Regional Airport/Middleton Field (United States) (KGZH)"
+  },
+  {
+    "id": "DCU",
+    "british": false,
+    "label": "Pryor Field Regional Airport (United States) (KDCU / DCU)"
+  },
+  {
+    "id": "GLW",
+    "british": false,
+    "label": "Glasgow Municipal Airport (United States) (KGLW / GLW)"
+  },
+  {
+    "id": "KLZD",
+    "british": false,
+    "label": "Danielson Airport (United States) (KLZD)"
+  },
+  {
+    "id": "DKV",
+    "british": false,
+    "label": "Docker River Airport (Australia) (YDVR / DKV)"
+  },
+  {
+    "id": "KFIG",
+    "british": false,
+    "label": "Clearfield Lawrence Airport (United States) (KFIG)"
+  },
+  {
+    "id": "RNZ",
+    "british": false,
+    "label": "Jasper County Airport (United States) (KRZL / RNZ)"
+  },
+  {
+    "id": "YTIT",
+    "british": false,
+    "label": "Ti Tree Airport (Australia) (YTIT)"
+  },
+  {
+    "id": "SBT",
+    "british": false,
+    "label": "Sabetta International Airport (Russia) (USDA / SBT)"
+  },
+  {
+    "id": "AXF",
+    "british": false,
+    "label": "Alxa Left Banner Bayanhot Airport (China) (ZBAL / AXF)"
+  },
+  {
+    "id": "SVFT",
+    "british": false,
+    "label": "El Fuentero Airport (Denmark) (SVFT)"
+  },
+  {
+    "id": "EGCS",
+    "british": false,
+    "label": "Sturgate Airfield (Hungary) (EGCS)"
+  },
+  {
+    "id": "NIS",
+    "british": false,
+    "label": "Simberi Airport (Papua New Guinea) (AYSE / NIS)"
+  },
+  {
+    "id": "BUL",
+    "british": false,
+    "label": "Bulolo Airport (Papua New Guinea) (AYBU / BUL)"
+  },
+  {
+    "id": "YKNT",
+    "british": false,
+    "label": "Kintore Airport (Australia) (YKNT)"
+  },
+  {
+    "id": "TBR",
+    "british": false,
+    "label": "Statesboro Bulloch County Airport (United States) (KTBR / TBR)"
+  },
+  {
+    "id": "YUTP",
+    "british": false,
+    "label": "Utopia Airport (Australia) (YUTP)"
+  },
+  {
+    "id": "YNRR",
+    "british": false,
+    "label": "Nyrripi Airport (Australia) (YNRR)"
+  },
+  {
+    "id": "AMT",
+    "british": false,
+    "label": "Amata Airport (Australia) (YAMT / AMT)"
+  },
+  {
+    "id": "NZGH",
+    "british": false,
+    "label": "Glacier Country Heliport (New Zealand) (NZGH)"
+  },
+  {
+    "id": "EDD",
+    "british": false,
+    "label": "Erldunda Airport (Australia) (YERL / EDD)"
+  },
+  {
+    "id": "SSHH",
+    "british": false,
+    "label": "Helisul I Heliport (Brazil) (SSHH)"
+  },
+  {
+    "id": "FIK",
+    "british": false,
+    "label": "Finke Airport (Australia) (YFNE / FIK)"
+  },
+  {
+    "id": "JJG",
+    "british": false,
+    "label": "Humberto Ghizzo Bortoluzzi Regional Airport (Brazil) (SBJA / JJG)"
+  },
+  {
+    "id": "YNYP",
+    "british": false,
+    "label": "Nypari Airport (Australia) (YNYP)"
+  },
+  {
+    "id": "LBHT",
+    "british": false,
+    "label": "Ihtiman Airfield (Bulgaria) (LBHT)"
+  },
+  {
+    "id": "EDNV",
+    "british": false,
+    "label": "Vogtareuth Airport (Germany) (EDNV)"
+  },
+  {
+    "id": "XXXX",
+    "british": false,
+    "label": "[Duplicate] Illertissen see EDMI - ED-0425 location moved out-of-the way (New Zealand) (XXXX)"
+  },
+  {
+    "id": "KEVB",
+    "british": false,
+    "label": "New Smyrna Beach Municipal Airport (United States) (KEVB)"
+  },
+  {
+    "id": "NV03",
+    "british": false,
+    "label": "Las Vegas Helicopters Heliport (United States) (NV03)"
+  },
+  {
+    "id": "FBDT",
+    "british": false,
+    "label": "Delta Camp Airport (Botswana) (FBDT)"
+  },
+  {
+    "id": "WKI",
+    "british": false,
+    "label": "Hwange (Town) Airport (Zimbabwe) (FVWT / WKI)"
+  },
+  {
+    "id": "CBC7",
+    "british": false,
+    "label": "Harbour (Public) Heliport (Canada) (CBC7)"
+  },
+  {
+    "id": "CBF7",
+    "british": false,
+    "label": "Victoria Harbour (Camel Point) Heliport (Canada) (CBF7)"
+  },
+  {
+    "id": "UNAU",
+    "british": false,
+    "label": "Shushenskoye Airport (Russia) (UNAU)"
+  },
+  {
+    "id": "LOAU",
+    "british": false,
+    "label": "Stockerau Airport (Austria) (LOAU)"
+  },
+  {
+    "id": "KLJ",
+    "british": false,
+    "label": "Klaipėda Airport (Lithuania) (EYKL / KLJ)"
+  },
+  {
+    "id": "KMRJ",
+    "british": false,
+    "label": "Iowa County Airport (United States) (KMRJ)"
+  },
+  {
+    "id": "ETB",
+    "british": false,
+    "label": "West Bend Municipal Airport (United States) (KETB / ETB)"
+  },
+  {
+    "id": "GLR",
+    "british": false,
+    "label": "Gaylord Regional Airport (United States) (KGLR / GLR)"
+  },
+  {
+    "id": "AID",
+    "british": false,
+    "label": "Anderson Municipal Darlington Field (United States) (KAID / AID)"
+  },
+  {
+    "id": "QND",
+    "british": false,
+    "label": "Cenej Airport (Serbia) (LYNS / QND)"
+  },
+  {
+    "id": "GUU",
+    "british": false,
+    "label": "Grundarfjörður Airport (Iceland) (BIGF / GUU)"
+  },
+  {
+    "id": "PCD",
+    "british": false,
+    "label": "Prairie Du Chien Municipal Airport (United States) (KPDC / PCD)"
+  },
+  {
+    "id": "WA98",
+    "british": false,
+    "label": "Cascade Heliport (Indonesia) (WA98)"
+  },
+  {
+    "id": "2FD7",
+    "british": false,
+    "label": "Air Orlando Heliport (United States) (2FD7)"
+  },
+  {
+    "id": "EKTB",
+    "british": false,
+    "label": "Tórshavn/Bodanes Heliport (Faroe Islands) (EKTB)"
+  },
+  {
+    "id": "OTJ",
+    "british": false,
+    "label": "Otjiwarongo Airport (Namibia) (FYOW / OTJ)"
+  },
+  {
+    "id": "EGOQ",
+    "british": true,
+    "label": "RAF Mona (United Kingdom) (EGOQ)"
+  },
+  {
+    "id": "EDCR",
+    "british": false,
+    "label": "Rerik-Zweedorf Airport (Germany) (EDCR)"
+  },
+  {
+    "id": "SSVV",
+    "british": false,
+    "label": "Fazenda Vaticano Airport (Brazil) (SSVV)"
+  },
+  {
+    "id": "KVUJ",
+    "british": false,
+    "label": "Stanly County Airport (United States) (KVUJ)"
+  },
+  {
+    "id": "KEXX",
+    "british": false,
+    "label": "Davidson County Airport (United States) (KEXX)"
+  },
+  {
+    "id": "WV62",
+    "british": false,
+    "label": "Windwood Fly-In Resort Airport (United States) (WV62)"
+  },
+  {
+    "id": "5NC2",
+    "british": false,
+    "label": "Lathan Strip (United States) (5NC2)"
+  },
+  {
+    "id": "KAEG",
+    "british": false,
+    "label": "Double Eagle II Airport (United States) (KAEG)"
+  },
+  {
+    "id": "KONM",
+    "british": false,
+    "label": "Socorro Municipal Airport (United States) (KONM)"
+  },
+  {
+    "id": "KVBT",
+    "british": false,
+    "label": "Bentonville Municipal-Louise M Thaden Field (United States) (KVBT)"
+  },
+  {
+    "id": "KMTV",
+    "british": false,
+    "label": "Blue Ridge Airport (United States) (KMTV)"
+  },
+  {
+    "id": "KMWK",
+    "british": false,
+    "label": "Mount Airy Surry County Airport (United States) (KMWK)"
+  },
+  {
+    "id": "TSM",
+    "british": false,
+    "label": "Taos Regional Airport (United States) (KSKX / TSM)"
+  },
+  {
+    "id": "RTN",
+    "british": false,
+    "label": "Raton Municipal-Crews Field (United States) (KRTN / RTN)"
+  },
+  {
+    "id": "KRCX",
+    "british": false,
+    "label": "Rusk County Airport (United States) (KRCX)"
+  },
+  {
+    "id": "PPA",
+    "british": false,
+    "label": "Perry Lefors Field (United States) (KPPA / PPA)"
+  },
+  {
+    "id": "KOWP",
+    "british": false,
+    "label": "William R. Pogue Municipal Airport (United States) (KOWP)"
+  },
+  {
+    "id": "FLP",
+    "british": false,
+    "label": "Marion County Regional Airport (United States) (KFLP / FLP)"
+  },
+  {
+    "id": "BGD",
+    "british": false,
+    "label": "Hutchinson County Airport (United States) (KBGD / BGD)"
+  },
+  {
+    "id": "LHBS",
+    "british": false,
+    "label": "Budaörs Airfield (Hungary) (LHBS)"
+  },
+  {
+    "id": "LHJK",
+    "british": false,
+    "label": "Jakabszállás Airport (Hungary) (LHJK)"
+  },
+  {
+    "id": "HLE",
+    "british": true,
+    "label": "St. Helena Airport (United Kingdom) (FHSH / HLE)"
+  },
+  {
+    "id": "BNJ",
+    "british": false,
+    "label": "Bonn-Hangelar Airport (Germany) (EDKB / BNJ)"
+  },
+  {
+    "id": "NGK",
+    "british": false,
+    "label": "Nogliki Airport (Russia) (UHSN / NGK)"
+  },
+  {
+    "id": "SQA",
+    "british": false,
+    "label": "Santa Ynez Airport (United States) (KIZA / SQA)"
+  },
+  {
+    "id": "HXD",
+    "british": false,
+    "label": "Delingha Airport (China) (ZLDL / HXD)"
+  },
+  {
+    "id": "BAR",
+    "british": false,
+    "label": "Qionghai Bo'ao Airport (China) (ZJQH / BAR)"
+  },
+  {
+    "id": "EDVN",
+    "british": false,
+    "label": "Northeim Airport (Germany) (EDVN)"
+  },
+  {
+    "id": "LIDE",
+    "british": false,
+    "label": "Reggio Emilia Airport (Italy) (LIDE)"
+  },
+  {
+    "id": "ZBO",
+    "british": false,
+    "label": "Bowen Airport (Australia) (YBWN / ZBO)"
+  },
+  {
+    "id": "UCB",
+    "british": false,
+    "label": "Ulanqab Jining Airport (China) (ZBUC / UCB)"
+  },
+  {
+    "id": "KEO",
+    "british": false,
+    "label": "Odienne Airport (Cote d'Ivoire) (DIOD / KEO)"
+  },
+  {
+    "id": "GII",
+    "british": false,
+    "label": "Siguiri Airport (Guinea) (GUSI / GII)"
+  },
+  {
+    "id": "NZE",
+    "british": false,
+    "label": "Nzérékoré Airport (Guinea) (GUNZ / NZE)"
+  },
+  {
+    "id": "OCM",
+    "british": false,
+    "label": "Boolgeeda (Australia) (YBGD / OCM)"
+  },
+  {
+    "id": "WGN",
+    "british": false,
+    "label": "Shaoyang Wugang Airport (China) (ZGSY / WGN)"
+  },
+  {
+    "id": "TXF",
+    "british": false,
+    "label": "9 de Maio - Teixeira de Freitas Airport (Brazil) (SNTF / TXF)"
+  },
+  {
+    "id": "SPA",
+    "british": false,
+    "label": "Spartanburg Downtown Memorial Airport (United States) (KSPA / SPA)"
+  },
+  {
+    "id": "BJW",
+    "british": false,
+    "label": "Bajawa Soa Airport (Indonesia) (WATB / BJW)"
+  },
+  {
+    "id": "EDOG",
+    "british": false,
+    "label": "Torgau-Beilrode Airport (Germany) (EDOG)"
+  },
+  {
+    "id": "NBN",
+    "british": false,
+    "label": "Annobón Airport (Equatorial Guinea) (FGAB / NBN)"
+  },
+  {
+    "id": "HSRN",
+    "british": false,
+    "label": "Renk Airport (China) (HSRN)"
+  },
+  {
+    "id": "OLL",
+    "british": false,
+    "label": "Oyo Ollombo Airport (Congo (Brazzaville)) (FCOD / OLL)"
+  },
+  {
+    "id": "CAW5",
+    "british": false,
+    "label": "Port Hardy Seaplane Base (Canada) (CAW5)"
+  },
+  {
+    "id": "PPF",
+    "british": false,
+    "label": "Tri-City Airport (United States) (KPPF / PPF)"
+  },
+  {
+    "id": "PCQ",
+    "british": false,
+    "label": "Boun Neau Airport (Laos) (VLFL / PCQ)"
+  },
+  {
+    "id": "AYS",
+    "british": false,
+    "label": "Waycross Ware County Airport (United States) (KAYS / AYS)"
+  },
+  {
+    "id": "DSS",
+    "british": false,
+    "label": "Blaise Diagne International Airport (Senegal) (GOBD / DSS)"
+  },
+  {
+    "id": "KPSB",
+    "british": false,
+    "label": "Mid-State Regional Airport (United States) (KPSB)"
+  },
+  {
+    "id": "PMH",
+    "british": false,
+    "label": "Greater Portsmouth Regional Airport (United States) (KPMH / PMH)"
+  },
+  {
+    "id": "YCNQ",
+    "british": false,
+    "label": "Coonawarra Airport (Australia) (YCNQ)"
+  },
+  {
+    "id": "NAC",
+    "british": false,
+    "label": "Naracoorte Airport (Australia) (YNRC / NAC)"
+  },
+  {
+    "id": "KCXU",
+    "british": false,
+    "label": "Camilla Mitchell County Airport (United States) (KCXU)"
+  },
+  {
+    "id": "CCZ3",
+    "british": false,
+    "label": "Clarenville Airport (Canada) (CCZ3)"
+  },
+  {
+    "id": "PGZ",
+    "british": false,
+    "label": "Ponta Grossa Airport - Comandante Antonio Amilton Beraldo (Brazil) (SSZW / PGZ)"
+  },
+  {
+    "id": "PQM",
+    "british": false,
+    "label": "Palenque International Airport (Mexico) (MMPQ / PQM)"
+  },
+  {
+    "id": "CUD",
+    "british": false,
+    "label": "Caloundra Airport (Australia) (YCDR / CUD)"
+  },
+  {
+    "id": "CLP",
+    "british": false,
+    "label": "Clarks Point Airport (United States) (PFCL / CLP)"
+  },
+  {
+    "id": "CBA9",
+    "british": false,
+    "label": "Ospika Airport (Canada) (CBA9)"
+  },
+  {
+    "id": "CCH4",
+    "british": false,
+    "label": "Charlottetown Airport (Canada) (CCH4)"
+  },
+  {
+    "id": "JOJ",
+    "british": false,
+    "label": "Doris Lake (Canada) (CDL7 / JOJ)"
+  },
+  {
+    "id": "ECI",
+    "british": false,
+    "label": "Costa Esmeralda Airport (Nicaragua) (MNCE / ECI)"
+  },
+  {
+    "id": "MDMC",
+    "british": false,
+    "label": "Monte Cristi Airport (Dominican Republic) (MDMC)"
+  },
+  {
+    "id": "MSSM",
+    "british": false,
+    "label": "El Papalon Airport (El Salvador) (MSSM)"
+  },
+  {
+    "id": "KSZT",
+    "british": false,
+    "label": "Sandpoint Airport (United States) (KSZT)"
+  },
+  {
+    "id": "QGQ",
+    "british": false,
+    "label": "Attu Heliport (Greenland) (BGAT / QGQ)"
+  },
+  {
+    "id": "QPW",
+    "british": false,
+    "label": "Kangaatsiaq Heliport (Greenland) (BGKA / QPW)"
+  },
+  {
+    "id": "QJE",
+    "british": false,
+    "label": "Kitsissuarsuit Heliport (Greenland) (BGKT / QJE)"
+  },
+  {
+    "id": "BGNK",
+    "british": false,
+    "label": "Niaqornaarsuk Heliport (Greenland) (BGNK)"
+  },
+  {
+    "id": "XIQ",
+    "british": false,
+    "label": "Ilimanaq Heliport (Greenland) (BGIL / XIQ)"
+  },
+  {
+    "id": "QQT",
+    "british": false,
+    "label": "Qeqertaq Heliport (Greenland) (BGQE / QQT)"
+  },
+  {
+    "id": "BGSQ",
+    "british": false,
+    "label": "Saqqaq Heliport (Greenland) (BGSQ)"
+  },
+  {
+    "id": "BGSV",
+    "british": false,
+    "label": "Savissivik Heliport (Greenland) (BGSV)"
+  },
+  {
+    "id": "BGSI",
+    "british": false,
+    "label": "Siorapaluk Heliport (Greenland) (BGSI)"
+  },
+  {
+    "id": "BGAG",
+    "british": false,
+    "label": "Aappilattoq (Qaasuitsup) Heliport (Greenland) (BGAG)"
+  },
+  {
+    "id": "BGIN",
+    "british": false,
+    "label": "Innarsuit Heliport (Greenland) (BGIN)"
+  },
+  {
+    "id": "BGKS",
+    "british": false,
+    "label": "Kangersuatsiaq Heliport (Greenland) (BGKS)"
+  },
+  {
+    "id": "BGKQ",
+    "british": false,
+    "label": "Kullorsuaq Heliport (Greenland) (BGKQ)"
+  },
+  {
+    "id": "BGNU",
+    "british": false,
+    "label": "Nuussuaq Heliport (Greenland) (BGNU)"
+  },
+  {
+    "id": "BGTA",
+    "british": false,
+    "label": "Tasiusaq (Qaasuitsup) Heliport (Greenland) (BGTA)"
+  },
+  {
+    "id": "BGKL",
+    "british": false,
+    "label": "Upernavik Kujalleq Heliport (Greenland) (BGKL)"
+  },
+  {
+    "id": "BGAQ",
+    "british": false,
+    "label": "Aappilattoq (Kujalleq) Heliport (Greenland) (BGAQ)"
+  },
+  {
+    "id": "BGTQ",
+    "british": false,
+    "label": "Tasiusaq (Kujalleq) Heliport (Greenland) (BGTQ)"
+  },
+  {
+    "id": "BGFD",
+    "british": false,
+    "label": "Narsaq Kujalleq Heliport (Greenland) (BGFD)"
+  },
+  {
+    "id": "QJI",
+    "british": false,
+    "label": "Ikamiut Heliport (Greenland) (BGIT / QJI)"
+  },
+  {
+    "id": "BGAS",
+    "british": false,
+    "label": "Ammassivik Heliport (Greenland) (BGAS)"
+  },
+  {
+    "id": "QFG",
+    "british": false,
+    "label": "Eqalugaarsuit Heliport (Greenland) (BGET / QFG)"
+  },
+  {
+    "id": "BGQT",
+    "british": false,
+    "label": "Qassimiut Heliport (Greenland) (BGQT)"
+  },
+  {
+    "id": "BGTN",
+    "british": false,
+    "label": "Tiniteqilaaq Heliport (Greenland) (BGTN)"
+  },
+  {
+    "id": "BGIS",
+    "british": false,
+    "label": "Isortoq Heliport (Greenland) (BGIS)"
+  },
+  {
+    "id": "BGKM",
+    "british": false,
+    "label": "Kuummiut Heliport (Greenland) (BGKM)"
+  },
+  {
+    "id": "BGSG",
+    "british": false,
+    "label": "Sermiligaaq Heliport (Greenland) (BGSG)"
+  },
+  {
+    "id": "QRY",
+    "british": false,
+    "label": "Ikerassaarsuk Heliport (Greenland) (BGIK / QRY)"
+  },
+  {
+    "id": "BGLL",
+    "british": false,
+    "label": "Illorsuit Heliport (Greenland) (BGLL)"
+  },
+  {
+    "id": "BGNQ",
+    "british": false,
+    "label": "Nuugaatsiaq Heliport (Greenland) (BGNQ)"
+  },
+  {
+    "id": "BGST",
+    "british": false,
+    "label": "Saattut Heliport (Greenland) (BGST)"
+  },
+  {
+    "id": "BGIA",
+    "british": false,
+    "label": "Ikerasak Heliport (Greenland) (BGIA)"
+  },
+  {
+    "id": "BGNT",
+    "british": false,
+    "label": "Niaqornat Heliport (Greenland) (BGNT)"
+  },
+  {
+    "id": "BGUT",
+    "british": false,
+    "label": "Ukkusissat Heliport (Greenland) (BGUT)"
+  },
+  {
+    "id": "SWHP",
+    "british": false,
+    "label": "Olhos D`água Airport (Brazil) (SWHP)"
+  },
+  {
+    "id": "NPR",
+    "british": false,
+    "label": "Novo Progresso Airport (Brazil) (SJNP / NPR)"
+  },
+  {
+    "id": "SMT",
+    "british": false,
+    "label": "Adolino Bedin Regional Airport (Brazil) (SBSO / SMT)"
+  },
+  {
+    "id": "SWKQ",
+    "british": false,
+    "label": "Serra da Capivara Airport (Brazil) (SWKQ)"
+  },
+  {
+    "id": "ENO",
+    "british": false,
+    "label": "Encarnación Airport (Paraguay) (SGEN / ENO)"
+  },
+  {
+    "id": "SMAM",
+    "british": false,
+    "label": "Amatopo Airstrip (Suriname) (SMAM)"
+  },
+  {
+    "id": "SMPE",
+    "british": false,
+    "label": "Poeketi Airstrip (Suriname) (SMPE)"
+  },
+  {
+    "id": "SMGH",
+    "british": false,
+    "label": "Godo Holo Airstrip (Suriname) (SMGH)"
+  },
+  {
+    "id": "EKAT",
+    "british": false,
+    "label": "Anholt Airport (Denmark) (EKAT)"
+  },
+  {
+    "id": "LFDP",
+    "british": false,
+    "label": "St Pierre d'Oléron Airfield (France) (LFDP)"
+  },
+  {
+    "id": "LFGQ",
+    "british": false,
+    "label": "Semur En Auxois Airfield (France) (LFGQ)"
+  },
+  {
+    "id": "UZR",
+    "british": false,
+    "label": "Urzhar Airport (Kazakhstan) (UASU / UZR)"
+  },
+  {
+    "id": "ENPY",
+    "british": false,
+    "label": "Pyramiden Heliport (Norway) (ENPY)"
+  },
+  {
+    "id": "UMMI",
+    "british": false,
+    "label": "Lipki Air Base (Belarus) (UMMI)"
+  },
+  {
+    "id": "LSEZ",
+    "british": false,
+    "label": "Zermatt  Heliport (Switzerland) (LSEZ)"
+  },
+  {
+    "id": "UHPX",
+    "british": false,
+    "label": "Nikolskoye Airport (Russia) (UHPX)"
+  },
+  {
+    "id": "UHPT",
+    "british": false,
+    "label": "Tilichiki Airport (Russia) (UHPT)"
+  },
+  {
+    "id": "NYR",
+    "british": false,
+    "label": "Nyurba Airport (Russia) (UENN / NYR)"
+  },
+  {
+    "id": "SUK",
+    "british": false,
+    "label": "Sakkyryr Airport (Russia) (UEBS / SUK)"
+  },
+  {
+    "id": "UKG",
+    "british": false,
+    "label": "Ust-Kuyga Airport (Russia) (UEBT / UKG)"
+  },
+  {
+    "id": "VHV",
+    "british": false,
+    "label": "Verkhnevilyuisk Airport (Russia) (UENI / VHV)"
+  },
+  {
+    "id": "DEE",
+    "british": false,
+    "label": "Mendeleyevo Airport (Russia) (UHSM / DEE)"
+  },
+  {
+    "id": "USMQ",
+    "british": false,
+    "label": "Yamburg Airport (Russia) (USMQ)"
+  },
+  {
+    "id": "EKS",
+    "british": false,
+    "label": "Shakhtyorsk Airport (Russia) (UHSK / EKS)"
+  },
+  {
+    "id": "TLK",
+    "british": false,
+    "label": "Talakan Airport (Russia) (UECT / TLK)"
+  },
+  {
+    "id": "UIKM",
+    "british": false,
+    "label": "Mama Airport (Russia) (UIKM)"
+  },
+  {
+    "id": "EKAC",
+    "british": false,
+    "label": "Aarhus Seaplne Terminal (Denmark) (EKAC)"
+  },
+  {
+    "id": "KVLL",
+    "british": false,
+    "label": "Oakland Troy Airport (United States) (KVLL)"
+  },
+  {
+    "id": "CYSA",
+    "british": false,
+    "label": "Stratford Municipal Airport (Canada) (CYSA)"
+  },
+  {
+    "id": "CYES",
+    "british": false,
+    "label": "Edmundston Airport (Canada) (CYES)"
+  },
+  {
+    "id": "RDB",
+    "british": false,
+    "label": "Red Dog Airport (United States) (PADG / RDB)"
+  },
+  {
+    "id": "ION",
+    "british": false,
+    "label": "Impfondo Airport (Congo (Brazzaville)) (FCOI / ION)"
+  },
+  {
+    "id": "EBH",
+    "british": false,
+    "label": "El Bayadh Airport (Algeria) (DAOY / EBH)"
+  },
+  {
+    "id": "ZIS",
+    "british": false,
+    "label": "Alzintan Airport (Libya) (HLZN / ZIS)"
+  },
+  {
+    "id": "MYZ",
+    "british": false,
+    "label": "Monkey Bay Airport (Malawi) (FWMY / MYZ)"
+  },
+  {
+    "id": "EPSU",
+    "british": false,
+    "label": "Suwałki Airport (Poland) (EPSU)"
+  },
+  {
+    "id": "DNBK",
+    "british": false,
+    "label": "Srr Ahmadu Bello International Airport (Nigeria) (DNBK)"
+  },
+  {
+    "id": "BCU",
+    "british": false,
+    "label": "Sir Abubakar Tafawa Balewa International Airport (Nigeria) (DNBC / BCU)"
+  },
+  {
+    "id": "GMO",
+    "british": false,
+    "label": "Gombe Lawanti International Airport (Nigeria) (DNGO / GMO)"
+  },
+  {
+    "id": "DNDS",
+    "british": false,
+    "label": "Dutse International Airport (Nigeria) (DNDS)"
+  },
+  {
+    "id": "DNJA",
+    "british": false,
+    "label": "Jalingo Airport (Nigeria) (DNJA)"
+  },
+  {
+    "id": "KDA",
+    "british": false,
+    "label": "Kolda North Airport (Senegal) (GODK / KDA)"
+  },
+  {
+    "id": "SHO",
+    "british": false,
+    "label": "King Mswati III International Airport (Swaziland) (FDSK / SHO)"
+  },
+  {
+    "id": "KIY",
+    "british": false,
+    "label": "Kilwa Masoko Airport (Tanzania) (HTKI / KIY)"
+  },
+  {
+    "id": "HTWK",
+    "british": false,
+    "label": "West Kilimanjaro Airport (Tanzania) (HTWK)"
+  },
+  {
+    "id": "QSI",
+    "british": false,
+    "label": "Moshi Airport (Tanzania) (HTMS / QSI)"
+  },
+  {
+    "id": "MNS",
+    "british": false,
+    "label": "Mansa Airport (Zambia) (FLMA / MNS)"
+  },
+  {
+    "id": "GZI",
+    "british": false,
+    "label": "Ghazni Airport (Afghanistan) (OAGN / GZI)"
+  },
+  {
+    "id": "DBC",
+    "british": false,
+    "label": "Baicheng Chang'an Airport (China) (ZYBA / DBC)"
+  },
+  {
+    "id": "LNL",
+    "british": false,
+    "label": "Longnan Chengzhou Airport (China) (ZLLN / LNL)"
+  },
+  {
+    "id": "SQD",
+    "british": false,
+    "label": "Shangrao Sanqingshan Airport (China) (ZSSR / SQD)"
+  },
+  {
+    "id": "YSQ",
+    "british": false,
+    "label": "Songyuan Chaganhu Airport (China) (ZYSQ / YSQ)"
+  },
+  {
+    "id": "JSJ",
+    "british": false,
+    "label": "Jiansanjiang Airport (China) (ZYJS / JSJ)"
+  },
+  {
+    "id": "WMT",
+    "british": false,
+    "label": "Zunyi Maotai Airport (China) (ZUMT / WMT)"
+  },
+  {
+    "id": "LLB",
+    "british": false,
+    "label": "Libo Airport (China) (ZULB / LLB)"
+  },
+  {
+    "id": "CDE",
+    "british": false,
+    "label": "Chengde Puning Airport (China) (ZBCD / CDE)"
+  },
+  {
+    "id": "DTU",
+    "british": false,
+    "label": "Wudalianchi Dedu Airport (China) (ZYDU / DTU)"
+  },
+  {
+    "id": "EJN",
+    "british": false,
+    "label": "Ejin Banner-Taolai Airport (China) (ZBEN / EJN)"
+  },
+  {
+    "id": "RHT",
+    "british": false,
+    "label": "Alxa Right Banner Badanjilin Airport (China) (ZBAR / RHT)"
+  },
+  {
+    "id": "HUO",
+    "british": false,
+    "label": "Holingol Huolinhe Airport (China) (ZBHZ / HUO)"
+  },
+  {
+    "id": "GMQ",
+    "british": false,
+    "label": "Golog Maqin Airport (China) (ZLGL / GMQ)"
+  },
+  {
+    "id": "QSZ",
+    "british": false,
+    "label": "Yeerqiang Airport (China) (ZWSC / QSZ)"
+  },
+  {
+    "id": "TEI",
+    "british": false,
+    "label": "Tezu Airport (India) (VETJ / TEI)"
+  },
+  {
+    "id": "CWJ",
+    "british": false,
+    "label": "Cangyuan Washan Airport (China) (ZPCW / CWJ)"
+  },
+  {
+    "id": "JMJ",
+    "british": false,
+    "label": "Lancang Jingmai Airport (China) (ZPJM / JMJ)"
+  },
+  {
+    "id": "NLH",
+    "british": false,
+    "label": "Ninglang Luguhu Airport (China) (ZPNL / NLH)"
+  },
+  {
+    "id": "PBQ",
+    "british": false,
+    "label": "Pimenta Bueno Airport (Brazil) (SWPM / PBQ)"
+  },
+  {
+    "id": "SJOG",
+    "british": false,
+    "label": "Ariquemes Airport (Brazil) (SJOG)"
+  },
+  {
+    "id": "SIXZ",
+    "british": false,
+    "label": "Fazenda Spartacus Airport (Brazil) (SIXZ)"
+  },
+  {
+    "id": "WUT",
+    "british": false,
+    "label": "Xinzhou Wutaishan Airport (China) (ZBXZ / WUT)"
+  },
+  {
+    "id": "NZL",
+    "british": false,
+    "label": "Chengjisihan Airport (China) (ZBZL / NZL)"
+  },
+  {
+    "id": "SJTF",
+    "british": false,
+    "label": "Fazenda Mequens Airport (Brazil) (SJTF)"
+  },
+  {
+    "id": "SWYN",
+    "british": false,
+    "label": "Prainha Airport (Brazil) (SWYN)"
+  },
+  {
+    "id": "SSMT",
+    "british": false,
+    "label": "Mostardas Airport (Brazil) (SSMT)"
+  },
+  {
+    "id": "SCSN",
+    "british": false,
+    "label": "Santo Domingo Airport (Brazil) (SCSN)"
+  },
+  {
+    "id": "AIP",
+    "british": false,
+    "label": "Adampur Airport (India) (VIAX / AIP)"
+  },
+  {
+    "id": "VDY",
+    "british": false,
+    "label": "Vijayanagar Aerodrome (JSW) (India) (VOJV / VDY)"
+  },
+  {
+    "id": "SAG",
+    "british": false,
+    "label": "Shirdi Airport (India) (VASD / SAG)"
+  },
+  {
+    "id": "PYB",
+    "british": false,
+    "label": "Jeypore Airport (India) (VEJP / PYB)"
+  },
+  {
+    "id": "SUP",
+    "british": false,
+    "label": "Trunojoyo Airport (Indonesia) (WART / SUP)"
+  },
+  {
+    "id": "WIMO",
+    "british": false,
+    "label": "Lasondre Airport (Indonesia) (WIMO)"
+  },
+  {
+    "id": "RKO",
+    "british": false,
+    "label": "Rokot Airport (Indonesia) (WIBR / RKO)"
+  },
+  {
+    "id": "PPR",
+    "british": false,
+    "label": "Pasir Pangaraan Airport (Indonesia) (WIDE / PPR)"
+  },
+  {
+    "id": "TJB",
+    "british": false,
+    "label": "Sei Bati Airport (Indonesia) (WIBT / TJB)"
+  },
+  {
+    "id": "KRC",
+    "british": false,
+    "label": "Departi Parbo Airport (Indonesia) (WIPH / KRC)"
+  },
+  {
+    "id": "NRE",
+    "british": false,
+    "label": "Namrole Airport (Indonesia) (WAPG / NRE)"
+  },
+  {
+    "id": "NAM",
+    "british": false,
+    "label": "Namlea Airport (Indonesia) (WAPR / NAM)"
+  },
+  {
+    "id": "DOB",
+    "british": false,
+    "label": "Rar Gwamar Airport (Indonesia) (WAPD / DOB)"
+  },
+  {
+    "id": "SQN",
+    "british": false,
+    "label": "Emalamo Sanana Airport (Indonesia) (WAPN / SQN)"
+  },
+  {
+    "id": "AYW",
+    "british": false,
+    "label": "Ayawasi Airport (Indonesia) (WASA / AYW)"
+  },
+  {
+    "id": "BYQ",
+    "british": false,
+    "label": "Bunyu Airport (Indonesia) (WALV / BYQ)"
+  },
+  {
+    "id": "UOL",
+    "british": false,
+    "label": "Buol Airport (Indonesia) (WAMY / UOL)"
+  },
+  {
+    "id": "RAQ",
+    "british": false,
+    "label": "Sugimanuru Airport (Indonesia) (WAWR / RAQ)"
+  },
+  {
+    "id": "JSK",
+    "british": false,
+    "label": "Jask Airport (Iran) (OIZJ / JSK)"
+  },
+  {
+    "id": "KFKS",
+    "british": false,
+    "label": "Frankfort Dow Memorial Field (United States) (KFKS)"
+  },
+  {
+    "id": "KSLH",
+    "british": false,
+    "label": "Cheboygan County Airport (United States) (KSLH)"
+  },
+  {
+    "id": "RJAZ",
+    "british": false,
+    "label": "Kozushima Airport (Japan) (RJAZ)"
+  },
+  {
+    "id": "UAFZ",
+    "british": false,
+    "label": "Kazarman Airport (Kyrgyzstan) (UAFZ)"
+  },
+  {
+    "id": "UAFE",
+    "british": false,
+    "label": "Kerben Airport (Kyrgyzstan) (UAFE)"
+  },
+  {
+    "id": "UAFN",
+    "british": false,
+    "label": "Naryn Airport (Kyrgyzstan) (UAFN)"
+  },
+  {
+    "id": "ZBY",
+    "british": false,
+    "label": "Sayaboury Airport (Laos) (VLSB / ZBY)"
+  },
+  {
+    "id": "BGL",
+    "british": false,
+    "label": "Baglung Airport (Nepal) (VNBL / BGL)"
+  },
+  {
+    "id": "RJB",
+    "british": false,
+    "label": "Rajbiraj Airport (Nepal) (VNRB / RJB)"
+  },
+  {
+    "id": "DQM",
+    "british": false,
+    "label": "Duqm International Airport (Oman) (OODQ / DQM)"
+  },
+  {
+    "id": "RPLN",
+    "british": false,
+    "label": "Palanan Community Airport (Philippines) (RPLN)"
+  },
+  {
+    "id": "RPLT",
+    "british": false,
+    "label": "Itbayat Airport (Philippines) (RPLT)"
+  },
+  {
+    "id": "RPVY",
+    "british": false,
+    "label": "Catbalogan Airport (Philippines) (RPVY)"
+  },
+  {
+    "id": "RPSM",
+    "british": false,
+    "label": "Maasin Airport (Philippines) (RPSM)"
+  },
+  {
+    "id": "RPSB",
+    "british": false,
+    "label": "Bantayan Airport (Philippines) (RPSB)"
+  },
+  {
+    "id": "RPVQ",
+    "british": false,
+    "label": "Biliran Airport (Philippines) (RPVQ)"
+  },
+  {
+    "id": "SIEL",
+    "british": false,
+    "label": "Fazenda Várzea Funda Airport (Brazil) (SIEL)"
+  },
+  {
+    "id": "SWPY",
+    "british": false,
+    "label": "Primavera do Leste Airport (Brazil) (SWPY)"
+  },
+  {
+    "id": "CKI",
+    "british": false,
+    "label": "Croker Island Airport (Australia) (YCKI / CKI)"
+  },
+  {
+    "id": "YTGT",
+    "british": false,
+    "label": "The Granites Airport (Australia) (YTGT)"
+  },
+  {
+    "id": "BYP",
+    "british": false,
+    "label": "Barimunya Airport (Australia) (YBRY / BYP)"
+  },
+  {
+    "id": "LUC",
+    "british": false,
+    "label": "Laucala Island Airport (Fiji) (NFNH / LUC)"
+  },
+  {
+    "id": "YAS",
+    "british": false,
+    "label": "Yasawa Island Airport (Fiji) (NFSW / YAS)"
+  },
+  {
+    "id": "NZNE",
+    "british": false,
+    "label": "North Shore Aerodrome (New Zealand) (NZNE)"
+  },
+  {
+    "id": "KJWN",
+    "british": false,
+    "label": "John C Tune Airport (United States) (KJWN)"
+  },
+  {
+    "id": "NZOX",
+    "british": false,
+    "label": "Okiwi Station Airport (New Zealand) (NZOX)"
+  },
+  {
+    "id": "WIK",
+    "british": false,
+    "label": "Waiheke Reeve Airport (New Zealand) (NZKE / WIK)"
+  },
+  {
+    "id": "NZKM",
+    "british": false,
+    "label": "Karamea Airport (New Zealand) (NZKM)"
+  },
+  {
+    "id": "EPJA",
+    "british": false,
+    "label": "Jastarnia Airport (Poland) (EPJA)"
+  },
+  {
+    "id": "DEX",
+    "british": false,
+    "label": "Nop Goliat Airport (Indonesia) (WAVD / DEX)"
+  },
+  {
+    "id": "NAU",
+    "british": false,
+    "label": "Napuka Island Airport (French Polynesia) (NTGN / NAU)"
+  },
+  {
+    "id": "FAC",
+    "british": false,
+    "label": "Faaite Airport (French Polynesia) (NTKF / FAC)"
+  },
+  {
+    "id": "NUK",
+    "british": false,
+    "label": "Nukutavake Airport (French Polynesia) (NTGW / NUK)"
+  },
+  {
+    "id": "VHZ",
+    "british": false,
+    "label": "Vahitahi Airport (French Polynesia) (NTUV / VHZ)"
+  },
+  {
+    "id": "HHZ",
+    "british": false,
+    "label": "Hikueru Atoll Airport (French Polynesia) (NTGH / HHZ)"
+  },
+  {
+    "id": "RRR",
+    "british": false,
+    "label": "Raroia Airport (French Polynesia) (NTKO / RRR)"
+  },
+  {
+    "id": "KHZ",
+    "british": false,
+    "label": "Kauehi Airport (French Polynesia) (NTKA / KHZ)"
+  },
+  {
+    "id": "TKV",
+    "british": false,
+    "label": "Tatakoto Airport (French Polynesia) (NTGO / TKV)"
+  },
+  {
+    "id": "TDS",
+    "british": false,
+    "label": "Sasereme Airport (Papua New Guinea) (AYSS / TDS)"
+  },
+  {
+    "id": "TMH",
+    "british": false,
+    "label": "Tanah Merah Airport (Indonesia) (WAKT / TMH)"
+  },
+  {
+    "id": "AK06",
+    "british": false,
+    "label": "Denali Airport (United States) (AK06)"
+  },
+  {
+    "id": "SBJD",
+    "british": false,
+    "label": "Comte. Rolim Adolfo Amaro–Jundiaí State Airport (Brazil) (SBJD)"
+  },
+  {
+    "id": "KW35",
+    "british": false,
+    "label": "Potomac Airpark (United States) (KW35)"
+  },
+  {
+    "id": "SSHS",
+    "british": false,
+    "label": "Helisul IV Heliport (Brazil) (SSHS)"
+  },
+  {
+    "id": "FABS",
+    "british": false,
+    "label": "Brits Airport (South Africa) (FABS)"
+  },
+  {
+    "id": "NZWL",
+    "british": false,
+    "label": "West Melton Aerodrome (New Zealand) (NZWL)"
+  },
+  {
+    "id": "NZRT",
+    "british": false,
+    "label": "Rangiora Airfield (New Zealand) (NZRT)"
+  },
+  {
+    "id": "SIDG",
+    "british": false,
+    "label": "Fazenda Jatobasso Airport (Brazil) (SIDG)"
+  },
+  {
+    "id": "SIMC",
+    "british": false,
+    "label": "FIC Heliport (Brazil) (SIMC)"
+  },
+  {
+    "id": "NKB",
+    "british": false,
+    "label": "Noonkanbah Airport (Australia) (YNKA / NKB)"
+  },
+  {
+    "id": "AEI",
+    "british": false,
+    "label": "Algeciras Heliport (Spain) (LEAG / AEI)"
+  },
+  {
+    "id": "UKKH",
+    "british": false,
+    "label": "Chepelevka Airport (Ukraine) (UKKH)"
+  },
+  {
+    "id": "SWQT",
+    "british": false,
+    "label": "Fazenda São Nicolau Airport (Brazil) (SWQT)"
+  },
+  {
+    "id": "HUKI",
+    "british": false,
+    "label": "Kisoro Airport (Uganda) (HUKI)"
+  },
+  {
+    "id": "KSE",
+    "british": false,
+    "label": "Kasese Airport (Uganda) (HUKS / KSE)"
+  },
+  {
+    "id": "KHSA",
+    "british": false,
+    "label": "Stennis International Airport (United States) (KHSA)"
+  },
+  {
+    "id": "NCJ",
+    "british": false,
+    "label": "Sunchales Aeroclub Airport (Argentina) (SAFS / NCJ)"
+  },
+  {
+    "id": "IST",
+    "british": false,
+    "label": "Istanbul Airport (Turkey) (LTFM / IST)"
+  },
+  {
+    "id": "SOV",
+    "british": false,
+    "label": "Seldovia Airport (United States) (PASO / SOV)"
+  },
+  {
+    "id": "YSG",
+    "british": false,
+    "label": "Lutselk'e Airport (Canada) (CYLK / YSG)"
+  },
+  {
+    "id": "ENEN",
+    "british": false,
+    "label": "Engeløy Airport (Norway) (ENEN)"
+  },
+  {
+    "id": "DWA",
+    "british": false,
+    "label": "Dwangwa Airport (Malawi) (FWDW / DWA)"
+  },
+  {
+    "id": "HGI",
+    "british": false,
+    "label": "Paloich Airport, Heliport (South Sudan) (HSFA / HGI)"
+  },
+  {
+    "id": "KJKL",
+    "british": false,
+    "label": "Julian Carroll Airport (United States) (KJKL)"
+  },
+  {
+    "id": "KNBC",
+    "british": false,
+    "label": "Beaufort MCAS - Merritt Field (United States) (KNBC)"
+  },
+  {
+    "id": "KNFG",
+    "british": false,
+    "label": "Camp Pendleton MCAS (Munn Field) Airport (United States) (KNFG)"
+  },
+  {
+    "id": "LPCB",
+    "british": false,
+    "label": "Aerodromo de Castelo Branco (Portugal) (LPCB)"
+  },
+  {
+    "id": "LPSO",
+    "british": false,
+    "label": "Ponte de Sor Airport (Portugal) (LPSO)"
+  },
+  {
+    "id": "LPVL",
+    "british": false,
+    "label": "Vilar de Luz Airfield (Portugal) (LPVL)"
+  },
+  {
+    "id": "MYLR",
+    "british": false,
+    "label": "Hard Bargain Airport (Bahamas) (MYLR)"
+  },
+  {
+    "id": "RJCS",
+    "british": false,
+    "label": "Kenebetsu JASDF Airfield (Japan) (RJCS)"
+  },
+  {
+    "id": "SBNT",
+    "british": false,
+    "label": "Augusto Severo Airport (Brazil) (SBNT)"
+  },
+  {
+    "id": "KQH",
+    "british": false,
+    "label": "Kishangarh Airport (India) (VIKG / KQH)"
+  },
+  {
+    "id": "CNN",
+    "british": false,
+    "label": "Kannur International Airport (India) (VOKN / CNN)"
+  },
+  {
+    "id": "ZBBB",
+    "british": false,
+    "label": "Beijing Xijiao Airport (China) (ZBBB)"
+  },
+  {
+    "id": "SWFN",
+    "british": false,
+    "label": "Flores Airport (Brazil) (SWFN)"
+  },
+  {
+    "id": "YUMU",
+    "british": false,
+    "label": "Umuwa Airport (Australia) (YUMU)"
+  },
+  {
+    "id": "ZCO",
+    "british": false,
+    "label": "La Araucanía Airport (Chile) (SCQP / ZCO)"
+  },
+  {
+    "id": "ASS",
+    "british": false,
+    "label": "Arathusa Safari Lodge Airport (South Africa) (FACC / ASS)"
+  },
+  {
+    "id": "VDI",
+    "british": false,
+    "label": "Vidalia Regional Airport (United States) (KVDI / VDI)"
+  },
+  {
+    "id": "KGDJ",
+    "british": false,
+    "label": "Granbury Regional Airport (United States) (KGDJ)"
+  },
+  {
+    "id": "KFZY",
+    "british": false,
+    "label": "Oswego County Airport (United States) (KFZY)"
+  },
+  {
+    "id": "ISB",
+    "british": false,
+    "label": "New Islamabad International Airport (Pakistan) (OPIS / ISB)"
+  },
+  {
+    "id": "FBVM",
+    "british": false,
+    "label": "Vumbura Airport (Botswana) (FBVM)"
+  },
+  {
+    "id": "FYGK",
+    "british": false,
+    "label": "Farm Whitwater East Landing Strip (Namibia) (FYGK)"
+  },
+  {
+    "id": "OJ40",
+    "british": false,
+    "label": "Muwaffaq Salti Air Base (Jordan) (OJ40)"
+  },
+  {
+    "id": "BIKL",
+    "british": false,
+    "label": "Kirkjubæjarklaustur Airport (Iceland) (BIKL)"
+  },
+  {
+    "id": "SWVJ",
+    "british": false,
+    "label": "Fazenda Uiapuru Airport (Brazil) (SWVJ)"
+  },
+  {
+    "id": "CEZ5",
+    "british": false,
+    "label": "Whitehorse Seaplane Base (Canada) (CEZ5)"
+  },
+  {
+    "id": "ULAT",
+    "british": false,
+    "label": "Pertominsk Airport (Russia) (ULAT)"
+  },
+  {
+    "id": "YMNW",
+    "british": false,
+    "label": "Mount Weld Airport (Australia) (YMNW)"
+  },
+  {
+    "id": "YKID",
+    "british": false,
+    "label": "Kidston Airport (Australia) (YKID)"
+  },
+  {
+    "id": "EKKV",
+    "british": false,
+    "label": "Klaksvik Heliport (Faroe Islands) (EKKV)"
+  },
+  {
+    "id": "MHE",
+    "british": false,
+    "label": "Mitchell Municipal Airport (United States) (KMHE / MHE)"
+  },
+  {
+    "id": "FBHU",
+    "british": false,
+    "label": "Hunda Airport (Botswana) (FBHU)"
+  },
+  {
+    "id": "GIT",
+    "british": false,
+    "label": "Mchauru Airport (Tanzania) (HTRU / GIT)"
+  },
+  {
+    "id": "GID",
+    "british": false,
+    "label": "Gitega Airport (Burundi) (HBBE / GID)"
+  },
+  {
+    "id": "RMU",
+    "british": false,
+    "label": "Región de Murcia International Airport (Spain) (LEMI / RMU)"
+  },
+  {
+    "id": "SJYD",
+    "british": false,
+    "label": "Fazenda Kajussol Airport (Brazil) (SJYD)"
+  },
+  {
+    "id": "CYPT",
+    "british": false,
+    "label": "Pelee Island Airport (Canada) (CYPT)"
+  },
+  {
+    "id": "CQS",
+    "british": false,
+    "label": "Costa Marques Airport (Brazil) (SWCQ / CQS)"
+  },
+  {
+    "id": "YMNG",
+    "british": false,
+    "label": "Mangalore Airport (Australia) (YMNG)"
+  },
+  {
+    "id": "MRSI",
+    "british": false,
+    "label": "San Isidro del General Airport (Costa Rica) (MRSI)"
+  },
+  {
+    "id": "ZXT",
+    "british": false,
+    "label": "Zabrat Airport (Azerbaijan) (UBTT / ZXT)"
+  },
+  {
+    "id": "JAM",
+    "british": false,
+    "label": "Bezmer Air Base (Bulgaria) (LBIA / JAM)"
+  },
+  {
+    "id": "UMMO",
+    "british": false,
+    "label": "Osovtsy Air Base (Belarus) (UMMO)"
+  },
+  {
+    "id": "YUA",
+    "british": false,
+    "label": "Yuanmou Air Base (China) (ZPYM / YUA)"
+  },
+  {
+    "id": "ZGCS",
+    "british": false,
+    "label": "Changsha Datuopu Airport/AFB (China) (ZGCS)"
+  },
+  {
+    "id": "XEN",
+    "british": false,
+    "label": "Xingcheng Air Base (China) (ZYXC / XEN)"
+  },
+  {
+    "id": "GEC",
+    "british": false,
+    "label": "Lefkoniko Airport (Cyprus) (LCGK / GEC)"
+  },
+  {
+    "id": "MBI",
+    "british": false,
+    "label": "Songwe Airport (Tanzania) (HTGW / MBI)"
+  },
+  {
+    "id": "LHKA",
+    "british": false,
+    "label": "Kalocsa/Foktő Airport (Hungary) (LHKA)"
+  },
+  {
+    "id": "UGU",
+    "british": false,
+    "label": "Bilogai-Sugapa Airport (Indonesia) (WABV / UGU)"
+  },
+  {
+    "id": "VOJK",
+    "british": false,
+    "label": "Jakkur Aerodrome (India) (VOJK)"
+  },
+  {
+    "id": "UAFJ",
+    "british": false,
+    "label": "Jalal-Abad Airport (Kyrgyzstan) (UAFJ)"
+  },
+  {
+    "id": "ETM",
+    "british": false,
+    "label": "Ramon Airport (Israel) (LLER / ETM)"
+  },
+  {
+    "id": "MNH",
+    "british": false,
+    "label": "Rustaq Airport (Oman) (OORQ / MNH)"
+  },
+  {
+    "id": "CGY",
+    "british": false,
+    "label": "Laguindingan Airport (Philippines) (RPMY / CGY)"
+  },
+  {
+    "id": "ULPM",
+    "british": false,
+    "label": "Kostomuksha Airport (Russia) (ULPM)"
+  },
+  {
+    "id": "XRAP",
+    "british": false,
+    "label": "Privolzhskiy Air Base (Russia) (XRAP)"
+  },
+  {
+    "id": "UUMB",
+    "british": false,
+    "label": "Kubinka Air Base (Russia) (UUMB)"
+  },
+  {
+    "id": "ULDA",
+    "british": false,
+    "label": "Rogachyovo Air Base (Russia) (ULDA)"
+  },
+  {
+    "id": "XIUW",
+    "british": false,
+    "label": "Ulan-Ude East Airport (Russia) (XIUW)"
+  },
+  {
+    "id": "ULLK",
+    "british": false,
+    "label": "Krechevitsy Air Base (Russia) (ULLK)"
+  },
+  {
+    "id": "CPO",
+    "british": false,
+    "label": "Desierto de Atacama Airport (Chile) (SCAT / CPO)"
+  },
+  {
+    "id": "UKDM",
+    "british": false,
+    "label": "Melitopol Air Base (Ukraine) (UKDM)"
+  }
+]

--- a/src/common/utils/autocomplete.js
+++ b/src/common/utils/autocomplete.js
@@ -1,7 +1,7 @@
 const countries = require('i18n-iso-countries');
 const en = require('i18n-iso-countries/langs/en.json');
 const logger = require('./logger')(__filename);
-const airportList = require('./airport_codes.json');
+const airportList = require('./airport_codes_v2.json');
 /**
  * Utility function for generating the list of country codes in a format for this app.
  * This essentially means taking the more normally used alpha-2 (GB) code and country

--- a/src/import-codes.js
+++ b/src/import-codes.js
@@ -1,25 +1,26 @@
+/* eslint-disable import/no-extraneous-dependencies */
 const csv = require('csvtojson/v2');
-const csvFile='./airports.dat';
 const fs = require('fs');
-const logger = require('../../../common/utils/logger')(__filename);
+const logger = require('./common/utils/logger')(__filename);
 
+const csvFile = './airports.dat';
 /**
- * A converter to take in an openflights.org data file (in CSV format) and converting it into a JSON format that can be
- * used by sGAR.
+ * A converter to take in an openflights.org data file (in CSV format) and converting
+ * it into a JSON format that can be used by sGAR.
  *
  * This will not be expected to be used during the app use and is expected to be run as:
- * 
+ *
  * node import-codes
- * 
+ *
  * Which will take a file called "airports.dat" which can be obtained via:
  * https://raw.githubusercontent.com/jpatokal/openflights/master/data/airports.dat
- * 
+ *
  * So Kudos to openflights: https://openflights.org/data.html
  */
 csv({
   headers: ['id', 'name', 'city', 'country', 'IATA', 'ICAO', 'lat', 'long', 'alt', 'utc', 'dst', 'tz', 'type', 'source'],
   colParser: {
-    'city': 'omit',
+    city: 'omit',
     'lat': 'omit',
     'long': 'omit',
     'alt': 'omit',
@@ -32,27 +33,35 @@ csv({
 }).fromFile(csvFile).then((jsonResult) => {
   const processedArray = [];
   jsonResult.forEach((row) => {
-    logger.info('Processing row ' + row.id + ' - ' + row.name);
-    logger.info('IATA: ' + row.IATA);
-    logger.info('ICAO: ' + row.ICAO);
+    logger.info(`Processing row ${row.id} - ${row.name}`);
+    logger.info(`IATA: ${row.IATA}`);
+    logger.info(`ICAO: ${row.ICAO}`);
     // Adding a flag to the row to signify whether the airport is in the UK
     // TODO: Does "Isle of Man" and others like "Jersey" also count as in the UK?
     const british = row.country === 'United Kingdom';
-    const label = row.name + ' (' + row.country + ') ';
-    // It is possible that IATA codes do not exist, which appear to be read as a "\N" character so ignore those.
-    if (row.IATA !== '\\N') {
-      processedArray.push({id: row.IATA, british: british, label: label + '(' + row.IATA + ')'})
-    }
+    const label = `${row.name} (${row.country}) `;
+    let code = '(';
+    let hasIATA = false;
     if (row.ICAO !== '\\N') {
-      processedArray.push({id: row.ICAO, british: british, label: label + '(' + row.ICAO + ')'})
+      code += row.ICAO;
     }
+    // It is possible that IATA codes do not exist, which appear to be read as
+    // a "\N" character so ignore those.
+    if (row.IATA !== '\\N') {
+      hasIATA = true;
+      if (row.ICAO !== '\\N') {
+        code += ' / ';
+      }
+      code += row.IATA;
+    }
+    code += ')';
+    processedArray.push({ id: hasIATA ? row.IATA : row.ICAO, british, label: label + code });
   });
   logger.info('Resulting output');
-  logger.info(processedArray);
+  logger.info(JSON.stringify(processedArray));
   fs.writeFileSync('airport_codes.json', JSON.stringify(processedArray, null, 2), 'utf8', (err) => {
     if (err) {
       logger.error('An error occurred while saving to JSON');
-      return logger.error(err);
     }
-  })
-})
+  });
+});

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "description": "Electronic Gar Site",
   "main": "index.js",
   "scripts": {
-    "test": "nyc --reporter=lcov --reporter=text mocha --recursive",
+    "test": "nyc --reporter=lcov mocha --recursive",
     "test-drone": "nyc --report-dir=/drone/src/coverage --reporter=lcov --reporter=text mocha --recursive"
   },
   "nyc": {
@@ -84,6 +84,7 @@
     "node-test": "^1.2.4",
     "nodemon": "^1.18.7",
     "proxyquire": "^2.1.0",
+    "rewire": "^4.0.1",
     "sinon": "^7.1.1",
     "sinon-chai": "^3.3.0",
     "supertest": "^4.0.2"

--- a/src/test/aircraft/add/get.controller.test.js
+++ b/src/test/aircraft/add/get.controller.test.js
@@ -1,19 +1,24 @@
 /* eslint-disable no-undef */
+
 const sinon = require('sinon');
 const { expect } = require('chai');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 
-const controller = require('../../app/welcome/get.controller');
+const CookieModel = require('../../../common/models/Cookie.class');
 
-describe('Welcome Get Controller', () => {
+const controller = require('../../../app/aircraft/add/get.controller');
+
+describe('Aircraft Add Get Controller', () => {
   let req; let res;
 
   beforeEach(() => {
     chai.use(sinonChai);
 
     // Example request and response objects with appropriate spies
-    req = {};
+    req = {
+      session: {},
+    };
     res = {
       render: sinon.spy(),
     };
@@ -23,9 +28,10 @@ describe('Welcome Get Controller', () => {
     sinon.restore();
   });
 
-  it('should render the welcome page', async () => {
+  it('should render the appropriate page', async () => {
+    cookie = new CookieModel(req);
     await controller(req, res);
 
-    expect(res.render).to.have.been.calledWith('app/welcome/index');
+    expect(res.render).to.have.been.calledWith('app/aircraft/add/index', { cookie });
   });
 });

--- a/src/test/aircraft/add/post.controller.test.js
+++ b/src/test/aircraft/add/post.controller.test.js
@@ -1,0 +1,119 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const craftApi = require('../../../common/services/craftApi');
+const ValidationRule = require('../../../common/models/ValidationRule.class');
+const validator = require('../../../common/utils/validator');
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/aircraft/add/post.controller');
+
+describe('Aircraft Add Post Controller', () => {
+  let req; let res; let craftApiStub;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example response object with appropriate spies
+    req = {
+      body: {
+        craftreg: 'G-ABCD',
+        crafttype: 'Gulfstream',
+        craftbase: 'LHR',
+      },
+      session: {
+        cookie: {},
+      },
+    };
+    res = {
+      redirect: sinon.stub(),
+      render: sinon.stub(),
+    };
+    craftApiStub = sinon.stub(craftApi, 'create');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('validation chains', () => {
+    it('should return message when registration is empty', () => {
+      delete req.body.craftreg;
+      const rule = new ValidationRule(validator.notEmpty, 'craftreg', '', 'Enter the registration details of the craft');
+      const cookie = new CookieModel(req);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(res.render).to.have.been.calledWith('app/aircraft/add/index', { cookie, errors: [rule] });
+      });
+    });
+
+    it('should return message when type is empty', () => {
+      delete req.body.crafttype;
+      const rule = new ValidationRule(validator.notEmpty, 'crafttype', '', 'Enter the craft type');
+      const cookie = new CookieModel(req);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        // TODO: Cookie and Error Message Check
+        expect(res.render).to.have.been.calledWith('app/aircraft/add/index', { cookie, errors: [rule] });
+      });
+    });
+
+    it('should return message when base is empty', () => {
+      delete req.body.craftbase;
+      const rule = new ValidationRule(validator.notEmpty, 'craftbase', '', 'Enter the base of the craft');
+      const cookie = new CookieModel(req);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(craftApiStub).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/aircraft/add/index', { cookie, errors: [rule] });
+      });
+    });
+  });
+
+  describe('craft api calls', () => {
+    it('should return error message if api returns error', () => {
+      cookie = new CookieModel(req);
+      craftApiStub.resolves(JSON.stringify({
+        message: 'Some sort of error',
+      }));
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(res.render).to.have.been.calledWith('app/aircraft/add/index', { errors: [{ message: 'Some sort of error' }], cookie });
+      });
+    });
+
+    it('should redirect when ok', () => {
+      cookie = new CookieModel(req);
+      craftApiStub.resolves(JSON.stringify({}));
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+  });
+});

--- a/src/test/aircraft/delete/get.controller.test.js
+++ b/src/test/aircraft/delete/get.controller.test.js
@@ -1,0 +1,175 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const craftApi = require('../../../common/services/craftApi');
+
+const controller = require('../../../app/aircraft/delete/get.controller');
+
+describe('Aircraft Delete Get Controller', () => {
+  let req; let res; let deleteCraftStub; let deleteOrgCraftStub;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {
+        deleteCraftId: 'G-ABCD',
+        save: callback => callback(),
+        u: {
+          dbId: 'someone@somewhere.net',
+        },
+      },
+      cookie: {
+        u: {},
+      },
+    };
+    res = {
+      redirect: sinon.spy(),
+    };
+    deleteCraftStub = sinon.stub(craftApi, 'deleteCraft');
+    deleteOrgCraftStub = sinon.stub(craftApi, 'deleteOrgCraft');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should redirect if craftId is undefined', async () => {
+    delete req.session.deleteCraftId;
+
+    await controller(req, res);
+
+    expect(deleteCraftStub).to.not.have.been.called;
+    expect(deleteOrgCraftStub).to.not.have.been.called;
+    expect(res.redirect).to.have.been.calledWith('/aircraft');
+  });
+
+  describe('individuals', () => {
+    beforeEach(() => {
+      req.session.u.rl = 'Admin';
+      req.session.org = {
+        i: 12345,
+      };
+    });
+
+    it('should redirect if with success message', () => {
+      deleteOrgCraftStub.resolves(JSON.stringify({}));
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.session.errMsg).to.be.undefined;
+        expect(req.session.successHeader).to.eq('Success');
+        expect(req.session.successMsg).to.eq('Craft deleted');
+        expect(deleteOrgCraftStub).to.have.been.calledWith(12345, 'someone@somewhere.net', 'G-ABCD');
+        expect(deleteCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+
+    it('should redirect if craft api responds with an error', () => {
+      deleteOrgCraftStub.resolves(JSON.stringify({
+        message: 'Example error message',
+      }));
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.session.errMsg).to.eql({ message: 'Failed to delete craft. Try again' });
+        expect(deleteOrgCraftStub).to.have.been.calledWith(12345, 'someone@somewhere.net', 'G-ABCD');
+        expect(deleteCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+
+    it('should redirect if craft api rejects', () => {
+      deleteOrgCraftStub.rejects('craftApi.deleteOrgCraft Example Reject');
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(deleteOrgCraftStub).to.have.been.calledWith(12345, 'someone@somewhere.net', 'G-ABCD');
+        expect(deleteCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+  });
+
+  describe('organisations', () => {
+    beforeEach(() => {
+      req.session.u.rl = 'Individual';
+    });
+
+    it('should redirect if with success message', () => {
+      deleteCraftStub.resolves(JSON.stringify({}));
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.session.errMsg).to.be.undefined;
+        expect(req.session.successHeader).to.eq('Success');
+        expect(req.session.successMsg).to.eq('Craft deleted');
+        expect(deleteCraftStub).to.have.been.calledWith('someone@somewhere.net', 'G-ABCD');
+        expect(deleteOrgCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+
+    it('should redirect if craft api responds with an error', () => {
+      deleteCraftStub.resolves(JSON.stringify({
+        message: 'Example error message',
+      }));
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.session.errMsg).to.eql({ message: 'Failed to delete craft. Try again' });
+        expect(deleteCraftStub).to.have.been.calledWith('someone@somewhere.net', 'G-ABCD');
+        expect(deleteOrgCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+
+    it('should redirect if craft api rejects', () => {
+      deleteCraftStub.rejects('craftApi.deleteCraft Example Reject');
+      const sessionSaveStub = sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(deleteCraftStub).to.have.been.calledWith('someone@somewhere.net', 'G-ABCD');
+        expect(deleteOrgCraftStub).to.not.have.been.called;
+        expect(sessionSaveStub).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/aircraft');
+      });
+    });
+  });
+});

--- a/src/test/aircraft/get.controller.test.js
+++ b/src/test/aircraft/get.controller.test.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../common/models/Cookie.class');
+const craftApi = require('../../common/services/craftApi');
+
+const controller = require('../../app/aircraft/get.controller');
+
+describe('Aircraft Get Controller', () => {
+  let res; let individualCraftStub; let organisationCraftStub;
+
+  const apiResponse = JSON.stringify(
+    [{ id: 1, name: 'Craft 1' }, { id: 2, name: 'Craft 2' }],
+  );
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    res = {
+      render: sinon.spy(),
+    };
+    individualCraftStub = sinon.stub(craftApi, 'getCrafts');
+    organisationCraftStub = sinon.stub(craftApi, 'getOrgCrafts');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('individuals', () => {
+    const req = {
+      session: {
+        u: {
+          dbId: 'example@somewhere.com',
+          rl: 'Individual',
+        },
+      },
+    };
+
+    it('should return an error message when craft api rejects', async () => {
+      const cookie = new CookieModel(req);
+      individualCraftStub.rejects('craftApi.getCrafts Example Reject');
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(individualCraftStub).to.have.been.called;
+        expect(organisationCraftStub).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/aircraft/index');
+        res.render('app/aircraft/index', { cookie, errors: [{ message: 'There was a problem fetching data' }] });
+      });
+    });
+
+    it('should return error messages if in the session', async () => {
+      req.session.errMsg = 'Example Error Message';
+      const cookie = new CookieModel(req);
+      individualCraftStub.resolves(apiResponse);
+      await controller(req, res);
+
+      expect(req.session.errMsg).to.be.undefined;
+      expect(res.render).to.have.been.calledWith('app/aircraft/index', {
+        cookie,
+        savedCrafts: [{ id: 1, name: 'Craft 1' }, { id: 2, name: 'Craft 2' }],
+        errors: ['Example Error Message'],
+      });
+    });
+
+    it('should return success messages if in the session', async () => {
+      req.session.successMsg = 'Example Success Message';
+      req.session.successHeader = 'Example Success Header';
+      const cookie = new CookieModel(req);
+      individualCraftStub.resolves(apiResponse);
+      await controller(req, res);
+
+      expect(req.session.errMsg).to.be.undefined;
+      expect(req.session.successMsg).to.be.undefined;
+      expect(req.session.successHeader).to.be.undefined;
+      expect(res.render).to.have.been.calledWith('app/aircraft/index', {
+        cookie,
+        savedCrafts: [{ id: 1, name: 'Craft 1' }, { id: 2, name: 'Craft 2' }],
+        successMsg: 'Example Success Message',
+        successHeader: 'Example Success Header',
+      });
+    });
+
+    it('should just go to the page if no messages', async () => {
+      const cookie = new CookieModel(req);
+      individualCraftStub.resolves(apiResponse);
+      await controller(req, res);
+
+      expect(req.session.errMsg).to.be.undefined;
+      expect(req.session.successMsg).to.be.undefined;
+      expect(req.session.successHeader).to.be.undefined;
+      expect(res.render).to.have.been.calledWith('app/aircraft/index', {
+        cookie,
+        savedCrafts: [{ id: 1, name: 'Craft 1' }, { id: 2, name: 'Craft 2' }],
+      });
+    });
+  });
+
+  describe('organisations', () => {
+    const req = {
+      session: {
+        u: {
+          dbId: 'example@somewhere.com',
+          rl: 'Admin',
+        },
+      },
+    };
+
+    it('should return an error message when craft api rejects', async () => {
+      const cookie = new CookieModel(req);
+      organisationCraftStub.rejects('craftApi.getOrgCrafts Example Reject');
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(individualCraftStub).to.not.have.been.called;
+        expect(organisationCraftStub).to.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/aircraft/index');
+        res.render('app/aircraft/index', { cookie, errors: [{ message: 'There was a problem fetching data' }] });
+      });
+    });
+
+    it('should just go to the page if no messages', async () => {
+      const cookie = new CookieModel(req);
+      organisationCraftStub.resolves(apiResponse);
+      await controller(req, res);
+
+      expect(req.session.errMsg).to.be.undefined;
+      expect(req.session.successMsg).to.be.undefined;
+      expect(req.session.successHeader).to.be.undefined;
+      expect(res.render).to.have.been.calledWith('app/aircraft/index', {
+        cookie,
+        savedCrafts: [{ id: 1, name: 'Craft 1' }, { id: 2, name: 'Craft 2' }],
+      });
+    });
+  });
+});

--- a/src/test/aircraft/post.controller.test.js
+++ b/src/test/aircraft/post.controller.test.js
@@ -1,0 +1,92 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const controller = require('../../app/aircraft/post.controller');
+
+describe('Aircraft Post Controller', () => {
+  let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example response object with appropriate spies
+    res = {
+      redirect: sinon.stub(),
+      render: sinon.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should do nothing if editCraft or deleteCraft are not set', async () => {
+    const emptyRequest = {
+      body: {
+      },
+      session: {
+        cookie: {},
+        save: sinon.spy(),
+      },
+    };
+
+    await controller(emptyRequest, res);
+
+    expect(emptyRequest.session.editCraftId).to.be.undefined;
+    expect(emptyRequest.session.deleteCraftId).to.be.undefined;
+    expect(emptyRequest.session.save).to.not.have.been.called;
+  });
+
+  it('should redirect to edit', async () => {
+    const editRequest = {
+      body: {
+        editCraft: '1234',
+      },
+      session: {
+        cookie: {},
+        save: callback => callback(),
+      },
+    };
+    const sessionSaveStub = sinon.stub(editRequest.session, 'save').callsArg(0);
+
+    callController = async () => {
+      await controller(editRequest, res);
+    };
+
+    callController().then(() => {
+      expect(editRequest.session.editCraftId).to.eq('1234');
+      expect(sessionSaveStub).to.have.been.called;
+    }).then(() => {
+      expect(res.redirect).to.have.been.calledWith('/aircraft/edit');
+    });
+  });
+
+  it('should redirect to delete', async () => {
+    const deleteRequest = {
+      body: {
+        deleteCraft: '1234',
+      },
+      session: {
+        cookie: {},
+        save: callback => callback(),
+      },
+    };
+    const sessionSaveStub = sinon.stub(deleteRequest.session, 'save').callsArg(0);
+
+    callController = async () => {
+      await controller(deleteRequest, res);
+    };
+
+    callController().then(() => {
+      expect(deleteRequest.session.deleteCraftId).to.eq('1234');
+      expect(sessionSaveStub).to.have.been.called;
+    }).then(() => {
+      expect(res.redirect).to.have.been.calledWith('/aircraft/delete');
+    });
+  });
+});

--- a/src/test/api/healthcheck/get.controller.tests.js
+++ b/src/test/api/healthcheck/get.controller.tests.js
@@ -9,7 +9,7 @@ const getApp = require('../../../server').getApp;
 /**
  * N.B. NOTIFY_API_KEY needs to be set, as a NotifyClient instance is
  * created during this test.
- * 
+ *
  * TODO: Mock the NotifyClient...?
  * TODO: Branch condition is the presence of req.session, need to remove it
  */

--- a/src/test/cookie/get.controller.test.js
+++ b/src/test/cookie/get.controller.test.js
@@ -1,19 +1,22 @@
 /* eslint-disable no-undef */
+
 const sinon = require('sinon');
 const { expect } = require('chai');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 
-const controller = require('../../app/welcome/get.controller');
+const controller = require('../../app/cookie/get.controller');
 
-describe('Welcome Get Controller', () => {
+describe('Cookie Get Controller', () => {
   let req; let res;
 
   beforeEach(() => {
     chai.use(sinonChai);
 
     // Example request and response objects with appropriate spies
-    req = {};
+    req = {
+      session: {},
+    };
     res = {
       render: sinon.spy(),
     };
@@ -23,9 +26,9 @@ describe('Welcome Get Controller', () => {
     sinon.restore();
   });
 
-  it('should render the welcome page', async () => {
+  it('should render the appropriate page', async () => {
     await controller(req, res);
 
-    expect(res.render).to.have.been.calledWith('app/welcome/index');
+    expect(res.render).to.have.been.calledWith('app/cookie/index');
   });
 });

--- a/src/test/garfile/arrival/get.controller.test.js
+++ b/src/test/garfile/arrival/get.controller.test.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const garApi = require('../../../common/services/garApi');
+
+const controller = require('../../../app/garfile/arrival/get.controller');
+
+describe('Arrival Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      body: {
+        departureDate: null,
+        departurePort: 'ZZZZ',
+      },
+      session: {},
+    };
+
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should display a message if gar api rejects', async () => {
+    const cookie = new CookieModel(req);
+    sinon.stub(garApi, 'get').rejects('garApi.get Example Reject');
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', { cookie, errors: [{ message: 'There was a problem getting GAR information' }] });
+    });
+  });
+
+  it('should set cookie values on response', async () => {
+    apiResponse = JSON.stringify({
+      arrivalDate: '2012-30-05',
+      arrivalTime: '15:00',
+      arrivalPort: 'LHR',
+      arrivalLong: '',
+      arrivalLat: '',
+    });
+    const cookie = new CookieModel(req);
+    cookie.setGarId('12345');
+    cookie.setGarArrivalVoyage(apiResponse);
+    sinon.stub(garApi, 'get').resolves(apiResponse);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(garApi.get).to.have.been.calledWith('12345');
+      expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', { cookie });
+    });
+  });
+});

--- a/src/test/garfile/arrival/post.controller.test.js
+++ b/src/test/garfile/arrival/post.controller.test.js
@@ -1,0 +1,240 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const garApi = require('../../../common/services/garApi');
+const CookieModel = require('../../../common/models/Cookie.class');
+const validator = require('../../../common/utils/validator');
+const ValidationRule = require('../../../common/models/ValidationRule.class');
+
+const controller = require('../../../app/garfile/arrival/post.controller');
+
+describe('Arrival Post Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    req = {
+      body: {
+        arrivalPort: 'LHR',
+        arrivalLat: '45.1000',
+        arrivalLong: '12.1000',
+        arrivalDay: '30',
+        arrivalMonth: '5',
+        arrivalYear: '2020',
+        arrivalHour: '15',
+        arrivalMinute: '00',
+      },
+      session: {
+        gar: {
+          id: 'ABCDEFGH',
+          voyageArrival: {},
+          status: 'Draft',
+        },
+      },
+    };
+
+    res = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // TODO: All the permutations?
+  describe('validation chains', () => {
+    let apiResponse;
+
+    beforeEach(() => {
+      apiResponse = JSON.stringify({
+        arrivalDate: '2012-30-05',
+        arrivalTime: '15:00',
+        arrivalPort: 'LHR',
+        arrivalLong: '',
+        arrivalLat: '',
+      });
+    });
+
+    it('should fail for two letter port code', () => {
+      req.body.arrivalPort = 'no'; // Check this upper cases the port
+      const cookie = new CookieModel(req);
+
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch');
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+        expect(garApi.patch).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
+          cookie,
+          errors: [new ValidationRule(validator.validPort, 'arrivalPort', 'NO', 'The arrival airport code must be a minimum of 3 letters and a maximum of 4 letters')],
+        });
+      });
+    });
+
+    describe('port codes and co-ordinates', () => {
+      it('should fail if port is ZZZZ and no longitude or latitude', () => {
+        req.body.arrivalPort = 'ZZZZ';
+        delete req.body.arrivalLong;
+        delete req.body.arrivalLat;
+        const cookie = new CookieModel(req);
+
+        sinon.stub(garApi, 'get').resolves(apiResponse);
+        sinon.stub(garApi, 'patch');
+
+        const callController = async () => {
+          await controller(req, res);
+        };
+
+        callController().then(() => {
+          expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+          expect(garApi.patch).to.not.have.been.called;
+          expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
+            cookie,
+            errors: [
+              // SIC: lattitude instead of latitide
+              new ValidationRule(validator.lattitude, 'arrivalLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
+              new ValidationRule(validator.longitude, 'arrivalLong', undefined, 'Value entered is incorrect. Enter longitude to 4 decimal places'),
+            ],
+          });
+        });
+      });
+
+      // TODO: Technically, if the port is NOT ZZZZ then there should not be a longitude or latitude
+      // which is not actually represented in the code
+      // it('should fail if port is not ZZZZ yet there is longitude and latitude', () => {
+      //   const cookie = new CookieModel(req);
+
+      //   sinon.stub(garApi, 'get').resolves(apiResponse);
+      //   sinon.stub(garApi, 'patch');
+
+      //   const callController = async () => {
+      //     await controller(req, res);
+      //   };
+
+      //   callController().then(() => {
+      //     expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+      //     expect(garApi.patch).to.not.have.been.called;
+      //     expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
+      //       cookie,
+      //       errors: [
+      //         // SIC: lattitude instead of latitide
+      // new ValidationRule(
+      //    validator.lattitude,
+      //    'arrivalLat', undefined,
+      //    'Value entered is incorrect. Enter latitude to 4 decimal places'),
+      // new ValidationRule(
+      //    validator.longitude,
+      //    'arrivalLong', undefined,
+      //    'Value entered is incorrect. Enter longitude to 4 decimal places'),
+      //       ],
+      //     });
+      //   });
+      // });
+    });
+  });
+
+  describe('performAPICall', () => {
+    let apiResponse;
+
+    beforeEach(() => {
+      apiResponse = JSON.stringify({
+        arrivalDate: '2012-30-05',
+        arrivalTime: '15:00',
+        arrivalPort: 'LHR',
+        arrivalLong: '',
+        arrivalLat: '',
+      });
+    });
+
+    it('should return an error message if api rejects', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').rejects('garApi.patch Example Reject');
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+        expect(garApi.patch).to.have.been.calledWith('ABCDEFGH', cookie.getGarStatus(), cookie.getGarArrivalVoyage());
+        expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
+          cookie,
+          errors: [{
+            message: 'Failed to add to GAR',
+          }],
+        });
+      });
+    });
+
+    it('should return the error message if one is returned from api', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({
+        message: 'GAR does not exist',
+      }));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+        expect(garApi.patch).to.have.been.calledWith('ABCDEFGH', cookie.getGarStatus(), cookie.getGarArrivalVoyage());
+        expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
+          cookie,
+          errors: [{
+            message: 'GAR does not exist',
+          }],
+        });
+      });
+    });
+
+    // TODO:
+    // Save and Continue currently goes to the next page, but it
+    // should probably go to the craft page if going through the flow,
+    // but back to the GAR view if going into specific sections.
+    it('should go to the home page if no buttonClicked property', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({}));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.body.buttonClicked).to.be.undefined;
+        expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+        expect(garApi.patch).to.have.been.calledWith('ABCDEFGH', cookie.getGarStatus(), cookie.getGarArrivalVoyage());
+        expect(res.redirect).to.have.been.calledWith('/home');
+      });
+    });
+
+    it('should go to craft page if buttonClicked property is set', () => {
+      req.body.buttonClicked = 'Save and continue';
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({}));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+        expect(garApi.patch).to.have.been.calledWith('ABCDEFGH', cookie.getGarStatus(), cookie.getGarArrivalVoyage());
+        expect(res.redirect).to.have.been.calledWith('/garfile/craft');
+      });
+    });
+  });
+});

--- a/src/test/garfile/cancel/get.controller.test.js
+++ b/src/test/garfile/cancel/get.controller.test.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/garfile/cancel/get.controller');
+
+describe('GAR Cancel Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/garfile/cancel/index', { cookie });
+  });
+});

--- a/src/test/garfile/departure/get.controller.test.js
+++ b/src/test/garfile/departure/get.controller.test.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const garApi = require('../../../common/services/garApi');
+
+const controller = require('../../../app/garfile/departure/get.controller');
+
+describe('Departure Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      body: {
+        departureDate: null,
+        departurePort: 'ZZZZ',
+      },
+      session: {},
+    };
+
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should display a message if gar api rejects', async () => {
+    const cookie = new CookieModel(req);
+    sinon.stub(garApi, 'get').rejects('garApi.get Example Reject');
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(res.render).to.have.been.calledWith('app/garfile/departure/index', { cookie, errors: [{ message: 'There was a problem getting GAR information' }] });
+    });
+  });
+
+  it('should set cookie values on response', async () => {
+    apiResponse = JSON.stringify({
+      departureDate: '2012-30-05',
+      departureTime: '15:00',
+      departurePort: 'LHR',
+      departureLong: '',
+      departureLat: '',
+    });
+    const cookie = new CookieModel(req);
+    cookie.setGarId('12345');
+    cookie.setGarDepartureVoyage(apiResponse);
+    sinon.stub(garApi, 'get').resolves(apiResponse);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(garApi.get).to.have.been.calledWith('12345');
+      expect(res.render).to.have.been.calledWith('app/garfile/departure/index', { cookie });
+    });
+  });
+});

--- a/src/test/garfile/departure/index.test.js
+++ b/src/test/garfile/departure/index.test.js
@@ -1,4 +1,7 @@
-const expect = require('chai').expect;
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const { expect } = require('chai');
 
 const index = require('../../../app/garfile/departure/index');
 

--- a/src/test/garfile/departure/post.controller.test.js
+++ b/src/test/garfile/departure/post.controller.test.js
@@ -1,15 +1,20 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
 const sinon = require('sinon');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 
-const logger = require('../../../common/utils/logger')(__filename);
 const garApi = require('../../../common/services/garApi');
+const CookieModel = require('../../../common/models/Cookie.class');
+const validator = require('../../../common/utils/validator');
+const ValidationRule = require('../../../common/models/ValidationRule.class');
 
 const controller = require('../../../app/garfile/departure/post.controller');
 
 describe('Departure Post Controller', () => {
-  let req, res;
+  let req; let res; let apiResponse;
 
   beforeEach(() => {
     chai.use(sinonChai);
@@ -17,38 +22,35 @@ describe('Departure Post Controller', () => {
     // Example request and response objects with appropriate spies
     req = {
       body: {
-        departureDate: null,
         departurePort: 'ZZZZ',
+        departureLat: '45.1000',
+        departureLong: '12.1000',
+        departureDay: '30',
+        departureMonth: '5',
+        departureYear: '2020',
+        departureHour: '15',
+        departureMinute: '00',
       },
       session: {
         gar: {
-          id: 12345,
-          voyageDeparture: {
-            departureDay: 6,
-            departureMonth: 6,
-            departureYear: 2019,
-          },
+          id: '12345',
+          voyageDeparture: {},
+          status: 'Draft',
         },
-      }
+      },
     };
 
     res = {
+      redirect: sinon.spy(),
       render: sinon.spy(),
     };
 
-    // Stub APIs, in this case, GAR API
-    sinon.stub(garApi, 'get').callsFake((garId) => {
-      logger.info('Stubbed garApi get method called');
-      logger.info('garId: ' + garId);
-      return Promise.resolve(JSON.stringify(req.session.gar));
-    });
-
-    sinon.stub(garApi, 'patch').callsFake((garId, status, partial) => {
-      logger.info('Stubbed garApi patch method called');
-      logger.info('garId: ' + garId);
-      logger.info('status: ' + status);
-      logger.info('partial: ' + partial);
-      return Promise.resolve();
+    apiResponse = JSON.stringify({
+      departureDate: '2012-30-05',
+      departureTime: '15:00',
+      departurePort: 'LHR',
+      departureLong: '',
+      departureLat: '',
     });
   });
 
@@ -56,9 +58,159 @@ describe('Departure Post Controller', () => {
     sinon.restore();
   });
 
-  it('should fail validation on basic submit', async() => {
+  // TODO: Validations could stub the performAPICall as it won't reach
+  // it normally (need to use rewire library)
+  it('should fail validation on basic submit', async () => {
+    delete req.body.departurePort;
+
+    sinon.stub(garApi, 'get').resolves(apiResponse);
+    sinon.stub(garApi, 'patch');
+
     await controller(req, res);
 
+    expect(garApi.get).to.have.been.called;
+    expect(garApi.patch).to.not.have.been.called;
     expect(res.render).to.have.been.calledWith('app/garfile/departure/index');
+  });
+
+  describe('port codes and co-ordinates', () => {
+    it('should fail if port is ZZZZ and no longitude or latitude', () => {
+      req.body.departurePort = 'ZZZZ';
+      delete req.body.departureLong;
+      delete req.body.departureLat;
+      const cookie = new CookieModel(req);
+
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch');
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
+          cookie,
+          errors: [
+            // SIC: lattitude instead of latitide
+            new ValidationRule(validator.lattitude, 'departureLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
+            new ValidationRule(validator.longitude, 'departureLong', undefined, 'Value entered is incorrect. Enter longitude to 4 decimal places'),
+          ],
+        });
+      });
+    });
+
+    // TODO: Technically, if the port is NOT ZZZZ then there should not be a longitude or latitude
+    // which is not actually represented in the code
+    // it('should fail if port is not ZZZZ yet there is longitude and latitude', () => {
+    //   const cookie = new CookieModel(req);
+
+    //   sinon.stub(garApi, 'get').resolves(apiResponse);
+    //   sinon.stub(garApi, 'patch');
+
+    //   const callController = async () => {
+    //     await controller(req, res);
+    //   };
+
+    //   callController().then(() => {
+    //     expect(garApi.get).to.have.been.calledWith('ABCDEFGH');
+    //     expect(garApi.patch).to.not.have.been.called;
+    //     expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
+    //       cookie,
+    //       errors: [
+    //         // SIC: lattitude instead of latitide
+    // new ValidationRule(
+    //    validator.lattitude,
+    //    'departureLat', undefined,
+    //    'Value entered is incorrect. Enter latitude to 4 decimal places'),
+    // new ValidationRule(
+    //    validator.longitude,
+    //    'departureLong', undefined,
+    //    'Value entered is incorrect. Enter longitude to 4 decimal places'),
+    //       ],
+    //     });
+    //   });
+    // });
+  });
+
+  describe('performAPICall', () => {
+    it('should return an error message if api rejects', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').rejects('garApi.patch Example Reject');
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.have.been.calledWith('12345', cookie.getGarStatus(), cookie.getGarDepartureVoyage());
+        expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
+          cookie,
+          errors: [{
+            message: 'Failed to add to GAR',
+          }],
+        });
+      });
+    });
+
+    it('should return the error message if one is returned from api', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({
+        message: 'GAR does not exist',
+      }));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.have.been.calledWith('12345', cookie.getGarStatus(), cookie.getGarDepartureVoyage());
+        expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
+          cookie,
+          errors: [{
+            message: 'GAR does not exist',
+          }],
+        });
+      });
+    });
+
+    // TODO:
+    // Save and Continue currently goes to the next page, but it
+    // should probably go to the craft page if going through the flow,
+    // but back to the GAR view if going into specific sections.
+    it('should go to the home page if no buttonClicked property', () => {
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({}));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(req.body.buttonClicked).to.be.undefined;
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.have.been.calledWith('12345', cookie.getGarStatus(), cookie.getGarDepartureVoyage());
+        expect(res.redirect).to.have.been.calledWith('/home');
+      });
+    });
+
+    it('should go to arrival page if buttonClicked property is set', () => {
+      req.body.buttonClicked = 'Save and continue';
+      const cookie = new CookieModel(req);
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch').resolves(JSON.stringify({}));
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.have.been.calledWith('12345', cookie.getGarStatus(), cookie.getGarDepartureVoyage());
+        expect(res.redirect).to.have.been.calledWith('/garfile/arrival');
+      });
+    });
   });
 });

--- a/src/test/garfile/garupload/get.controller.test.js
+++ b/src/test/garfile/garupload/get.controller.test.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/garfile/garupload/get.controller');
+
+describe('GAR Upload Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page when no failure', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/garfile/garupload/index', { cookie });
+  });
+
+  // TODO:
+  // req.session.failureMsg single object
+  // req.session.failureMsg array of messages
+});

--- a/src/test/garfile/manifest/editperson/get.controller.test.js
+++ b/src/test/garfile/manifest/editperson/get.controller.test.js
@@ -1,73 +1,71 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-expressions */
+
 const sinon = require('sinon');
-const controller = require('../../../../app/garfile/manifest/editperson/get.controller');
-const garApi = require('../../../../common/services/garApi');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
-const logger = require('../../../../common/utils/logger')(__filename);
+
+const garApi = require('../../../../common/services/garApi');
+
+const controller = require('../../../../app/garfile/manifest/editperson/get.controller');
 
 describe('Manifest Edit Person Get Controller', () => {
-    let req, res, apiResponse;
+  let req; let res; let apiResponse;
 
-    beforeEach(() => {
-        chai.use(sinonChai);
+  beforeEach(() => {
+    chai.use(sinonChai);
 
-        apiResponse = {
-            items: [
-                {
-                    garPeopleId: 1
-                },
-                {
-                    garPeopleId: 2
-                }
-            ]
-        }
+    apiResponse = {
+      items: [{ garPeopleId: 1 }, { garPeopleId: 2 }],
+    };
 
-        // Example request and response objects with appropriate spies
-        req = {
-            session: {
-                gar: {
-                    id: 1
-                },
-            }
-        };
-    
-        res = {
-            redirect: sinon.spy(),
-            render: sinon.spy(),
-        };
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {
+        gar: {
+          id: 1,
+        },
+      },
+    };
+
+    res = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should redirect back if no person id set', async () => {
+    await controller(req, res);
+
+    expect(res.redirect).to.have.been.calledWith('/garfile/manifest');
+  });
+
+  it('should render the appropriate page', async () => {
+    req.session.editPersonId = 1;
+    sinon.stub(garApi, 'getPeople').resolves(JSON.stringify(apiResponse));
+
+    await controller(req, res);
+
+    expect(res.redirect).to.have.not.been.called;
+    expect(res.render).to.have.been.calledWith('app/garfile/manifest/editperson/index');
+  });
+
+  it('should redirect if the api has an issue', async () => {
+    req.session.editPersonId = 1;
+    sinon.stub(garApi, 'getPeople').rejects('Some reason here');
+
+    // Promise chain, so controller call is wrapped into its own method
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(res.redirect).to.have.been.calledWith('/garfile/manifest');
     });
-
-    afterEach(() => {
-        sinon.restore();
-    });
-
-    it('should redirect back if no person id set', async() => {
-        await controller(req, res);
-
-        expect(res.redirect).to.have.been.calledWith('/garfile/manifest');
-    });
-
-    it('should render the appropriate page', async() => {
-        req.session.editPersonId = 1;
-        sinon.stub(garApi, 'getPeople').resolves(JSON.stringify(apiResponse));
-
-        await controller(req, res);
-        
-        expect(res.redirect).to.have.not.been.called;
-        expect(res.render).to.have.been.calledWith('app/garfile/manifest/editperson/index');
-    });
-
-    it('should redirect if the api has an issue', async() => {
-        req.session.editPersonId = 1;
-        sinon.stub(garApi, 'getPeople').rejects('Some reason here');
-
-        await controller(req, res);
-
-        // TODO: For some reason, despite going into the catch block of the get.controller.js
-        // The res.redirect call appears to not be picked up by the spy, so the not called
-        // passes, whcih seems incorrect
-        // expect(res.redirect).to.have.been.called;
-        expect(res.redirect).to.have.not.been.called;
-    });
+  });
 });

--- a/src/test/garfile/submit/failure/get.controller.test.js
+++ b/src/test/garfile/submit/failure/get.controller.test.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../../common/models/Cookie.class');
+
+const controller = require('../../../../app/garfile/submit/failure/get.controller');
+
+describe('GAR Submit Failure Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/garfile/review/failure/index', { cookie });
+  });
+});

--- a/src/test/garfile/submit/success/get.controller.test.js
+++ b/src/test/garfile/submit/success/get.controller.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../../common/models/Cookie.class');
+
+const controller = require('../../../../app/garfile/submit/success/get.controller');
+
+describe('GAR Submit Success Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    // Sic: sucess instead of success
+    expect(res.render).to.have.been.calledWith('app/garfile/submit/sucess/index', { cookie });
+  });
+});

--- a/src/test/help/get.controller.test.js
+++ b/src/test/help/get.controller.test.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const controller = require('../../app/help/get.controller');
+
+describe('Help Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/help/index');
+  });
+});

--- a/src/test/index/get.controller.test.js
+++ b/src/test/index/get.controller.test.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const controller = require('../../app/index/get.controller');
+
+describe('Index Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      redirect: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should redirect to the welcome page', async () => {
+    await controller(req, res);
+
+    expect(res.redirect).to.have.been.calledWith('/welcome/index');
+  });
+});

--- a/src/test/organisation/assignrole/get.controller.test.js
+++ b/src/test/organisation/assignrole/get.controller.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const roles = require('../../../common/seeddata/egar_user_roles.json');
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/organisation/assignrole/get.controller');
+
+describe('Organisation Assign Role Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/organisation/assignrole/index', { cookie, roles });
+  });
+});

--- a/src/test/organisation/invitesuccess/get.controller.test.js
+++ b/src/test/organisation/invitesuccess/get.controller.test.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/organisation/invitesuccess/get.controller');
+
+describe('Organisation Invite Success Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/organisation/invitesuccess/index', { cookie });
+  });
+});

--- a/src/test/organisation/inviteusers/get.controller.test.js
+++ b/src/test/organisation/inviteusers/get.controller.test.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/organisation/inviteusers/get.controller');
+
+describe('Organisation Invite Users Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/organisation/inviteusers/index', { cookie });
+  });
+});

--- a/src/test/people/add/get.controller.test.js
+++ b/src/test/people/add/get.controller.test.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const persontype = require('../../../common/seeddata/egar_type_of_saved_person');
+const documenttype = require('../../../common/seeddata/egar_saved_people_travel_document_type.json');
+const genderchoice = require('../../../common/seeddata/egar_gender_choice.json');
+
+const controller = require('../../../app/people/add/get.controller');
+
+describe('People Add Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(res.render).to.have.been.calledWith('app/people/add/index', {
+      cookie, genderchoice, persontype, documenttype,
+    });
+  });
+});

--- a/src/test/user/deleteAccount/get.controller.test.js
+++ b/src/test/user/deleteAccount/get.controller.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+
+const controller = require('../../../app/user/deleteAccount/get.controller');
+
+describe('User Delete Account Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+    };
+    res = {
+      render: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the appropriate page', async () => {
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    // SIC: deleteAccount instead of deleteaccount
+    expect(res.render).to.have.been.calledWith('app/user/deleteAccount/index', { cookie });
+  });
+});

--- a/src/test/user/login/post.controller.test.js
+++ b/src/test/user/login/post.controller.test.js
@@ -46,6 +46,7 @@ describe('User Login Post Controller', () => {
   });
 
   afterEach(() => {
+    sinon.reset();
     sinon.restore();
   });
 
@@ -115,8 +116,6 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.have.been.called;
-        // TODO: Resolve -> Resolve -> Resolve
-        // expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       }).then(() => {
         expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       });
@@ -136,9 +135,12 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.have.been.called;
+        expect(res.redirect).to.not.have.been.called;
       }).then(() => {
-        // The emailService rejects the Promise
-      }).catch(() => {
+        expect(emailService.send).to.have.been.called;
+        expect(res.redirect).to.not.have.been.called;
+      }).then(() => {
+        expect(emailService.send).to.have.been.called;
         expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       });
     });
@@ -193,9 +195,11 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.not.have.been.called;
+        expect(res.render).to.not.have.been.called;
       }).then(() => {
-        // The tokenApi rejects the Promise
-      }).catch(() => {
+        expect(emailService.send).to.not.have.been.called;
+        expect(res.render).to.not.have.been.called;
+      }).then(() => {
         expect(emailService.send).to.not.have.been.called;
         expect(res.render).to.have.been.calledWith('app/user/login/index');
       });

--- a/src/test/user/login/post.controller.test.js
+++ b/src/test/user/login/post.controller.test.js
@@ -49,7 +49,7 @@ describe('User Login Post Controller', () => {
     sinon.restore();
   });
 
-  it('should fail validation on erroneous submit', async () => {
+  it('should fail validation on empty submit', async () => {
     const emptyRequest = {
       body: {
         Username: '',
@@ -96,7 +96,7 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.not.have.been.called;
-        // TODO: Resolve -> Resolve -> Resolve
+      }).then(() => {
         expect(res.render).to.have.been.calledWith('app/user/login/index');
       });
     });
@@ -117,6 +117,8 @@ describe('User Login Post Controller', () => {
         expect(emailService.send).to.have.been.called;
         // TODO: Resolve -> Resolve -> Resolve
         // expect(res.redirect).to.have.been.calledWith('/login/authenticate');
+      }).then(() => {
+        expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       });
     });
 
@@ -134,9 +136,10 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.have.been.called;
-        // TODO: Resolve -> Resolve -> Reject
-        // expect(res.redirect).to.have.been.calledWith('/login/authenticate');
-        expect(res.redirect).to.have.been.called;
+      }).then(() => {
+        // The emailService rejects the Promise
+      }).catch(() => {
+        expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       });
     });
   });
@@ -161,8 +164,12 @@ describe('User Login Post Controller', () => {
       };
 
       callController().then(() => {
+        expect(userApi.userSearch).to.have.been.calledWith('exampleuser');
         expect(emailService.send).to.not.have.been.called;
-        expect(res.redirect).to.have.been.calledWith('app/user/login/index');
+        expect(res.redirect).to.not.have.been.called;
+      }).then(() => {
+        expect(emailService.send).to.have.been.called;
+        expect(res.redirect).to.have.been.calledWith('/login/authenticate');
       });
     });
 
@@ -186,8 +193,11 @@ describe('User Login Post Controller', () => {
 
       callController().then(() => {
         expect(emailService.send).to.not.have.been.called;
-        // TODO: Resolve -> Resolve -> Reject
-        // expect(res.render).to.have.been.called;
+      }).then(() => {
+        // The tokenApi rejects the Promise
+      }).catch(() => {
+        expect(emailService.send).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/user/login/index');
       });
     });
   });

--- a/src/test/user/manageuserdetail/get.controller.test.js
+++ b/src/test/user/manageuserdetail/get.controller.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef */
+
 const sinon = require('sinon');
 const { expect } = require('chai');
 const chai = require('chai');

--- a/src/test/user/manageuserdetail/post.controller.test.js
+++ b/src/test/user/manageuserdetail/post.controller.test.js
@@ -1,0 +1,136 @@
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const validator = require('../../../common/utils/validator');
+const ValidationRule = require('../../../common/models/ValidationRule.class');
+const userApi = require('../../../common/services/userManageApi');
+
+const controller = require('../../../app/user/manageuserdetail/post.controller');
+
+describe('Manage User Detail Post Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    req = {
+      body: {
+        Firstname: 'Kylo',
+        Lastname: 'Ren',
+      },
+      session: {
+        u: {
+          e: 'kylo.ren@firstorder.emp',
+        },
+      },
+    };
+    res = {
+      redirect: sinon.stub(),
+      render: sinon.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return validation error on empty first name', () => {
+    req.body.Firstname = '';
+    const cookie = new CookieModel(req);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(res.render).to.have.been.calledWith('app/user/manageuserdetail/index', {
+        cookie,
+        errors: [new ValidationRule(validator.notEmpty, 'firstname', '', 'Enter your given name')],
+      });
+    });
+
+    delete req.body.Firstname;
+
+    callController().then(() => {
+      expect(res.render).to.have.been.calledWith('app/user/manageuserdetail/index', {
+        cookie,
+        errors: [new ValidationRule(validator.notEmpty, 'firstname', undefined, 'Enter your given name')],
+      });
+    });
+  });
+
+  it('should return validation error on empty last name', () => {
+    req.body.Lastname = '';
+    const cookie = new CookieModel(req);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(res.render).to.have.been.calledWith('app/user/manageuserdetail/index', {
+        cookie,
+        errors: [new ValidationRule(validator.notEmpty, 'lastname', '', 'Enter your surname')],
+      });
+    });
+  });
+
+  it('should return an error if the user api rejects', () => {
+    sinon.stub(userApi, 'updateDetails').rejects('userApi.updateDetails Example Reject');
+    const cookie = new CookieModel(req);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then().then(() => {
+      expect(res.render).to.have.been.calledWith('app/user/manageuserdetail/index', {
+        cookie,
+        errors: [{ message: 'Failed to update. Try again' }],
+      });
+    });
+  });
+
+  it('should return the response if the api returns an error message', () => {
+    sinon.stub(userApi, 'updateDetails').resolves(JSON.stringify({
+      message: 'Person does not exist',
+    }));
+    const cookie = new CookieModel(req);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then().then(() => {
+      expect(userApi.updateDetails).to.have.been.calledWith('kylo.ren@firstorder.emp', 'Kylo', 'Ren');
+      expect(res.render).to.have.been.calledWith('app/user/manageuserdetail/index', {
+        cookie,
+        errors: [{ message: 'Person does not exist' }],
+      });
+    });
+  });
+
+  it('should update the cookie if the api returns ok', () => {
+    sinon.stub(userApi, 'updateDetails').resolves(JSON.stringify({
+      firstName: 'Kylo',
+      lastName: 'Ren',
+    }));
+    const cookie = new CookieModel(req);
+    cookie.setUserFirstName('Kylo');
+    cookie.setUserLastName('Ren');
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then().then(() => {
+      expect(userApi.updateDetails).to.have.been.calledWith('kylo.ren@firstorder.emp', 'Kylo', 'Ren');
+      expect(res.render).to.have.been.calledWith('app/user/detailschanged/index', { cookie });
+    });
+  });
+});

--- a/src/test/user/register/post.controller.test.js
+++ b/src/test/user/register/post.controller.test.js
@@ -1,14 +1,20 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-unused-expressions */
 /* eslint-disable no-undef */
+
 const sinon = require('sinon');
 const { expect } = require('chai');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
+const rewire = require('rewire');
 
 const tokenApi = require('../../../common/services/tokenApi');
 const config = require('../../../common/config');
 const userCreateApi = require('../../../common/services/createUserApi');
 const tokenService = require('../../../common/services/create-token');
 const sendTokenService = require('../../../common/services/send-token');
+const CookieModel = require('../../../common/models/Cookie.class');
+const whiteListService = require('../../../common/services/whiteList');
 
 const controller = require('../../../app/user/register/post.controller');
 
@@ -36,6 +42,7 @@ describe('User Register Post Controller', () => {
           },
         },
         cookie: {},
+        save: callback => callback(),
       },
     };
 
@@ -69,12 +76,72 @@ describe('User Register Post Controller', () => {
   });
 
   describe('whitelist enabled', () => {
+    const rewiredController = rewire('../../../app/user/register/post.controller.js');
+    const createUserFunction = { createUser: rewiredController.__get__('createUser') };
+    const stubCreateUser = sinon.stub(createUserFunction, 'createUser');
 
+    beforeEach(() => {
+      config.WHITELIST_REQUIRED = 'true';
+      rewiredController.__set__('createUser', stubCreateUser);
+    });
+
+    afterEach(() => {
+      stubCreateUser.reset();
+    });
+
+    it('should create user if whitelisted', async () => {
+      config.WHITELIST_REQUIRED = 'true';
+      const cookie = new CookieModel(req);
+      sinon.stub(whiteListService, 'isWhitelisted').resolves(true);
+
+      const callController = async () => {
+        await rewiredController(req, res);
+      };
+
+      callController().then(() => {
+        expect(whiteListService.isWhitelisted).to.have.been.calledWith('dvader@empire.net');
+        expect(stubCreateUser).to.have.been.calledWith(req, res, cookie);
+      });
+    });
+
+    // TODO: If a user is not whitelisted, they still are presented with the success page
+    it('should go to success if not whitelisted', async () => {
+      sinon.stub(whiteListService, 'isWhitelisted').resolves(false);
+      sinon.stub(req.session, 'save').callsArg(0);
+
+      const callController = async () => {
+        await rewiredController(req, res);
+      };
+
+      callController().then(() => {
+        expect(whiteListService.isWhitelisted).to.have.been.calledWith('dvader@empire.net');
+        expect(req.session.save).to.have.been.called;
+        expect(stubCreateUser).to.not.have.been.called;
+      }).then(() => {
+        expect(res.redirect).to.have.been.calledWith('/user/regmsg');
+      });
+    });
+
+    it('should return an error if the whiteListService rejects', () => {
+      sinon.stub(whiteListService, 'isWhitelisted').rejects('whiteListService.isWhitelisted Example Reject');
+      const cookie = new CookieModel(req);
+
+      const callController = async () => {
+        await rewiredController(req, res);
+      };
+
+      callController().then(() => {
+        expect(whiteListService.isWhitelisted).to.have.been.calledWith('dvader@empire.net');
+        expect(stubCreateUser).to.not.have.been.called;
+        expect(res.render).to.not.have.been.called;
+      }).then(() => {
+        expect(res.render).to.have.been.calledWith('app/user/register/index', { cookie, errors: [{ message: 'Registration failed, try again' }] });
+      });
+    });
   });
 
   describe('whitelist disabled', () => {
     it('should call createUser function, and send token when all resolves', async () => {
-      // sinon.stub(nanoid).returns('FakeNanoId');
       config.WHITELIST_REQUIRED = 'false';
       sinon.stub(sendTokenService, 'send').resolves();
       sinon.stub(tokenApi, 'setToken');
@@ -91,14 +158,14 @@ describe('User Register Post Controller', () => {
       callController().then(() => {
         expect(userCreateApi.post).to.have.been.calledWith('Darth', 'Vader', 'dvader@empire.net', sinon.match.falsy);
         expect(sendTokenService.send).to.have.been.calledWith('Darth', 'dvader@empire.net', sinon.match.string);
-        // TODO: Investigate
-        // expect(res.redirect).to.have.been.calledWith('/user/regmsg');
+      }).then(() => {
+        expect(res.redirect).to.have.been.calledWith('/user/regmsg');
       });
     });
 
     it('should call createUser function, but inform user if there is an issue with GOV notify', async () => {
-      // sinon.stub(nanoid).returns('FakeNanoId');
       config.WHITELIST_REQUIRED = 'false';
+      const cookie = new CookieModel(req);
       sinon.stub(sendTokenService, 'send').rejects('Example Reject');
       sinon.stub(tokenApi, 'setToken');
       sinon.stub(userCreateApi, 'post').resolves(
@@ -114,9 +181,57 @@ describe('User Register Post Controller', () => {
       callController().then(() => {
         expect(userCreateApi.post).to.have.been.calledWith('Darth', 'Vader', 'dvader@empire.net', sinon.match.falsy);
         expect(sendTokenService.send).to.have.been.calledWith('Darth', 'dvader@empire.net', sinon.match.string);
-        // TODO: Investigate
-        // expect(res.redirect).to.have.been.calledWith('/user/regmsg');
+      }).then(() => {
+        expect(res.render).to.not.been.called;
+      }).then(() => {
+        expect(res.render).to.have.been.calledWith('app/user/register/index', { cookie, errors: [{ message: 'Registration failed, try again' }] });
       });
+    });
+  });
+
+  // TODO: Current functionality is that a message from the API could be that a user exists
+  // but then goes to the next page without informing the user (so re-registering is not a thing)
+  it('should redirect if createUserApi resolves but with an error', async () => {
+    config.WHITELIST_REQUIRED = 'false';
+    sinon.stub(req.session, 'save').callsArg(0);
+    sinon.stub(sendTokenService, 'send');
+    sinon.stub(tokenApi, 'setToken');
+    sinon.stub(userCreateApi, 'post').resolves(
+      JSON.stringify({
+        message: 'User already exists',
+      }),
+    );
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(userCreateApi.post).to.have.been.calledWith('Darth', 'Vader', 'dvader@empire.net', sinon.match.falsy);
+      expect(sendTokenService.send).to.not.have.been.called;
+      expect(req.session.save).to.have.been.called;
+    }).then(() => {
+      expect(res.redirect).to.have.been.calledWith('/user/regmsg');
+    });
+  });
+
+  it('should return an error message when userCreateApi rejects', async () => {
+    config.WHITELIST_REQUIRED = 'false';
+    const cookie = new CookieModel(req);
+    sinon.stub(sendTokenService, 'send');
+    sinon.stub(tokenApi, 'setToken');
+    sinon.stub(userCreateApi, 'post').rejects('userCreateApi.post Example Reject');
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(userCreateApi.post).to.have.been.calledWith('Darth', 'Vader', 'dvader@empire.net', sinon.match.falsy);
+      expect(sendTokenService.send).to.not.have.been.called;
+      expect(res.render).to.not.have.been.called;
+    }).then(() => {
+      expect(res.render).to.have.been.calledWith('app/user/register/index', { cookie, errors: [{ message: 'Registration failed, try again' }] });
     });
   });
 });

--- a/src/test/user/viewDetails/post.controller.test.js
+++ b/src/test/user/viewDetails/post.controller.test.js
@@ -1,0 +1,102 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const controller = require('../../../app/user/viewDetails/post.controller');
+
+describe('Aircraft Post Controller', () => {
+  let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example response object with appropriate spies
+    res = {
+      redirect: sinon.stub(),
+      render: sinon.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should do nothing if editCraft or deleteCraft are not set', async () => {
+    const emptyRequest = {
+      body: {
+      },
+      session: {
+        cookie: {},
+        save: sinon.spy(),
+      },
+    };
+
+    await controller(emptyRequest, res);
+  });
+
+  it('should redirect to craft edit', async () => {
+    const editRequest = {
+      body: {
+        editCraft: '1234',
+      },
+      session: {
+        cookie: {},
+        save: callback => callback(),
+      },
+    };
+    callController = async () => {
+      await controller(editRequest, res);
+    };
+
+    callController().then(() => {
+      expect(editRequest.session.editCraftId).to.eq('1234');
+      expect(res.redirect).to.have.been.calledWith('/user/savedcraft/edit');
+    });
+  });
+
+  it('should redirect to craft delete', async () => {
+    const deleteRequest = {
+      body: {
+        deleteCraft: '1234',
+      },
+      session: {
+        cookie: {},
+        save: callback => callback(),
+      },
+    };
+
+    callController = async () => {
+      await controller(deleteRequest, res);
+    };
+
+    callController().then(() => {
+      expect(deleteRequest.session.deleteCraftId).to.eq('1234');
+      expect(res.redirect).to.have.been.calledWith('/user/savedcraft/delete');
+    });
+  });
+
+  it('should redirect to people edit', async () => {
+    const deleteRequest = {
+      body: {
+        editPerson: 'ABCDEFG',
+      },
+      session: {
+        cookie: {},
+        save: callback => callback(),
+      },
+    };
+
+    callController = async () => {
+      await controller(deleteRequest, res);
+    };
+
+    callController().then(() => {
+      expect(deleteRequest.session.editPersonId).to.eq('ABCDEFG');
+      expect(res.redirect).to.have.been.calledWith('/user/savedpeople/edit');
+    });
+  });
+});

--- a/src/test/verify/get.controller.test.js
+++ b/src/test/verify/get.controller.test.js
@@ -1,0 +1,150 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const i18n = require('i18n');
+const config = require('../../common/config');
+const tokenService = require('../../common/services/create-token');
+const verifyUserService = require('../../common/services/verificationApi');
+const tokenApi = require('../../common/services/tokenApi');
+const sendTokenService = require('../../common/services/send-token');
+
+const controller = require('../../app/verify/get.controller');
+
+describe('Verify Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    // Example request and response objects with appropriate spies
+    req = {
+      session: {},
+      query: {
+        query: 'abcd1234',
+      },
+    };
+    res = {
+      render: sinon.spy(),
+    };
+
+    // Will need to move or make as accessible fields should the expired
+    // token testing be more robust
+    sinon.stub(tokenApi, 'updateToken');
+    sinon.stub(sendTokenService, 'send');
+    sinon.stub(i18n, '__').callsFake((key) => {
+      switch (key) {
+        case 'verify_user_account_success':
+          return 'Example Success Message';
+        case 'verify_user_account_token_invalid':
+          return 'Example Invalid Token Message';
+        case 'verify_user_account_token_expired':
+          return 'Example Token Expired Message';
+        default:
+          return 'Unexpected Key';
+      }
+    });
+    config.NOTIFY_TOKEN_SECRET = 'example_secret';
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // TODO: Back end can return 'Account already verified'
+
+  // TODO: There is no error message returned when the API has an issue
+  // so should probably add one
+  it('should render the page when verification api rejects', async () => {
+    // Use this test to check the generateHash method
+    // i.e. let's ensure crypto is defined!
+    const tokenSpy = sinon.spy(tokenService, 'generateHash');
+    sinon.stub(verifyUserService, 'verifyUser').rejects('verificationApi.verifyUser Example Reject');
+    await controller(req, res);
+
+    expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
+    expect(verifyUserService.verifyUser).to.have.been.calledWith(tokenSpy.returnValues[0]);
+    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index');
+  });
+
+  it('should return with a success message', async () => {
+    // Happy path from the API is 'Token verified'
+    const apiResponse = {
+      message: 'Token verified',
+    };
+    sinon.stub(tokenService, 'generateHash').returns('hashedTokenExample');
+    sinon.stub(verifyUserService, 'verifyUser').resolves(JSON.stringify(apiResponse));
+
+    await controller(req, res);
+
+    expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
+    expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
+    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Success Message' });
+  });
+
+  it('should return with a token invalid message', async () => {
+    const apiResponse = {
+      message: 'Token is invalid',
+    };
+    sinon.stub(tokenService, 'generateHash').returns('hashedTokenExample');
+    sinon.stub(verifyUserService, 'verifyUser').resolves(JSON.stringify(apiResponse));
+
+    await controller(req, res);
+
+    expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
+    expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_token_invalid');
+    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
+  });
+
+  it('should return with a token invalid message', async () => {
+    const apiResponse = {
+      message: 'Token is invalid',
+    };
+    sinon.stub(tokenService, 'generateHash').returns('hashedTokenExample');
+    sinon.stub(verifyUserService, 'verifyUser').resolves(JSON.stringify(apiResponse));
+
+    await controller(req, res);
+
+    expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
+    expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_token_invalid');
+    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
+  });
+
+  // TODO: The block has two asynchronous events with no specific rejection
+  // handling. They essentially both need to succeed really so this functionality
+  // will need revisiting.
+  it('should resend token and return with a token expired message', async () => {
+    const apiResponse = {
+      userId: '1234',
+      firstName: 'Some First Name',
+      email: 'someone@somewhere.com',
+      message: 'Token has expired',
+    };
+    const generateHashStub = sinon.stub(tokenService, 'generateHash').onCall(0).returns('hashedTokenExample');
+    generateHashStub.onCall(1).returns('secondHashedTokenExample');
+    sinon.stub(verifyUserService, 'verifyUser').resolves(JSON.stringify(apiResponse));
+
+    await controller(req, res);
+
+    expect(generateHashStub).to.have.been.calledWith('abcd1234');
+    expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
+    // Cannot easily mock the nanoid library so easier to stub the generateHash
+    // function and retrieve the argument going into it
+    const parameter = generateHashStub.getCall(1).args[0];
+    expect(generateHashStub).to.have.been.calledWith(parameter);
+    expect(tokenApi.updateToken).to.have.been.calledWith('secondHashedTokenExample', '1234');
+    expect(sendTokenService.send).to.have.been.calledWith('Some First Name', 'someone@somewhere.com', parameter);
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_token_expired');
+    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Token Expired Message' });
+  });
+});

--- a/src/test/verify/mfa/get.controller.test.js
+++ b/src/test/verify/mfa/get.controller.test.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const tokenService = require('../../../common/services/create-token');
+const tokenApi = require('../../../common/services/tokenApi');
+const emailService = require('../../../common/services/sendEmail');
+const settings = require('../../../common/config/index');
+
+const controller = require('../../../app/verify/mfa/get.controller');
+
+describe('Verify MFA Get Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    req = {
+      session: {
+        u: {
+          e: 'example@somewhere.com',
+          vr: true,
+        },
+      },
+      query: {
+        resend: 'true',
+      },
+    };
+
+    res = {
+      render: sinon.spy(),
+    };
+
+    sinon.stub(tokenService, 'generateHash').returns('Token123');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should only render the page if resend flag not set', async () => {
+    const emptyReq = {
+      session: {},
+      query: {
+        resend: 'false',
+      },
+    };
+    sinon.stub(tokenApi, 'setMfaToken');
+    settings.MFA_TOKEN_LENGTH = 20;
+    const cookie = new CookieModel(emptyReq);
+    await controller(emptyReq, res);
+
+    expect(tokenApi.setMfaToken).to.not.have.been.called;
+    expect(res.render).to.have.been.calledWith('app/verify/mfa/index', { cookie, mfaTokenLength: 20 });
+  });
+
+  // TODO: Essentially, existing functionality just returns you to the page if you are
+  // unverified. In the future, this screen should not even be possible to enter if
+  // the user is unverified...
+  it('should create a token and send an email if verified user', async () => {
+    sinon.stub(tokenApi, 'setMfaToken').resolves();
+    sinon.stub(tokenService, 'genMfaToken').returns('123456');
+    sinon.stub(emailService, 'send');
+    settings.MFA_TOKEN_LENGTH = 20;
+    settings.NOTIFY_MFA_TEMPLATE_ID = 12345;
+    const cookie = new CookieModel(req);
+
+    await controller(req, res);
+
+    expect(tokenApi.setMfaToken).to.have.been.called;
+    expect(emailService.send).to.have.been.calledWith(12345, 'example@somewhere.com', { mfaToken: '123456' });
+    expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+      cookie, mfaTokenLength: 20, successHeader: 'We have resent your code', successMsg: 'Check your email',
+    });
+  });
+
+  it('should not send an email if verified user but token rejects', async () => {
+    sinon.stub(tokenApi, 'setMfaToken').rejects('Example Reject');
+    sinon.stub(tokenService, 'genMfaToken').returns('123456');
+    sinon.stub(emailService, 'send');
+    settings.MFA_TOKEN_LENGTH = 20;
+    settings.NOTIFY_MFA_TEMPLATE_ID = 12345;
+    const cookie = new CookieModel(req);
+
+    try {
+      await controller(req, res);
+    } catch (err) {
+      expect(tokenApi.setMfaToken).to.have.been.calledWith('example@somewhere.com', '123456', true);
+      expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+        cookie, mfaTokenLength: 20, errors: [{ message: 'There was a problem creating your code. Try again' }],
+      });
+    }
+  });
+
+  it('should render with a check your mail message if unverified', async () => {
+    const emptyReq = {
+      session: {
+        u: {
+          vr: false,
+        },
+      },
+      query: {
+        resend: 'true',
+      },
+    };
+    sinon.stub(tokenApi, 'setMfaToken');
+    settings.MFA_TOKEN_LENGTH = 20;
+    const cookie = new CookieModel(emptyReq);
+    await controller(emptyReq, res);
+
+    expect(tokenApi.setMfaToken).to.not.have.been.called;
+    expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+      cookie, mfaTokenLength: 20, successHeader: 'We have resent your code', successMsg: 'Check your email',
+    });
+  });
+});

--- a/src/test/verify/mfa/post.controller.test.js
+++ b/src/test/verify/mfa/post.controller.test.js
@@ -1,0 +1,215 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+
+const CookieModel = require('../../../common/models/Cookie.class');
+const tokenService = require('../../../common/services/create-token');
+const tokenApi = require('../../../common/services/tokenApi');
+const userApi = require('../../../common/services/userManageApi');
+const settings = require('../../../common/config/index');
+
+const controller = require('../../../app/verify/mfa/post.controller');
+
+describe('Verify MFA Post Controller', () => {
+  let req; let res;
+
+  beforeEach(() => {
+    chai.use(sinonChai);
+
+    req = {
+      session: {
+        u: {
+          e: 'example@somewhere.com',
+        },
+      },
+      body: {
+        'mfa-authentication-code': 123456,
+      },
+    };
+
+    res = {
+      render: sinon.spy(),
+      redirect: sinon.spy(),
+    };
+
+    sinon.stub(tokenService, 'generateHash').returns('Token123');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render page with message on validation error', async () => {
+    const emptyReq = {
+      session: {},
+      body: {
+        'mfa-authentication-code': '',
+      },
+    };
+    sinon.stub(tokenApi, 'validateMfaToken');
+    sinon.stub(tokenApi, 'updateMfaToken');
+    sinon.stub(userApi, 'getDetails');
+    settings.MFA_TOKEN_LENGTH = 20;
+    const cookie = new CookieModel(emptyReq);
+
+    try {
+      await controller(emptyReq, res);
+    } catch (err) {
+      expect(tokenApi.validateMfaToken).to.not.have.been.called;
+      expect(tokenApi.updateMfaToken).to.not.have.been.called;
+      expect(res.render).to.have.been.calledWithExactly('app/verify/mfa/index', {
+        cookie, mfaTokenLength: 20, errors: [{ identifier: 'mfa-authentication-code', value: '', message: 'Enter your code' }],
+      });
+    }
+  });
+
+  it('should render page with message when token api rejects', async () => {
+    sinon.stub(tokenApi, 'validateMfaToken').rejects('Example Reject');
+    sinon.stub(tokenApi, 'updateMfaToken');
+    sinon.stub(userApi, 'getDetails');
+    settings.MFA_TOKEN_LENGTH = 20;
+    const cookie = new CookieModel(req);
+
+    // Promise chain, so controller call is wrapped into its own method
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+      expect(tokenApi.updateMfaToken).to.not.have.been.called;
+      expect(res.render).to.not.have.been.called;
+    }).then(() => {
+      expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+      expect(tokenApi.updateMfaToken).to.not.have.been.called;
+      expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+        cookie, mfaTokenLength: 20, errors: [{ message: 'There was a problem verifying your token. Try again' }],
+      });
+    });
+  });
+
+  describe('token api resolves', () => {
+    // TODO: The service never resolves to false
+    it('should do nothing if not valid', async () => {
+      sinon.stub(tokenApi, 'validateMfaToken').resolves(false);
+      sinon.stub(tokenApi, 'updateMfaToken');
+      sinon.stub(userApi, 'getDetails');
+
+      await controller(req, res);
+      expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+      expect(tokenApi.updateMfaToken).to.not.have.been.called;
+      expect(res.render).to.not.have.been;
+    });
+
+    it('should return message if valid but token api update rejects', async () => {
+      sinon.stub(tokenApi, 'validateMfaToken').resolves(true);
+      sinon.stub(tokenApi, 'updateMfaToken').rejects('tokenApi.updateMfaToken Example Reject');
+      sinon.stub(userApi, 'getDetails');
+      settings.MFA_TOKEN_LENGTH = 20;
+      const cookie = new CookieModel(req);
+
+      // Promise chain, so controller call is wrapped into its own method
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then().then().then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+          cookie, mfaTokenLength: 20, errors: [{ message: 'There was a problem verifying your token. Try again' }],
+        });
+      });
+    });
+
+    it('should return message if valid token api resolves but user api rejects', async () => {
+      sinon.stub(tokenApi, 'validateMfaToken').resolves(true);
+      sinon.stub(tokenApi, 'updateMfaToken').resolves();
+      sinon.stub(userApi, 'getDetails').rejects('userApi.getDetails Example Reject');
+      settings.MFA_TOKEN_LENGTH = 20;
+      const cookie = new CookieModel(req);
+
+      // Promise chain, so controller call is wrapped into its own method
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      // Lots of redundancy but is there to illustrate the chained promises
+      // Mystery here is why the second and third block have the same
+      // assertions. It could be the nested catches perhaps in the code
+      callController().then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called;
+        expect(userApi.getDetails).to.not.have.been.called;
+        expect(res.render).to.not.have.been.called;
+      }).then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called;
+        expect(userApi.getDetails).to.have.been.called;
+        expect(res.render).to.not.have.been.called;
+      }).then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called;
+        expect(userApi.getDetails).to.have.been.called;
+        expect(res.render).to.not.have.been.called;
+      })
+        .then(() => {
+          expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+          expect(tokenApi.updateMfaToken).to.have.been.called;
+          expect(userApi.getDetails).to.have.been.called;
+          expect(res.render).to.have.been.calledWith('app/verify/mfa/index', {
+            cookie, mfaTokenLength: 20, errors: [{ message: 'There was a problem verifying your token. Try again' }],
+          });
+        });
+    });
+
+    it('should successfully login', async () => {
+      sinon.stub(tokenApi, 'validateMfaToken').resolves(true);
+      sinon.stub(tokenApi, 'updateMfaToken').resolves();
+      sinon.stub(userApi, 'getDetails').resolves(JSON.stringify({
+        firstName: 'Darth',
+        lastName: 'Vader',
+        userId: 'dvader@empire.net',
+        role: {
+          name: 'INDIVIDUAL',
+        },
+        state: 'verified',
+        organisation: null,
+      }));
+      settings.MFA_TOKEN_LENGTH = 20;
+
+      // Promise chain, so controller call is wrapped into its own method
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      // Lots of redundancy but is there to illustrate the chained promises
+      // Mystery here is why the second and third block have the same
+      // assertions. It could be the catches perhaps in the code
+      callController().then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called.calledWith('example@somewhere.com', 123456);
+        expect(userApi.getDetails).to.not.have.been.called;
+        expect(res.redirect).to.not.have.been.called;
+      }).then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called.calledWith('example@somewhere.com', 123456);
+        expect(userApi.getDetails).to.have.been.called.calledWith('example@somewhere.com');
+        expect(res.redirect).to.not.have.been.called;
+      }).then(() => {
+        expect(tokenApi.validateMfaToken).to.have.been.calledWith('example@somewhere.com', 123456);
+        expect(tokenApi.updateMfaToken).to.have.been.called.calledWith('example@somewhere.com', 123456);
+        expect(userApi.getDetails).to.have.been.calledWith('example@somewhere.com');
+        expect(res.redirect).to.have.been.calledWith('/home');
+      });
+    });
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+});


### PR DESCRIPTION
**What changes does this PR bring?**
EGAR-588 (and also CDR-4) to have country be an autocomplete field. User can type in a code or the country name, and appears to be responsive enough to not need further tweaks. Leverages the GOV UK's accessible autocomplete component, so hopefully, that implies accessibility is handled out of the box.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [x] Have you added enough relevant unit tests for your change?
- [x] Have you added enough relevant E2E tests for your change?
- [x] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
