### PR TITLE
Feature/fair 400 - add certificate configuration into the egar-public-site-ui

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -140,7 +140,7 @@ steps:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
       - export KUBE_SERVER=$${TEST_KUBE_SERVER}
       - export KUBE_TOKEN=$${TEST_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${TEST_URL_SERVICE}
+      - export PUBLIC_SITE_INTERNAL_URL=$${TEST_BASE_URL}
       - export KUBE_ARTIFACTORY_APP_SECRET=$${TEST_KUBE_ARTIFACTORY_APP_SECRET}
       - source ./ops/common_lib
       - source ./ops/notprod_values

--- a/.drone.yml
+++ b/.drone.yml
@@ -87,39 +87,42 @@ steps:
     image: quay.io/ukhomeofficedigital/kd
     commands:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
-      - export KUBE_SERVER=$${DEV_KUBE_SERVER}
-      - export KUBE_TOKEN=$${DEV_KUBE_TOKEN}
-      - export BASE_URL=$${DEV_BASE_URL}
-      - export BASE_URL_SERVICE=$${DEV_URL_SERVICE}
-      - export KUBE_ARTIFACTORY_APP_SECRET=$${DEV_KUBE_ARTIFACTORY_APP_SECRET}
+      - export KUBE_ARTIFACTORY_APP_SECRET=$${SIT_KUBE_ARTIFACTORY_APP_SECRET}
+      - export KUBE_SERVER=$${SIT_KUBE_SERVER}
+      - export KUBE_TOKEN=$${SIT_KUBE_TOKEN}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${SIT_BASE_URL}
+      - export PUBLIC_SITE_INTERNAL_URL=$${SIT_BASE_URL_SERVICE}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
       - kd --timeout=6m --file ops/kube/public-site-network-policy.yml
       - kd --timeout=12m --file ops/kube/public-site-deployment.yml
       - kd --timeout=6m --file ops/kube/public-site-service.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress-for-service.gov.uk.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-tls.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-tls.yml
     environment:
       INGRESS_CLASS: nginx-internal
       INSECURE_SKIP_TLS_VERIFY: true
-      KUBE_NAMESPACE: egar-dev
-      NODE_ENV: development
-      DEV_BASE_URL:
-        from_secret: DEV_BASE_URL
-      DEV_KUBE_ARTIFACTORY_APP_SECRET:
-        from_secret: DEV_KUBE_ARTIFACTORY_APP_SECRET
-      DEV_KUBE_SERVER:
-        from_secret: DEV_KUBE_SERVER
-      DEV_KUBE_TOKEN:
-        from_secret: DEV_KUBE_TOKEN
-      DEV_URL_SERVICE:
-        from_secret: DEV_URL_SERVICE
+      KUBE_NAMESPACE: egar-sit
+      NODE_ENV: sit
+      SIT_BASE_URL:
+        from_secret: SIT_BASE_URL
+      SIT_BASE_URL_SERVICE:
+        from_secret: SIT_BASE_URL_SERVICE
+      SIT_KUBE_ARTIFACTORY_APP_SECRET:
+        from_secret: SIT_KUBE_ARTIFACTORY_APP_SECRET
+      SIT_KUBE_SERVER:
+        from_secret: SIT_KUBE_SERVER
+      SIT_KUBE_TOKEN:
+        from_secret: SIT_KUBE_TOKEN
 trigger:
   event:
     - tag
   ref:
     - refs/tags/release*
+    - refs/tag/test-ingress
     
 ---
 kind: pipeline
@@ -138,8 +141,8 @@ steps:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
       - export KUBE_SERVER=$${TEST_KUBE_SERVER}
       - export KUBE_TOKEN=$${TEST_KUBE_TOKEN}
-      - export BASE_URL=$${TEST_BASE_URL}
-      # - export BASE_URL_SERVICE=$${DEV_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${TEST_BASE_URL}
+      # - export PUBLIC_SITE_INTERNAL_URL=$${DEV_URL_SERVICE}
       - export KUBE_ARTIFACTORY_APP_SECRET=$${TEST_KUBE_ARTIFACTORY_APP_SECRET}
       - source ./ops/common_lib
       - source ./ops/notprod_values
@@ -147,7 +150,8 @@ steps:
       - kd --timeout=6m --file ops/kube/public-site-network-policy.yml
       - kd --timeout=12m --file ops/kube/public-site-deployment.yml
       - kd --timeout=6m --file ops/kube/public-site-service.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-tls.yml
     environment:
       INGRESS_CLASS: nginx-internal
       INSECURE_SKIP_TLS_VERIFY: true
@@ -188,16 +192,18 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${SIT_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${SIT_KUBE_SERVER}
       - export KUBE_TOKEN=$${SIT_KUBE_TOKEN}
-      - export BASE_URL=$${SIT_BASE_URL}
-      - export BASE_URL_SERVICE=$${SIT_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${SIT_BASE_URL}
+      - export PUBLIC_SITE_INTERNAL_URL=$${SIT_BASE_URL_SERVICE}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
       - kd --timeout=6m --file ops/kube/public-site-network-policy.yml
       - kd --timeout=12m --file ops/kube/public-site-deployment.yml
       - kd --timeout=6m --file ops/kube/public-site-service.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress-for-service.gov.uk.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-tls.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-tls.yml
     environment:
       INGRESS_CLASS: nginx-internal
       INSECURE_SKIP_TLS_VERIFY: true
@@ -306,16 +312,18 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${STAGING_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${STAGING_KUBE_SERVER}
       - export KUBE_TOKEN=$${STAGING_KUBE_TOKEN}
-      - export BASE_URL=$${STAGING_BASE_URL}
-      - export BASE_URL_SERVICE=$${STAGING_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${STAGING_BASE_URL}
+      - export PUBLIC_SITE_INTERNAL_URL=$${STAGING_BASE_URL_SERVICE}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
       - kd --timeout=6m --file ops/kube/public-site-network-policy.yml
       - kd --timeout=6m --file ops/kube/public-site-deployment.yml
       - kd --timeout=6m --file ops/kube/public-site-service.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress-for-service.gov.uk.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-internal-tls.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-tls.yml
     environment:
       DOCKER_REGISTRY_URL:
         from_secret: DOCKER_REGISTRY_URL
@@ -365,15 +373,16 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${PRODUCTION_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${PRODUCTION_KUBE_SERVER}
       - export KUBE_TOKEN=$${PRODUCTION_KUBE_TOKEN}
-      - export BASE_URL=$${PRODUCTION_BASE_URL}
-      - export BASE_URL_SERVICE=$${PRODUCTION_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${PRODUCTION_BASE_URL}
+      - export PUBLIC_SITE_INTERNAL_URL=$${PRODUCTION_BASE_URL_SERVICE}
       - source ./ops/common_lib
       - source ./ops/prod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
       - kd --timeout=6m --file ops/kube/public-site-network-policy.yml
       - kd --timeout=6m --file ops/kube/public-site-deployment.yml
       - kd --timeout=6m --file ops/kube/public-site-service.yml
-      - kd --timeout=6m --file ops/kube/public-site-ingress-for-service.gov.uk.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-ingress.yml
+      - kd --timeout=6m --file ops/kube/public-site-external-tls.yml
     environment:
       DOCKER_REGISTRY_URL:
         from_secret: DOCKER_REGISTRY_URL

--- a/.drone.yml
+++ b/.drone.yml
@@ -87,11 +87,11 @@ steps:
     image: quay.io/ukhomeofficedigital/kd
     commands:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
-      - export KUBE_ARTIFACTORY_APP_SECRET=$${SIT_KUBE_ARTIFACTORY_APP_SECRET}
-      - export KUBE_SERVER=$${SIT_KUBE_SERVER}
-      - export KUBE_TOKEN=$${SIT_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${SIT_BASE_URL}
-      - export PUBLIC_SITE_INTERNAL_URL=$${SIT_BASE_URL_SERVICE}
+      - export KUBE_SERVER=$${DEV_KUBE_SERVER}
+      - export KUBE_TOKEN=$${DEV_KUBE_TOKEN}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${DEV_BASE_URL}
+      - export PUBLIC_SITE_INTERNAL_URL=$${DEV_URL_SERVICE}
+      - export KUBE_ARTIFACTORY_APP_SECRET=$${DEV_KUBE_ARTIFACTORY_APP_SECRET}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
@@ -105,24 +105,23 @@ steps:
     environment:
       INGRESS_CLASS: nginx-internal
       INSECURE_SKIP_TLS_VERIFY: true
-      KUBE_NAMESPACE: egar-sit
-      NODE_ENV: sit
-      SIT_BASE_URL:
-        from_secret: SIT_BASE_URL
-      SIT_BASE_URL_SERVICE:
-        from_secret: SIT_BASE_URL_SERVICE
-      SIT_KUBE_ARTIFACTORY_APP_SECRET:
-        from_secret: SIT_KUBE_ARTIFACTORY_APP_SECRET
-      SIT_KUBE_SERVER:
-        from_secret: SIT_KUBE_SERVER
-      SIT_KUBE_TOKEN:
-        from_secret: SIT_KUBE_TOKEN
+      KUBE_NAMESPACE: egar-dev
+      NODE_ENV: development
+      DEV_BASE_URL:
+        from_secret: DEV_BASE_URL
+      DEV_KUBE_ARTIFACTORY_APP_SECRET:
+        from_secret: DEV_KUBE_ARTIFACTORY_APP_SECRET
+      DEV_KUBE_SERVER:
+        from_secret: DEV_KUBE_SERVER
+      DEV_KUBE_TOKEN:
+        from_secret: DEV_KUBE_TOKEN
+      DEV_URL_SERVICE:
+        from_secret: DEV_URL_SERVICE
 trigger:
   event:
     - tag
   ref:
     - refs/tags/release*
-    - refs/tag/test-ingress
     
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,8 +89,8 @@ steps:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
       - export KUBE_SERVER=$${DEV_KUBE_SERVER}
       - export KUBE_TOKEN=$${DEV_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${DEV_BASE_URL}
-      - export PUBLIC_SITE_INTERNAL_URL=$${DEV_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${DEV_URL_SERVICE}
+      - export PUBLIC_SITE_INTERNAL_URL=$${DEV_BASE_URL}
       - export KUBE_ARTIFACTORY_APP_SECRET=$${DEV_KUBE_ARTIFACTORY_APP_SECRET}
       - source ./ops/common_lib
       - source ./ops/notprod_values

--- a/.drone.yml
+++ b/.drone.yml
@@ -140,8 +140,7 @@ steps:
       - export TAGGED_VERSION=$${DRONE_COMMIT}
       - export KUBE_SERVER=$${TEST_KUBE_SERVER}
       - export KUBE_TOKEN=$${TEST_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${TEST_BASE_URL}
-      # - export PUBLIC_SITE_INTERNAL_URL=$${DEV_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${TEST_URL_SERVICE}
       - export KUBE_ARTIFACTORY_APP_SECRET=$${TEST_KUBE_ARTIFACTORY_APP_SECRET}
       - source ./ops/common_lib
       - source ./ops/notprod_values
@@ -191,8 +190,8 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${SIT_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${SIT_KUBE_SERVER}
       - export KUBE_TOKEN=$${SIT_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${SIT_BASE_URL}
-      - export PUBLIC_SITE_INTERNAL_URL=$${SIT_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${SIT_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_INTERNAL_URL=$${SIT_BASE_URL}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
@@ -311,8 +310,8 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${STAGING_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${STAGING_KUBE_SERVER}
       - export KUBE_TOKEN=$${STAGING_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${STAGING_BASE_URL}
-      - export PUBLIC_SITE_INTERNAL_URL=$${STAGING_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${STAGING_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_INTERNAL_URL=$${STAGING_BASE_URL}
       - source ./ops/common_lib
       - source ./ops/notprod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
@@ -372,8 +371,7 @@ steps:
       - export KUBE_ARTIFACTORY_APP_SECRET=$${PRODUCTION_KUBE_ARTIFACTORY_APP_SECRET}
       - export KUBE_SERVER=$${PRODUCTION_KUBE_SERVER}
       - export KUBE_TOKEN=$${PRODUCTION_KUBE_TOKEN}
-      - export PUBLIC_SITE_EXTERNAL_URL=$${PRODUCTION_BASE_URL}
-      - export PUBLIC_SITE_INTERNAL_URL=$${PRODUCTION_BASE_URL_SERVICE}
+      - export PUBLIC_SITE_EXTERNAL_URL=$${PRODUCTION_BASE_URL_SERVICE}
       - source ./ops/common_lib
       - source ./ops/prod_values
       - kd --timeout=6m --file ops/kube/artifactory-secret.yml
@@ -389,8 +387,6 @@ steps:
       INSECURE_SKIP_TLS_VERIFY: true
       KUBE_NAMESPACE: egar-production
       NODE_ENV: production
-      PRODUCTION_BASE_URL:
-        from_secret: PRODUCTION_BASE_URL
       PRODUCTION_BASE_URL_SERVICE:
         from_secret: PRODUCTION_BASE_URL_SERVICE
       PRODUCTION_KUBE_ARTIFACTORY_APP_SECRET:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ For the above scripts to work, the following variables must be existing in the s
 export KUBE_NAMESPACE='target-namespace'                    # The target namespace
 
 export TAGGED_VERSION='docker-tag'                          # The docker image tag as found in the quay io
-export BASE_URL='internal url'                              # The internal url. Please refer to drone secrets.
-export BASE_URL_SERVICE='www.egar-sit.homeoffice.gov.uk'    # The external url. Please refer to drone secrets.
+export PUBLIC_SITE_EXTERNAL_URL='www.egar-sit.homeoffice.gov.uk' # The external url. Please refer to drone secrets.
+export PUBLIC_SITE_INTERNAL_URL='internal url'              # The internal url. Please refer to drone secrets.
 ```
 The easiest is to have a file called `.idea` with all the above variables defined in it which will be included automatically in the `deploy_app` and the `destroy_app` scripts; the file `.idea` will not be tracked by git.

--- a/ops/kube/public-site-external-ingress.yml
+++ b/ops/kube/public-site-external-ingress.yml
@@ -7,19 +7,19 @@ metadata:
     cert-manager.io/solver: http01
   annotations:
     kubernetes.io/ingress.class: "nginx-external"
+    cert-manager.io/enabled: "true"
     ingress.kubernetes.io/force-ssl-redirect: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/proxy-body-size: "20m"
-    cert-manager.io/enabled: "true"
     ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:TLSv1.3:TLSv1.2:+HIGH'
     ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
 spec:
   tls:
   - hosts:
-    - {{ .BASE_URL_SERVICE }}
-    secretName: public-site-tls-cmio
+    - {{ .PUBLIC_SITE_EXTERNAL_URL }}
+    secretName: public-site-external-tls
   rules:
-  - host: {{ .BASE_URL_SERVICE }}
+  - host: {{ .PUBLIC_SITE_EXTERNAL_URL }}
     http:
       paths:
       - path: /

--- a/ops/kube/public-site-external-tls.yml
+++ b/ops/kube/public-site-external-tls.yml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: public-site-external
+spec:
+  commonName: {{ .PUBLIC_SITE_EXTERNAL_URL }}
+  dnsNames:
+  - {{ .PUBLIC_SITE_EXTERNAL_URL }}
+  issuerRef:
+    kind: ClusterIssuer
+    # @Note: we support letsencrypt-prod and letsencrypt-staging (use the latter to test your cert-manager related manifests)
+    name: letsencrypt-prod
+  secretName: public-site-external-tls

--- a/ops/kube/public-site-external-tls.yml
+++ b/ops/kube/public-site-external-tls.yml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: public-site-external
+  name: public-site-external-tls
 spec:
   commonName: {{ .PUBLIC_SITE_EXTERNAL_URL }}
   dnsNames:

--- a/ops/kube/public-site-internal-ingress.yml
+++ b/ops/kube/public-site-internal-ingress.yml
@@ -6,18 +6,20 @@ metadata:
   labels:
     cert-manager.io/solver: route53
   annotations:
-    cert-manager.io/enabled: "true"
-    ingress.kubernetes.io/backend-protocol: "HTTPS"
-    ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
+    cert-manager.io/enabled: "true"
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/proxy-body-size: "20m"
+    ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:TLSv1.3:TLSv1.2:+HIGH'
+    ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
 spec:
   tls:
   - hosts:
-    - {{ .BASE_URL }}
-    secretName: public-site-tls-cmio
+    - {{ .PUBLIC_SITE_INTERNAL_URL }}
+    secretName: public-site-internal-tls
   rules:
-  - host: {{ .BASE_URL }}
+  - host: {{ .PUBLIC_SITE_INTERNAL_URL }}
     http:
       paths:
       - path: /

--- a/ops/kube/public-site-internal-tls.yml
+++ b/ops/kube/public-site-internal-tls.yml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: public-site-internal
+  name: public-site-internal-tls
 spec:
   commonName: {{ .PUBLIC_SITE_INTERNAL_URL }}
   dnsNames:

--- a/ops/kube/public-site-internal-tls.yml
+++ b/ops/kube/public-site-internal-tls.yml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: public-site-internal
+spec:
+  commonName: {{ .PUBLIC_SITE_INTERNAL_URL }}
+  dnsNames:
+  - {{ .PUBLIC_SITE_INTERNAL_URL }}
+  issuerRef:
+    kind: ClusterIssuer
+    # @Note: we support letsencrypt-prod and letsencrypt-staging (use the latter to test your cert-manager related manifests)
+    name: letsencrypt-prod
+  secretName: public-site-internal-tls

--- a/ops/kube/public-site-internal-tls.yml
+++ b/ops/kube/public-site-internal-tls.yml
@@ -2,12 +2,14 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: public-site-internal-tls
+  labels:
+    # @Note: this label tells the cluster issuer to use the DNS01 Route53 solver instead of the default HTTP01 solver
+    cert-manager.io/solver: route53
 spec:
+  secretName: public-site-internal-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
   commonName: {{ .PUBLIC_SITE_INTERNAL_URL }}
   dnsNames:
   - {{ .PUBLIC_SITE_INTERNAL_URL }}
-  issuerRef:
-    kind: ClusterIssuer
-    # @Note: we support letsencrypt-prod and letsencrypt-staging (use the latter to test your cert-manager related manifests)
-    name: letsencrypt-prod
-  secretName: public-site-internal-tls


### PR DESCRIPTION
**What changes does this PR bring?**
* Add permanent certificate file to the application, meaning that certificate should be consistent across environments.
* Also makes the `base_url` (internal urls) and `base_url_service` (external urls) clearer.

I will delete this [documentation though](https://collaboration.homeoffice.gov.uk/display/BF/sGAR%3Ainvalid+certificate+issue+-+possible+fix).
* Use [ACP docs instead](https://docs.acp.homeoffice.gov.uk/how-to/security/cert-manager/).

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [x] Have you added enough relevant unit tests for your change?
- [x] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
