### PR TITLE
Bugfix/fair 283/err msg for uploading files >8 mb

### DIFF
--- a/src/app/api/uploadfile/index.js
+++ b/src/app/api/uploadfile/index.js
@@ -17,7 +17,7 @@ router.post(paths.index, (req, res, next) => {
   upload(req, res, (err) => {
     if (err) {
       logger.info('File rejected due to size at multer level');
-      res.redirect('/garfile/supportingdocuments?query=limit');
+      return res.redirect('/garfile/supportingdocuments?query=limit');
     }
     next(err);
   });


### PR DESCRIPTION
ℹ️ When a single file, images.pdf (>8MB in size) was uploaded:

[images.pdf](https://github.com/UKHomeOffice/egar-public-site-ui/files/13675341/images.pdf)

✅ The correct error message was displayed at the top of the page:

<img width="879" alt="Correct Error Message" src="https://github.com/UKHomeOffice/egar-public-site-ui/assets/132352825/7bd34483-f38e-484e-9f82-bf33a390285f">


