### PR TITLE
Sgar 1095/autotab on all date input fields

### DIFF
--- a/src/app/garfile/arrival/index.njk
+++ b/src/app/garfile/arrival/index.njk
@@ -46,7 +46,7 @@
                     <span class="govuk-visually-hidden">{{__('field_arrival_hint')}}</span>{{__('field_day')}}
                   </label>
                   <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="arrivalDay"
-                    name="arrivalDay" type="number" pattern="[0-9]*" min="1" max="31"
+                    name="arrivalDay"  type="text" maxLength=2 onKeyup="value = sanitiseValue(this.value, 'day');autoTab(arrivalDay, 'day', arrivalMonth);"
                     value="{{cookie.dateSlice('day', cookie.getGarArrivalVoyage().arrivalDate)}}"
                     {{ 'aria-describedby=arrivalDate-error' if errors | containsError('arrivalDate') }}>
                 </div>
@@ -59,7 +59,7 @@
                   </label>
                   <span id="arrival-month-hint" class="govuk-visually-hidden">{{__('field_month_hint')}}</span>
                   <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="arrivalMonth"
-                    name="arrivalMonth" type="number" pattern="[0-9]*" min="1" max="12"
+                    name="arrivalMonth" type="text" maxLength=2 onKeyup="value = sanitiseValue(this.value, 'month');autoTab(arrivalMonth, 'month', arrivalYear);" 
                     value="{{cookie.dateSlice('month', cookie.getGarArrivalVoyage().arrivalDate)}}"
                     aria-describedby="{{ 'arrivalDate-error ' if errors | containsError('arrivalDate') }}arrival-month-hint">
                   </div>
@@ -71,7 +71,7 @@
                     <span class="govuk-visually-hidden">{{__('field_arrival_hint')}}</span>{{__('field_year')}}
                   </label>
                   <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="arrivalYear"
-                    name="arrivalYear" type="number" pattern="[0-9]*" min="1900" max="2200"
+                    name="arrivalYear" type="text" maxLength=4  onKeyup="value = sanitiseValue(this.value, 'year');"
                     value="{{cookie.dateSlice('year', cookie.getGarArrivalVoyage().arrivalDate)}}"
                     {{ 'aria-describedby=arrivalDate-error' if errors | containsError('arrivalDate') }}>
                 </div>
@@ -98,7 +98,7 @@
                     <span class="govuk-visually-hidden">{{__('field_arrival_hint')}}</span>{{__('field_hour')}}
                   </label>
                   <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="arrivalHour"
-                    name="arrivalHour" type="number" pattern="[0-9]*" min="0" max="23"
+                    name="arrivalHour" type="text" maxLength=2 onKeyup="value = sanitiseValue(this.value, 'hour');"
                     value="{{cookie.timeSlice('hour', cookie.getGarArrivalVoyage().arrivalTime)}}"
                     {{ 'aria-describedby=arrivalTime-error' if errors | containsError('arrivalTime') }}>
                 </div>
@@ -110,7 +110,7 @@
                     <span class="govuk-visually-hidden">{{__('field_arrival_hint')}}</span>{{__('field_minute')}}
                   </label>
                   <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="arrivalMinute"
-                    name="arrivalMinute" type="number" pattern="[0-9]*" min="0" max="59"
+                    name="arrivalMinute" type="text" maxLength=2  onKeyup="value = sanitiseValue(this.value, 'minute');"
                     value="{{cookie.timeSlice('minute', cookie.getGarArrivalVoyage().arrivalTime)}}"
                     {{ 'aria-describedby=arrivalTime-error' if errors | containsError('arrivalTime') }}>
                 </div>
@@ -189,6 +189,7 @@
     </div>
   </div>
   <script type="text/javascript" src="/javascripts/accessible-autocomplete.min.js"></script>
+  <script type="text/javascript" src="/utils/validator.js"></script>
   <script type="text/javascript">
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: document.querySelector('#arrivalPort'),

