### PR TITLE
DSUP-545 update maintenance page

### DIFF
--- a/kube/public-site-deployment.yml
+++ b/kube/public-site-deployment.yml
@@ -265,6 +265,21 @@ spec:
                 secretKeyRef:
                   name: environment
                   key: USER_SURNAME_CHARACTER_COUNT
+            - name: IS_PLANNED_MAINTENANCE
+              valueFrom:
+                secretKeyRef:
+                  name: environment
+                  key: IS_PLANNED_MAINTENANCE
+            - name: MAINTENANCE_START_DATETIME
+              valueFrom:
+                secretKeyRef:
+                  name: environment
+                  key: MAINTENANCE_START_DATETIME
+            - name: MAINTENANCE_END_DATETIME
+              valueFrom:
+                secretKeyRef:
+                  name: environment
+                  key: MAINTENANCE_END_DATETIME
           ports:
             - name: public-site-prt
               containerPort: 3000

--- a/src/app/unavailable/get.controller.js
+++ b/src/app/unavailable/get.controller.js
@@ -1,5 +1,12 @@
 const navUtil = require('../../common/utils/nav');
+const availability = require('../../common/config/availability')
 
-module.exports = (req, res) => {
-  navUtil.simpleGetRender(req, res, 'app/unavailable/index');
-};
+if (availability.ENABLE_UNAVAILABLE_PAGE.toLowerCase() === 'false') {
+  module.exports = (req, res) => {
+    res.redirect('/welcome/index');
+  };
+} else {
+  module.exports = (req, res) => {
+    navUtil.simpleGetRender(req, res, 'app/unavailable/index');
+  };
+}

