### PR TITLE
DSUP-3699 type error data must be string or buffer

### DIFF
--- a/src/app/verify/get.controller.js
+++ b/src/app/verify/get.controller.js
@@ -17,8 +17,9 @@ module.exports = async (req, res) => {
   cookie.reset();
   cookie.initialise();
 
+  var token;
   try {
-    const token = req.query.query;
+    token = req.query.query;
     const hashedToken = tokenService.generateHash(token);
     const apiResponse = await verifyUserService.verifyUser(hashedToken);
     const parsedResponse = JSON.parse(apiResponse);
@@ -40,13 +41,16 @@ module.exports = async (req, res) => {
       );
       message = i18n.__('verify_user_account_token_expired');
     }
+
     if (parsedResponse.message === 'Token is invalid') {
       message = i18n.__('verify_user_account_token_invalid');
     }
+
     return res.render('app/verify/registeruser/index', { message });
+
   } catch (err) {
     logger.error('Error during user verification');
-    logger.error(err);
+    token == null ? logger.error('Could not determine user registration token from URL') : logger.error(err);
     return res.render('app/verify/registeruser/index');
   }
 };

--- a/src/app/verify/get.controller.js
+++ b/src/app/verify/get.controller.js
@@ -50,7 +50,14 @@ module.exports = async (req, res) => {
 
   } catch (err) {
     logger.error('Error during user verification');
-    token == null ? logger.error('Could not determine user registration token from URL') : logger.error(err);
+    if(token == null) {
+      message = i18n.__('verify_user_account_token_not_provided');
+      logger.info(message);
+      return res.render('app/verify/registeruser/index', { message });
+    } else {
+      logger.error(err);
+    }
+
     return res.render('app/verify/registeruser/index');
   }
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -226,6 +226,7 @@
     "verify_user_account_success": "Your account has been successfully verified. You can now log in and submit GAR files online. Click 'Sign in' to begin.",
     "verify_user_account_token_expired": "Your token has expired. We have created a new token for you. Please check your email and click the new link.",
     "verify_user_account_token_invalid": "This token is invalid, click the link provided in the email or contact support for additional help.",
+    "verify_user_account_token_not_provided": "Could not determine user registration token from URL, please check the link provided in the email",
     "verify_help_caption_1": "If you are having difficulties using this service, please ",
     "verify_help_caption_2": "contact us",
     "verify_help_caption_3": ".",

--- a/src/test/verify/get.controller.test.js
+++ b/src/test/verify/get.controller.test.js
@@ -44,6 +44,8 @@ describe('Verify Get Controller', () => {
           return 'Example Invalid Token Message';
         case 'verify_user_account_token_expired':
           return 'Example Token Expired Message';
+        case 'verify_user_account_token_not_provided':
+          return 'Example Token Not Provided Message';
         default:
           return 'Unexpected Key';
       }
@@ -69,6 +71,16 @@ describe('Verify Get Controller', () => {
     expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
     expect(verifyUserService.verifyUser).to.have.been.calledWith(tokenSpy.returnValues[0]);
     expect(res.render).to.have.been.calledWith('app/verify/registeruser/index');
+  });
+
+  it('should return an error message when no user registration token is provided in the verification url', async () => {
+
+    reqNoQuery = {
+      session: {},
+    };
+
+    await controller(reqNoQuery, res);
+    expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Token Not Provided Message'});
   });
 
   it('should return with a success message', async () => {

--- a/src/test/verify/get.controller.test.js
+++ b/src/test/verify/get.controller.test.js
@@ -80,6 +80,7 @@ describe('Verify Get Controller', () => {
     };
 
     await controller(reqNoQuery, res);
+    expect(i18n.__).to.have.been.calledWith('verify_user_account_token_not_provided');
     expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Token Not Provided Message'});
   });
 
@@ -96,7 +97,7 @@ describe('Verify Get Controller', () => {
     expect(tokenService.generateHash).to.have.been.calledWith('abcd1234');
     expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
     expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
-    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Success Message' });
+    expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Success Message' });
   });
 
   it('should return with a token invalid message', async () => {
@@ -112,7 +113,7 @@ describe('Verify Get Controller', () => {
     expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
     expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
     expect(i18n.__).to.have.been.calledWith('verify_user_account_token_invalid');
-    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
+    expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
   });
 
   it('should return with a token invalid message', async () => {
@@ -128,7 +129,7 @@ describe('Verify Get Controller', () => {
     expect(verifyUserService.verifyUser).to.have.been.calledWith('hashedTokenExample');
     expect(i18n.__).to.have.been.calledWith('verify_user_account_success');
     expect(i18n.__).to.have.been.calledWith('verify_user_account_token_invalid');
-    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
+    expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Invalid Token Message' });
   });
 
   // TODO: The block has two asynchronous events with no specific rejection
@@ -157,6 +158,6 @@ describe('Verify Get Controller', () => {
     expect(tokenApi.updateToken).to.have.been.calledWith('secondHashedTokenExample', '1234');
     expect(sendTokenService.send).to.have.been.calledWith('Some First Name', 'someone@somewhere.com', parameter);
     expect(i18n.__).to.have.been.calledWith('verify_user_account_token_expired');
-    expect(res.render).to.have.been.calledWith('app/verify/registeruser/index', { message: 'Example Token Expired Message' });
+    expect(res.render).to.have.been.calledWithExactly('app/verify/registeruser/index', { message: 'Example Token Expired Message' });
   });
 });


### PR DESCRIPTION
**What changes does this PR bring?**
This PR fixes an issue when the user verification link does not have a query/token provided in the URL which resulted in 'typeError- data must be string or buffer'. Now it handles the exception and displays a useful error message to the user.  

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [✅] Have you built the code locally and confirmed its working?
- [✅] Is the build confirmed to be passing on CI?
- [✅ ] Have you added enough relevant unit tests for your change?
- [✅] Have you added enough relevant E2E tests for your change?
- [✅ ] Have you updated any relevant documentation as part of this change?
- [✅ ] Has this change been tested against the Acceptance Criteria?
- [✅ ] Have you considered how this will be deployed in SIT/Staging/Production?