--- a/src/common/templates/includes/person-details.njk
+++ b/src/common/templates/includes/person-details.njk
@@ -132,22 +132,22 @@
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="expiryDay">{{ __('field_date_day') }}</label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiryDay" name="expiryDay" type="number" pattern="[0-9]*"
-            min="01" max="31" value="{{ cookie.dateSlice('day', person.documentExpiryDate) or req.body['expiryDay'] }}">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiryDay" name="expiryDay" type="text" maxLength=2
+            value="{{ cookie.dateSlice('day', person.documentExpiryDate) or req.body['expiryDay'] }}" onKeyup="value = sanitiseValue(this.value, 'day');autoTab(expiryDay, 'day', expiryMonth);">
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="expiryMonth">{{ __('field_date_month') }}</label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiryMonth" name="expiryMonth" type="number" pattern="[0-9]*"
-            min="01" max="12" value="{{ cookie.dateSlice('month', person.documentExpiryDate) or req.body['expiryMonth'] }}">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="expiryMonth" name="expiryMonth" type="text" maxLength=2
+            value="{{ cookie.dateSlice('month', person.documentExpiryDate) or req.body['expiryMonth'] }}" onKeyup="value = sanitiseValue(this.value, 'month');autoTab(expiryMonth, 'month', expiryYear);">
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="expiryYear">{{ __('field_date_year') }}</label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiryYear" name="expiryYear" type="number" pattern="[0-9]*"
-            min="1900" max="2200" value="{{ cookie.dateSlice('year', person.documentExpiryDate) or req.body['expiryYear'] }}">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="expiryYear" name="expiryYear" type="text" maxLength=4
+            value="{{ cookie.dateSlice('year', person.documentExpiryDate) or req.body['expiryYear'] }}" onKeyup="value = sanitiseValue(this.value, 'year');">
           </div>
         </div>
       </div>

--- a/src/common/templates/includes/person-details.njk
+++ b/src/common/templates/includes/person-details.njk
@@ -46,22 +46,22 @@
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dobDay">{{ __('field_date_day') }}</label>
-            <input id="dobDay" name="dobDay" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" pattern="[0-9]*"
-              min="01" max="31" value="{{cookie.dateSlice('day', person.dateOfBirth) or req.body['dobDay']}}">
+            <input id="dobDay" name="dobDay" class="govuk-input govuk-date-input__input govuk-input--width-2" type="text" maxLength=2
+             value="{{cookie.dateSlice('day', person.dateOfBirth) or req.body['dobDay']}}" onKeyup="value = sanitiseValue(this.value, 'day');autoTab(dobDay, 'day', dobMonth);">
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label" for="dobMonth">{{ __('field_date_month') }}</label>
-            <input id="dobMonth" name="dobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" pattern="[0-9]*"
-            min="01" max="12" value="{{cookie.dateSlice('month', person.dateOfBirth) or req.body['dobMonth']}}">
+            <input id="dobMonth" name="dobMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="text" maxLength=2
+            value="{{cookie.dateSlice('month', person.dateOfBirth) or req.body['dobMonth']}}" onKeyup="value = sanitiseValue(this.value, 'month');autoTab(dobMonth, 'month', dobYear);">
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label" for="dobYear">{{ __('field_date_year') }}</label>
-            <input id="dobYear" name="dobYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number" pattern="[0-9]*"
-            min="1900" max="2200" value="{{cookie.dateSlice('year', person.dateOfBirth) or req.body['dobYear']}}">
+            <input id="dobYear" name="dobYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="text" maxLength=4
+            value="{{cookie.dateSlice('year', person.dateOfBirth) or req.body['dobYear']}}" onKeyup="value = sanitiseValue(this.value, 'year');">
           </div>
         </div>
       </div>
@@ -181,6 +181,7 @@
   </div>
 
 <script type="text/javascript" src="/javascripts/accessible-autocomplete.min.js"></script>
+<script type="text/javascript" src="/utils/validator.js"></script>
 <script type="text/javascript">
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#nationality')


### PR DESCRIPTION
**What changes does this PR bring?**

added autotab to arrival, person manifest, when you add/edit person's date of birth and passport expiry date

the  pull request needs to go in before this. https://github.com/UKHomeOffice/egar-public-site-ui/pull/159


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
