### PR TITLE
Disable submit button after user clicks submit to prevent double clic…

### DIFF
--- a/src/app/user/login/index.njk
+++ b/src/app/user/login/index.njk
@@ -58,7 +58,7 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-		<form action="login" autocomplete="off" method="POST">
+        <form action="login" autocomplete="off" method="POST" onsubmit="submitButton.disabled=true; return true;">
 			<h1 class="govuk-heading-xl">{{ __('button_sign_in') }}</h1>
 			<div class="govuk-form-group {{ m.form_group_class('username', errors) }}">
 				<label class="govuk-label govuk-label--m" for="username">{{ __('field_username') }}</label>
@@ -67,7 +67,7 @@
 				<input class="govuk-input" id="username" name="username" type="text" aria-describedby="username-hint{{ ' username-error' if errors }}">
 			</div>
 
-			<button type="submit" class="govuk-button">
+            <button id="submitButton" type="submit" class="govuk-button" data-prevent-double-click="true">
 				{{ __('button_sign_in' )}}
 			</button>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,7 +33,7 @@
     "nav_back": "Back",
 
     "field_username": "Registered email address",
-    "field_username_hint": "Enter the email address you used when you created your account.",
+    "field_username_hint": "Enter the email address you used when you created your account. A new one-time authentication code will be sent to your email.",
     "button_sign_in": "Sign in",
     "create_account_caption": "Need to create an account?",
 


### PR DESCRIPTION
…k. Amended hint message as appropriate

**What changes does this PR bring?**
Fix for SGAR-1078. Disables submit button after user has pressed it. This is to avoid users accidentally double clicking sign in which triggered the sending of multiple MFA tokens. 

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ✅] Have you built the code locally and confirmed its working?
- [ ✅] Is the build confirmed to be passing on CI?
- [ ✅] Have you added enough relevant unit tests for your change?
- [ ✅] Have you added enough relevant E2E tests for your change?
- [ ✅] Have you updated any relevant documentation as part of this change?
- [ ✅] Has this change been tested against the Acceptance Criteria?
- [ ✅] Have you considered how this will be deployed in SIT/Staging/Production?
