### PR TITLE
Externalise latitude and longitude labels to en.json

### DIFF
--- a/src/app/garfile/arrival/index.njk
+++ b/src/app/garfile/arrival/index.njk
@@ -147,10 +147,10 @@
          <!-- Start arrival coords -->
         <div class="govuk-form-group {{ m.form_group_class('arrivalLat', errors) }}">
           <label class="govuk-label" for="arrivalLat">
-            Latitude
+            {{__('field_latitude')}}
           </label>
           <span id="arrivalLattitude-hint" class="govuk-hint">
-              For example 51.4700
+            {{__('field_latitude_hint')}}
           </span>
 
           {{ m.error_message('arrivalLat', errors) }}
@@ -159,10 +159,10 @@
 
         <div class="govuk-form-group {{ m.form_group_class('arrivalLong', errors) }}">
           <label class="govuk-label" for="arrivalLong">
-            Longitude
+            {{__('field_longitude')}}
           </label>
           <span id="arrivalLongitude-hint" class="govuk-hint">
-                For example -0.4542
+            {{__('field_longitude_hint')}}
           </span>
           {{ m.error_message('arrivalLong', errors) }}
           <input class="govuk-input" id="arrivalLong" name="arrivalLong" autocomplete="off" type="text" value="{{cookie.getGarArrivalVoyage().arrivalLong}}"/>

--- a/src/app/garfile/departure/index.njk
+++ b/src/app/garfile/departure/index.njk
@@ -150,10 +150,10 @@
          <!-- Start departure coords -->
         <div class="govuk-form-group {{ m.form_group_class('departureLat', errors) }}">
           <label class="govuk-label" for="departureLat">
-            Latitude
+            {{__('field_latitude')}}
           </label>
           <span id="departureLattitude-hint" class="govuk-hint">
-              For example 51.4700
+            {{__('field_latitude_hint')}}
           </span>
 
           {{ m.error_message('departureLat', errors) }}
@@ -163,10 +163,10 @@
 
         <div class="govuk-form-group {{ m.form_group_class('departureLong', errors) }}">
           <label class="govuk-label" for="departureLong">
-            Longitude
+            {{__('field_longitude')}}
           </label>
           <span id="departureLongitude-hint" class="govuk-hint">
-              For example -0.4542
+            {{__('field_longitude_hint')}}
           </span>
           {{ m.error_message('departureLong', errors) }}
           <input class="govuk-input" id="departureLong" name="departureLong" autocomplete="off" type="text"

--- a/src/common/templates/check-your-answers.njk
+++ b/src/common/templates/check-your-answers.njk
@@ -49,8 +49,8 @@
           Departure port coordinates
         </dt>
         <dd class="app-check-your-answers__answer">
-          Lat: {{garfile.departureLat}} <br>
-          Long: {{garfile.departureLong}}
+          {{__('field_latitude')}}: {{garfile.departureLat}} <br>
+          {{__('field_longitude')}}: {{garfile.departureLong}}
         </dd>
         <dd class="app-check-your-answers__change">
         </dd>
@@ -108,8 +108,8 @@
           Arrival port coordinates
         </dt>
         <dd class="app-check-your-answers__answer">
-          Lat: {{garfile.arrivalLat}} <br>
-          Long: {{garfile.arrivalLong}}
+          {{__('field_latitude')}}: {{garfile.arrivalLat}} <br>
+          {{__('field_longitude')}}: {{garfile.arrivalLong}}
         </dd>
         <dd class="app-check-your-answers__change">
         </dd>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,10 @@
     "field_departure_time": "Departure time (UTC)",
     "field_departure_time_hint": "For example 17 30",
     "field_departure_port": "Departure port",
+    "field_longitude": "Longitude",
+    "field_longitude_hint": "For example -0.4542",
+    "field_latitude": "Latitude",
+    "field_latitude_hint": "For example 51.4700",
 
     "title_edit_person": "Edit Person Details",
     "heading_edit_person": "Edit a person",


### PR DESCRIPTION
**What changes does this PR bring?**
Field labels should not use abbreviations.
- change "Lat." to "Latitude" and "Long." to "Longitude"

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [x] Have you added enough relevant unit tests for your change?
- [x] Have you added enough relevant E2E tests for your change?
- [x] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
