### PR TITLE
SGAR-746 ZZZZ ports

### DIFF
--- a/src/app/garfile/arrival/index.njk
+++ b/src/app/garfile/arrival/index.njk
@@ -149,7 +149,7 @@
           <label class="govuk-label" for="arrivalLat">
             {{__('field_latitude')}}
           </label>
-          <span id="arrivalLattitude-hint" class="govuk-hint">
+          <span id="arrivalLatitude-hint" class="govuk-hint">
             {{__('field_latitude_hint')}}
           </span>
 

--- a/src/app/garfile/arrival/post.controller.js
+++ b/src/app/garfile/arrival/post.controller.js
@@ -73,7 +73,7 @@ const buildValidations = (voyage) => {
   const arrivalPortZZZZ = [new ValidationRule(validator.validatePortCoords, 'arrivalPort', arrivePortObj, portMsg)];
 
   // Define latitude validations
-  const arrivalLatValidation = [new ValidationRule(validator.lattitude, 'arrivalLat', voyage.arrivalLat, latitudeMsg)];
+  const arrivalLatValidation = [new ValidationRule(validator.latitude, 'arrivalLat', voyage.arrivalLat, latitudeMsg)];
 
   // Define latitude validations
   const arrivalLongValidation = [new ValidationRule(validator.longitude, 'arrivalLong', voyage.arrivalLong, longitudeMsg)];

--- a/src/app/garfile/craft/index.njk
+++ b/src/app/garfile/craft/index.njk
@@ -32,11 +32,7 @@
 				<p class="govuk-body-l">Add the details of an aircraft you have previously added</p>
   </div>
   <div class="govuk-grid-column-full">
-{% if cookie.getSavedCraft().items | length %}
-<table class="table-clickable govuk-table">
-{% else %}
 <table class="govuk-table">
-{% endif %}
   <thead class="govuk-table__head">
 	<tr class="govuk-table__row">
 	  <th class="govuk-table__header" style="width: 5%;">&nbsp;</th>
@@ -51,16 +47,16 @@
       <tr class="govuk-table__row">
         <div class="govuk-radios">
         <td class="govuk-table__cell">
-        <div class="govuk-radios govuk-radios--inline">
+          <div class="govuk-radios govuk-radios--inline">
             <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="aircraft" name="addCraft" type="radio" value="{{craft.craftId}}">
-                <label class="govuk-label govuk-radios__label" for="aircraft"></label>
+              <input class="govuk-radios__input" id="aircraft_{{ loop.index }}" name="addCraft" type="radio" value="{{craft.craftId}}">
+              <label class="govuk-label govuk-radios__label" for="aircraft_{{ loop.index }}"></label>
             </div>
-        </div>
+          </div>
         </td>
-      <td class="govuk-table__cell">{{ craft.registration }}</td>
-      <td class="govuk-table__cell">{{ craft.craftType }}</td>
-      <td class="govuk-table__cell">{{ craft.craftBase }}</td>
+        <td class="govuk-table__cell">{{ craft.registration }}</td>
+        <td class="govuk-table__cell">{{ craft.craftType }}</td>
+        <td class="govuk-table__cell">{{ craft.craftBase }}</td>
       </tr>
     {% endfor %}
   {% else %}
@@ -77,7 +73,7 @@
 <div class="govuk-grid-column-two-thirds">
   {% if cookie.getSavedCraft().items | length %}
     <div class="govuk-form-group">
-      <input id="saveCraft" class="govuk-button" type="submit" value="Add to GAR"
+      <input id="saveCraft" class="govuk-button" type="submit" name="buttonClicked" value="Add to GAR"
       onclick="sendAnalytics(event, 'Add craft to GAR - submit', 'click')">
     </div>
   {% endif %}

--- a/src/app/garfile/craft/post.controller.js
+++ b/src/app/garfile/craft/post.controller.js
@@ -9,6 +9,7 @@ const pagination = require('../../../common/utils/pagination');
 module.exports = (req, res) => {
   logger.debug('In garfile / craft post controller');
 
+  const { buttonClicked } = req.body;
   const cookie = new CookieModel(req);
   const userId = cookie.getUserDbId();
 
@@ -18,13 +19,13 @@ module.exports = (req, res) => {
     return;
   }
 
-  if (req.body.addCraft) {
+  if (req.body.addCraft && buttonClicked === 'Add to GAR') {
     craftApi.getDetails(userId, req.body.addCraft)
       .then((apiResponse) => {
         const craft = JSON.parse(apiResponse);
         // Overwrite GAR craft info if a user has clicked on a craft
         cookie.setGarCraft(craft.registration, craft.craftType, craft.craftBase);
-        res.redirect('/garfile/craft');
+        req.session.save(() => res.redirect('/garfile/craft'));
       })
       .catch((err) => {
         logger.error(err);
@@ -36,8 +37,6 @@ module.exports = (req, res) => {
       craftType: req.body.craftType,
       craftBase: req.body.craftBase,
     };
-
-    const { buttonClicked } = req.body;
 
     cookie.setGarCraft(craftObj.registration, craftObj.craftType, craftObj.craftBase);
 

--- a/src/app/garfile/departure/get.controller.js
+++ b/src/app/garfile/departure/get.controller.js
@@ -8,6 +8,9 @@ module.exports = (req, res) => {
 
   garApi.get(cookie.getGarId()).then((apiResponse) => {
     const parsedResponse = JSON.parse(apiResponse);
+    if (parsedResponse.departurePort === 'ZZZZ') {
+      parsedResponse.departurePort = 'YYYY';
+    }
     cookie.setGarDepartureVoyage(parsedResponse);
 
     return res.render('app/garfile/departure/index', { cookie });

--- a/src/app/garfile/departure/index.njk
+++ b/src/app/garfile/departure/index.njk
@@ -116,7 +116,7 @@
             Departure port
           </label>
           <span id="departurePort-hint" class="govuk-hint">
-            Provide the IATA or ICAO code for the port. If the port does not have a code, enter 'ZZZZ'. <br>
+            Provide the IATA or ICAO code for the port. If the port does not have a code, enter 'YYYY'. <br>
             The departure port must be different to the arrival port.
           </span>
           {{ m.error_message('departurePort', errors) }}
@@ -152,7 +152,7 @@
           <label class="govuk-label" for="departureLat">
             {{__('field_latitude')}}
           </label>
-          <span id="departureLattitude-hint" class="govuk-hint">
+          <span id="departureLatitude-hint" class="govuk-hint">
             {{__('field_latitude_hint')}}
           </span>
 

--- a/src/app/garfile/departure/post.controller.js
+++ b/src/app/garfile/departure/post.controller.js
@@ -7,7 +7,7 @@ const ValidationRule = require('../../../common/models/ValidationRule.class');
 
 const createValidationChains = (voyage) => {
   // Define port / date validation msgs
-  const portMsg = 'As you have entered an arrival port code of "ZZZZ", you must provide longitude and latitude coordinates for the location';
+  const portMsg = 'As you have entered a departure port code of "YYYY", you must provide longitude and latitude coordinates for the location';
   const portCodeMsg = 'The departure airport code must be a minimum of 3 letters and a maximum of 4 letters';
   const futureDateMsg = 'Departure date must be today or in the future';
   const realDateMsg = 'Enter a real departure date';
@@ -40,7 +40,7 @@ const createValidationChains = (voyage) => {
   const departurePortZZZZ = [new ValidationRule(validator.validatePortCoords, 'departurePort', departPortObj, portMsg)];
 
   // Define latitude validations
-  const departureLatValidation = [new ValidationRule(validator.lattitude, 'departureLat', voyage.departureLat, latitudeMsg)];
+  const departureLatValidation = [new ValidationRule(validator.latitude, 'departureLat', voyage.departureLat, latitudeMsg)];
 
   // Define latitude validations
   const departureLongValidation = [new ValidationRule(validator.longitude, 'departureLong', voyage.departureLong, longitudeMsg)];
@@ -52,7 +52,7 @@ const createValidationChains = (voyage) => {
   ];
 
   // Check if port code is ZZZZ then need to validate lat/long and display req zzzz message
-  if (departPortObj.portCode.toUpperCase() === 'ZZZZ') {
+  if (departPortObj.portCode.toUpperCase() === 'YYYY') {
     validations.push(
       departurePortZZZZ,
       departureLatValidation,
@@ -110,6 +110,9 @@ module.exports = async (req, res) => {
   const voyage = req.body;
   voyage.departurePort = _.toUpper(voyage.departurePort);
   delete voyage.buttonClicked;
+  if (voyage.departurePort === 'ZZZZ') {
+    voyage.departurePort = 'YYYY';
+  }
   cookie.setGarDepartureVoyage(voyage);
 
   const validations = createValidationChains(voyage);

--- a/src/app/garfile/manifest/index.njk
+++ b/src/app/garfile/manifest/index.njk
@@ -83,7 +83,7 @@
         </table>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <button id="addToManifest" type="submit" name="addToManifest"  class="govuk-button">Add to GAR</button>
+    <button id="addToManifest" type="submit" name="buttonClicked" value="Add to GAR" class="govuk-button">Add to GAR</button>
   </div>
   <div class="govuk-grid-column-full">
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/src/app/garfile/manifest/post.controller.js
+++ b/src/app/garfile/manifest/post.controller.js
@@ -6,6 +6,8 @@ const manifestUtil = require('./bulkAdd');
 
 module.exports = (req, res) => {
   const cookie = new CookieModel(req);
+  const { buttonClicked } = req.body;
+
   logger.debug('In garfile / manifest post controller');
   if (req.body.editPersonId) {
     req.session.editPersonId = req.body.editPersonId;
@@ -13,7 +15,7 @@ module.exports = (req, res) => {
   } else if (req.body.deletePersonId) {
     req.session.deletePersonId = req.body.deletePersonId;
     req.session.save(() => res.redirect('/garfile/manifest/deleteperson'));
-  } else if (req.body.personId) {
+  } else if (req.body.personId && buttonClicked === 'Add to GAR') {
     logger.debug('Found people to add to manifest');
     manifestUtil.getDetailsByIds(req.body.personId, cookie.getUserDbId())
       .then((selectedPeople) => {

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -218,7 +218,7 @@ function validatePortCoords(portObj) {
   return true;
 }
 
-function lattitude(value) {
+function latitude(value) {
   const regex = /^-?([1-8]?[0-9]\.{1}\d{4}$|90\.{1}0{4}$)/;
   return regex.test(value);
 }
@@ -401,7 +401,7 @@ module.exports = {
   validFreeCirculation,
   validVisitReason,
   validGender,
-  lattitude,
+  latitude,
   longitude,
   validIntlPhone,
   notSameValues,

--- a/src/test/garfile/arrival/post.controller.test.js
+++ b/src/test/garfile/arrival/post.controller.test.js
@@ -106,8 +106,7 @@ describe('Arrival Post Controller', () => {
           expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
             cookie,
             errors: [
-              // SIC: lattitude instead of latitide
-              new ValidationRule(validator.lattitude, 'arrivalLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
+              new ValidationRule(validator.latitude, 'arrivalLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
               new ValidationRule(validator.longitude, 'arrivalLong', undefined, 'Value entered is incorrect. Enter longitude to 4 decimal places'),
             ],
           });
@@ -132,9 +131,8 @@ describe('Arrival Post Controller', () => {
       //     expect(res.render).to.have.been.calledWith('app/garfile/arrival/index', {
       //       cookie,
       //       errors: [
-      //         // SIC: lattitude instead of latitide
       // new ValidationRule(
-      //    validator.lattitude,
+      //    validator.latitude,
       //    'arrivalLat', undefined,
       //    'Value entered is incorrect. Enter latitude to 4 decimal places'),
       // new ValidationRule(

--- a/src/test/garfile/craft/post.controller.test.js
+++ b/src/test/garfile/craft/post.controller.test.js
@@ -68,6 +68,7 @@ describe('GAR Craft Post Controller', () => {
     let craftApiStub;
 
     beforeEach(() => {
+      req.body.buttonClicked = 'Add to GAR';
       req.body.addCraft = 'ExampleCraft';
       craftApiStub = sinon.stub(craftApi, 'getDetails');
     });
@@ -176,6 +177,26 @@ describe('GAR Craft Post Controller', () => {
     });
 
     it('should go to the manifest screen if save and continue is buttonClicked', () => {
+      req.body.buttonClicked = 'Save and continue';
+      cookie = new CookieModel(req);
+      garApiPatchStub.resolves(JSON.stringify({}));
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then().then(() => {
+        expect(garApiPatchStub).to.have.been.calledWith('GAR1-ID', 'Draft', {
+          registration: 'G-ABCD',
+          craftType: 'Gulfstream',
+          craftBase: 'LHR',
+        });
+        expect(res.redirect).to.have.been.calledWith('/garfile/manifest');
+      });
+    });
+
+    it('should go to the manifest screen if save and continue is buttonClicked even if addCraft is set', () => {
+      req.body.addCraft = 'ExampleCraft';
       req.body.buttonClicked = 'Save and continue';
       cookie = new CookieModel(req);
       garApiPatchStub.resolves(JSON.stringify({}));

--- a/src/test/garfile/departure/get.controller.test.js
+++ b/src/test/garfile/departure/get.controller.test.js
@@ -71,4 +71,28 @@ describe('Departure Get Controller', () => {
       expect(res.render).to.have.been.calledWith('app/garfile/departure/index', { cookie });
     });
   });
+
+  it('should set cookie values on response, changing if port is ZZZZ', async () => {
+    apiResponse = JSON.stringify({
+      departureDate: '2012-30-05',
+      departureTime: '15:00',
+      departurePort: 'ZZZZ',
+      departureLong: '12.4000',
+      departureLat: '-4.1234',
+    });
+    const cookie = new CookieModel(req);
+    cookie.setGarId('12345');
+    cookie.setGarDepartureVoyage(apiResponse);
+    cookie.session.gar.voyageDeparture.departurePort = 'YYYY';
+    sinon.stub(garApi, 'get').resolves(apiResponse);
+
+    const callController = async () => {
+      await controller(req, res);
+    };
+
+    callController().then(() => {
+      expect(garApi.get).to.have.been.calledWith('12345');
+      expect(res.render).to.have.been.calledWith('app/garfile/departure/index', { cookie });
+    });
+  });
 });

--- a/src/test/garfile/departure/post.controller.test.js
+++ b/src/test/garfile/departure/post.controller.test.js
@@ -93,8 +93,33 @@ describe('Departure Post Controller', () => {
         expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
           cookie,
           errors: [
-            // SIC: lattitude instead of latitide
-            new ValidationRule(validator.lattitude, 'departureLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
+            new ValidationRule(validator.latitude, 'departureLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
+            new ValidationRule(validator.longitude, 'departureLong', undefined, 'Value entered is incorrect. Enter longitude to 4 decimal places'),
+          ],
+        });
+      });
+    });
+
+    it('should fail if port is YYYY and no longitude or latitude', () => {
+      req.body.departurePort = 'YYYY';
+      delete req.body.departureLong;
+      delete req.body.departureLat;
+      const cookie = new CookieModel(req);
+
+      sinon.stub(garApi, 'get').resolves(apiResponse);
+      sinon.stub(garApi, 'patch');
+
+      const callController = async () => {
+        await controller(req, res);
+      };
+
+      callController().then(() => {
+        expect(garApi.get).to.have.been.calledWith('12345');
+        expect(garApi.patch).to.not.have.been.called;
+        expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
+          cookie,
+          errors: [
+            new ValidationRule(validator.latitude, 'departureLat', undefined, 'Value entered is incorrect. Enter latitude to 4 decimal places'),
             new ValidationRule(validator.longitude, 'departureLong', undefined, 'Value entered is incorrect. Enter longitude to 4 decimal places'),
           ],
         });
@@ -119,9 +144,8 @@ describe('Departure Post Controller', () => {
     //     expect(res.render).to.have.been.calledWith('app/garfile/departure/index', {
     //       cookie,
     //       errors: [
-    //         // SIC: lattitude instead of latitide
     // new ValidationRule(
-    //    validator.lattitude,
+    //    validator.latitude,
     //    'departureLat', undefined,
     //    'Value entered is incorrect. Enter latitude to 4 decimal places'),
     // new ValidationRule(

--- a/src/test/garfile/review/get.controller.test.js
+++ b/src/test/garfile/review/get.controller.test.js
@@ -120,7 +120,9 @@ describe('GAR Review Get Controller', () => {
         garsupportingdocs: {},
         showChangeLinks: true,
         errors: [
-          new ValidationRule(validator.isValidDepAndArrDate, 'voyageDates', { arrivalDate: undefined, arrivalTime: undefined, departureDate: undefined, departureTime: undefined }, 'Arrival time must be after departure time'),
+          new ValidationRule(validator.isValidDepAndArrDate, 'voyageDates', {
+            arrivalDate: undefined, arrivalTime: undefined, departureDate: undefined, departureTime: undefined,
+          }, 'Arrival time must be after departure time'),
           new ValidationRule(validator.notEmpty, 'registration', undefined, 'Aircraft registration must be completed'),
           new ValidationRule(validator.notEmpty, 'responsibleGivenName', undefined, 'Responsible person details must be completed'),
         ],

--- a/src/test/validators.test.js
+++ b/src/test/validators.test.js
@@ -285,22 +285,22 @@ describe('Validator', () => {
   });
 
   // Latitude tests
-  it('Should return true for a valid lattitude - 4 dp', () => {
-    expect(validator.lattitude('51.9576')).to.be.true;
-    expect(validator.lattitude('1.9576')).to.be.true;
-    expect(validator.lattitude('-51.9576')).to.be.true;
-    expect(validator.lattitude('90.0000')).to.be.true;
-    expect(validator.lattitude('-90.0000')).to.be.true;
+  it('Should return true for a valid latitude - 4 dp', () => {
+    expect(validator.latitude('51.9576')).to.be.true;
+    expect(validator.latitude('1.9576')).to.be.true;
+    expect(validator.latitude('-51.9576')).to.be.true;
+    expect(validator.latitude('90.0000')).to.be.true;
+    expect(validator.latitude('-90.0000')).to.be.true;
   });
 
-  it('Should return false for an invalid lattitude - 4 dp', () => {
-    expect(validator.lattitude('51.95377')).to.be.false;
-    expect(validator.lattitude('51.953')).to.be.false;
-    expect(validator.lattitude('51.95')).to.be.false;
-    expect(validator.lattitude('51.9')).to.be.false;
-    expect(validator.lattitude('51')).to.be.false;
-    expect(validator.lattitude('90.0001')).to.be.false;
-    expect(validator.lattitude('-90.0001')).to.be.false;
+  it('Should return false for an invalid latitude - 4 dp', () => {
+    expect(validator.latitude('51.95377')).to.be.false;
+    expect(validator.latitude('51.953')).to.be.false;
+    expect(validator.latitude('51.95')).to.be.false;
+    expect(validator.latitude('51.9')).to.be.false;
+    expect(validator.latitude('51')).to.be.false;
+    expect(validator.latitude('90.0001')).to.be.false;
+    expect(validator.latitude('-90.0001')).to.be.false;
   });
 
   // Longitude tests


### PR DESCRIPTION
**What changes does this PR bring?**
If an arrival or departure port is set to ZZZZ, it is expected that co-ordinates are entered. However, the application and possibly CBP as well will raise an error if the port codes are the same, despite in this case potentially being different co-ordinates.

This is an initial attempt to address is by referring to departure ports in this instance to 'YYYY', in the hopes that this should pass app validations and possibly CBP as well.

This pull request also folds in a fix for SGAR-765, which addresses an issue where the GAR aircraft and manifest pages do not behave as expected due to having more than one action button.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [x] Have you added enough relevant unit tests for your change?
- [x] Have you added enough relevant E2E tests for your change?
- [x] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
