### PR TITLE
added text for gars are listed in order

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -84,7 +84,7 @@
     "create_gar_caption_2": ".",
     "button_start_now": "Start now",
     "heading_manage_gars": "Manage GARs",
-    "manage_gars_caption": "You can view, edit, cancel or delete GARs depending on the status of the GAR. You cannot edit a GAR once it has been submitted.",
+    "manage_gars_caption": "You can view, edit, cancel or delete GARs depending on the status of the GAR. You cannot edit a GAR once it has been submitted. (Gars list is in order by departure date)",
     "tab_gar_draft": "Draft (%s)",
     "gar_draft_no_records": "There are no draft GARs",
     "tab_gar_submitted": "Submitted (%s)",


### PR DESCRIPTION
**What changes does this PR bring?**

Gars are now ordered by departure date when loaded. the pull requests adds the text on the main screen. 

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
