### PR TITLE
reverted change to Coal Aston

### DIFF
--- a/src/common/utils/airport_codes.json
+++ b/src/common/utils/airport_codes.json
@@ -46253,13 +46253,7 @@
     "id": "EGCA",
     "id2": "EGCA",
     "british": true,
-    "label": "Coal Aston Airfield / Apperknowle Airstrip (United Kingdom) (EGCA)"
-  },
-  {
-    "id": "COAL ASTON - BENTLEY FARM",
-    "id2": "COAL ASTON - BENTLEY FARM",
-    "british": true,
-    "label": "COAL ASTON - BENTLEY FARM (United Kingdom)"
+    "label": "COAL ASTON - BENTLEY FARM (United Kingdom) (EGCA)"
   },
   {
     "id": "EGCG",


### PR DESCRIPTION
Reverted change to Coal Aston - only a single airfield there now. 
Will reinstate the other one when more info available.

**What changes does this PR bring?**


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
