### PR TITLE
sGAR ~ 2024.01.20 ~ FAIR 380, type error from garfile

### DIFF
--- a/src/common/utils/transformers.js
+++ b/src/common/utils/transformers.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 function transformPerson(personObj) {
   const copyPersonObj = personObj;
   if (Object.prototype.hasOwnProperty.call(personObj, 'peopleType')) {
@@ -14,7 +12,7 @@ function transformPerson(personObj) {
  * @returns {String} Undefined if undefined input else the string title case'd
  */
 function titleCase(str) {
-  if (str === undefined || !_.isString(str)) {
+  if (typeof str !== "string") {
     return str;
   }
   return str.split(' ')
@@ -23,9 +21,10 @@ function titleCase(str) {
 }
 
 function upperCamelCase(str) {
-  if (str === undefined) {
+  if (typeof str !== "string") {
     return str;
   }
+
   return str.split(' ')
     .map(word => word.charAt(0).toUpperCase() + word.substr(1).toLowerCase())
     .join('');
@@ -78,7 +77,7 @@ function unknownToUnspecified(aGender) {
 }
 
 function toUpper(aStr) {
-  return aStr === undefined ? undefined : _.toUpper(aStr);
+  return typeof aStr !== "string" ? aStr : aStr.toUpperCase();
 }
 
 module.exports = {

--- a/src/package.json
+++ b/src/package.json
@@ -80,7 +80,7 @@
     "mocha": "10.2.0",
     "nock": "^10.0.0",
     "node-test": "^1.2.4",
-    "nodemon": "^3.0.2",
+    "nodemon": "^3.0.3",
     "proxyquire": "^2.1.3",
     "rewire": "7.0.0",
     "sequelize-test-helpers": "^1.1.2",


### PR DESCRIPTION
**What changes does this PR bring?**

Fixes `TypeError` for excel upload error (see [ticket information](https://collaboration.homeoffice.gov.uk/jira/browse/FAIR-380))


- checks for typeof string before spliting string.
- This previously caused an error during validation if left on checked.
- It was a concidence that this occurred during UPT, there was nothing stopping this bug from occurring at another time.
- removed transient dependency on lodash, it was unnecessary for the code.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