--- a/src/app/unavailable/index.njk
+++ b/src/app/unavailable/index.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block header %}
-{% include "header-user.njk" %}
+{% include "header-pre-user.njk" %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -18,7 +18,6 @@
 
 {% block content %}
 
-
   {% import "common/templates/includes/macros.njk" as m %}
 
   {% if errors %}
@@ -26,26 +25,43 @@
   {% endif %}
   <div class="govuk-grid-row">
   	<div class="govuk-grid-column-two-thirds">
-
-     <h1 class="govuk-heading-xl">
+		 <h1 class="govuk-heading-xl">
+				Service Unavailable
+		 </h1>
+     <h2 class="govuk-heading-l">
         The Submit a General Aviation Report (GAR) service is currently unavailable.
-     </h1>
-
+     </h2>
+    {% if (IS_PLANNED_MAINTENANCE == "true") %}
      <div>
-       <p class="govuk-body-m">
-         Please submit your GAR using the following method:
-       </p>
-
         <p class="govuk-body-m">
-          Download the GAR template
-          <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/946913/GAR_Template_Updated_Dec_2020_v6.4_SDS.xlsx">here</a>
-          and fill in the details. Then submit the GAR by contacting
-          the National Co-ordination Unit directly at: <br> Telephone: +44 (0) 845 723 1110
+         This is due to a planned outage. The service will be unavailable between {{ MAINTENANCE_START_DATETIME }} UTC and {{ MAINTENANCE_END_DATETIME }} UTC, but available thereafter.
         </p>
+        <p class="govuk-body-m">
+          If you are required to submit a GAR during this period, please download and complete the required GAR form found <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/946913/GAR_Template_Updated_Dec_2020_v6.4_SDS.xlsx">here</a>.
+				</p>
+				<p class="govuk-body-m">
+					GAR forms should be submitted directly to the National Co-Ordination Unit (NCU) at <a href="mailto:ncu@hmrc.gov.uk">ncu@hmrc.gov.uk</a> as per the instructions on GOV.UK. Submissions will not be received direct from sGAR for the duration of this outage.
+				</p>
+				<p class="govuk-body-m">
+					We apologise for any inconvenience.
+				</p>
        <p class="govuk-body-m">
-
      </div>
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-    </div>
+		{% else %}
+		<div>
+			 <p class="govuk-body-m">
+				 If you are required to submit a GAR for an imminent service, please download and complete the required GAR form found <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/946913/GAR_Template_Updated_Dec_2020_v6.4_SDS.xlsx">here</a>.
+			 </p>
+			 <p class="govuk-body-m">
+				 GAR forms should be submitted directly to the National Co-Ordination Unit (NCU) at <a href="mailto:ncu@hmrc.gov.uk">ncu@hmrc.gov.uk</a> as per the instructions on GOV.UK. Submissions will not be received direct from sGAR whilst the service is unavailable.
+			 </p>
+			 <p class="govuk-body-m">
+				 We apologise for any inconvenience.
+			 </p>
+			<p class="govuk-body-m">
+		</div>
+    {% endif %}
+     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+  </div>
 
 {% endblock %}

--- a/src/app/unavailable/index.njk
+++ b/src/app/unavailable/index.njk
@@ -37,7 +37,7 @@
          This is due to a planned outage. The service will be unavailable between {{ MAINTENANCE_START_DATETIME }} UTC and {{ MAINTENANCE_END_DATETIME }} UTC, but available thereafter.
         </p>
         <p class="govuk-body-m">
-          If you are required to submit a GAR during this period, please download and complete the required GAR form found <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/946913/GAR_Template_Updated_Dec_2020_v6.4_SDS.xlsx">here</a>.
+          If you are required to submit a GAR during this period, please download and complete the required GAR form found on <a href="https://www.gov.uk/government/publications/general-aviation-operators-and-pilots-notification-of-flights" target="_blank" rel="noopener noreferrer">General aviation operators and pilots notification of flights - GOV.UK (www.gov.uk)</a>.
 				</p>
 				<p class="govuk-body-m">
 					GAR forms should be submitted directly to the National Co-Ordination Unit (NCU) at <a href="mailto:ncu@hmrc.gov.uk">ncu@hmrc.gov.uk</a> as per the instructions on GOV.UK. Submissions will not be received direct from sGAR for the duration of this outage.
@@ -50,7 +50,7 @@
 		{% else %}
 		<div>
 			 <p class="govuk-body-m">
-				 If you are required to submit a GAR for an imminent service, please download and complete the required GAR form found <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/946913/GAR_Template_Updated_Dec_2020_v6.4_SDS.xlsx">here</a>.
+				 If you are required to submit a GAR for an imminent service, please download and complete the required GAR form found on <a href="https://www.gov.uk/government/publications/general-aviation-operators-and-pilots-notification-of-flights" target="_blank" rel="noopener noreferrer">General aviation operators and pilots notification of flights - GOV.UK (www.gov.uk)</a>.
 			 </p>
 			 <p class="govuk-body-m">
 				 GAR forms should be submitted directly to the National Co-Ordination Unit (NCU) at <a href="mailto:ncu@hmrc.gov.uk">ncu@hmrc.gov.uk</a> as per the instructions on GOV.UK. Submissions will not be received direct from sGAR whilst the service is unavailable.

--- a/src/common/config/availability.js
+++ b/src/common/config/availability.js
@@ -1,0 +1,5 @@
+// Unavailable page setting
+exports.ENABLE_UNAVAILABLE_PAGE = process.env.ENABLE_UNAVAILABLE_PAGE || 'false';
+exports.IS_PLANNED_MAINTENANCE = process.env.IS_PLANNED_MAINTENANCE || 'false'
+exports.MAINTENANCE_START_DATETIME = process.env.MAINTENANCE_START_DATETIME || 'unknown'
+exports.MAINTENANCE_END_DATETIME = process.env.MAINTENANCE_END_DATETIME || 'unknown'

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -24,7 +24,6 @@ exports.CORRELATION_HEADER = process.env.CORRELATION_HEADER_NAME || 'x-request-i
 exports.CONNECTOR_URL = process.env.CONNECTOR_URL;
 exports.CONTACT_EMAIL = process.env.CONTACT_URL || 'supportegar@homeoffice.gov.uk';
 exports.WHITELIST_REQUIRED = process.env.WHITELIST_REQUIRED || 'true';
-exports.ENABLE_UNAVAILABLE_PAGE = process.env.ENABLE_UNAVAILABLE_PAGE || 'false';
 
 // Application settings
 exports.NODE_ENV = process.env.NODE_ENV || 'DEV';

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ const PgSession = require('connect-pg-simple')(session);
 // Local dependencies
 const logger = require('./common/utils/logger')(__filename);
 const config = require('./common/config/index');
+const availability = require('./common/config/availability')
 const router = require('./app/router');
 const db = require('./common/utils/db');
 const noCache = require('./common/utils/no-cache');
@@ -114,7 +115,7 @@ function initialisExpressSession(app) {
 function initialiseGlobalMiddleware(app) {
   logger.info('Initalising global middleware');
 
-  if (config.ENABLE_UNAVAILABLE_PAGE.toLowerCase() === 'true') {
+  if (availability.ENABLE_UNAVAILABLE_PAGE.toLowerCase() === 'true') {
     logger.info('Enabling service unavailable middleware');
     const validRoutes = ['unavailable', 'public', 'javascripts', 'stylesheets'];
     app.use((req, res, next) => {
@@ -223,8 +224,6 @@ function initialiseTemplateEngine(app) {
   // nunjucksEnvironment.addGlobal('js_path', NODE_ENV === 'production' ? JAVASCRIPT_PATH : staticify.getVersionedPath('/javascripts/application.js'));
   nunjucksEnvironment.addGlobal('ga_id', GA_ID);
   nunjucksEnvironment.addGlobal('base_url', BASE_URL);
-
-  logger.info('Set global settings for nunjucks');
   nunjucksEnvironment.addFilter('uncamelCase', nunjucksFilters.uncamelCase);
   nunjucksEnvironment.addFilter('containsError', nunjucksFilters.containsError);
   // Country list added to the nunjucks global environment, up for debate whether this is the best place
@@ -237,6 +236,11 @@ function initialiseTemplateEngine(app) {
   nunjucksEnvironment.addGlobal('MAX_EMAIL_LENGTH', config.MAX_EMAIL_LENGTH);
   nunjucksEnvironment.addGlobal('MAX_ADDRESS_LINE_LENGTH', config.MAX_ADDRESS_LINE_LENGTH);
   nunjucksEnvironment.addGlobal('MAX_TEXT_BOX_LENGTH', config.MAX_TEXT_BOX_LENGTH);
+  // Add unavailable page variables into nunjucks envrionment
+  nunjucksEnvironment.addGlobal('IS_PLANNED_MAINTENANCE', availability.IS_PLANNED_MAINTENANCE);
+  nunjucksEnvironment.addGlobal('MAINTENANCE_START_DATETIME', availability.MAINTENANCE_START_DATETIME);
+  nunjucksEnvironment.addGlobal('MAINTENANCE_END_DATETIME', availability.MAINTENANCE_END_DATETIME);
+  logger.info('Set global settings for nunjucks');
 }
 
 function initialisePublic(app) {


### PR DESCRIPTION
**What changes does this PR bring?**
1. Updated wording of maintenance page with a toggle to switch between planned and unplanned outages. Planned outage displays start and end time of known maintenance window. 
2. Bugfix for nav bar showing incorrectly on unavailable page
3. Implemented a redirect to force users back to /welcome/index if they navigate to unavailable page when it is not enabled.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [Y] Have you built the code locally and confirmed its working?
- [Y] Is the build confirmed to be passing on CI?
- [Y] Have you added enough relevant unit tests for your change?
- [Y] Have you added enough relevant E2E tests for your change?
- [N/A] Have you updated any relevant documentation as part of this change?
- [Y] Has this change been tested against the Acceptance Criteria?
- [Y] Have you considered how this will be deployed in SIT/Staging/Production?
