### PR TITLE
Feature/fair 408 ~ 2024.02.09 ~ apostephe changes

### DIFF
--- a/src/app/api/uploadgar/validations.js
+++ b/src/app/api/uploadgar/validations.js
@@ -102,12 +102,12 @@ module.exports.validations = (voyageObj, crewArr, passengersArr) => {
     validationArr.push([
       new ValidationRule(validator.notEmpty, '', crew.lastName, `Enter a surname for ${peopleType} ${crew.firstName}`),
       new ValidationRule(validator.isValidStringLength, '', crew.lastName, `Surname for ${name} must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, '', crew.lastName, `Surname for ${name}  must not contain special characters or numbers`),
+      new ValidationRule(validator.isAlpha, '', crew.lastName, `Surname for ${name}  must not contain special characters, apostrephes or numbers`),
     ]);
     validationArr.push([
       new ValidationRule(validator.notEmpty, '', crew.firstName, `Enter a given name for ${peopleType} ${crew.lastName}`),
       new ValidationRule(validator.isValidStringLength, '', crew.firstName, `Given name for ${name} must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, '', crew.firstName, `Given name for ${name}  must not contain special characters or numbers`),
+      new ValidationRule(validator.isAlpha, '', crew.firstName, `Given name for ${name}  must not contain special characters, apostrephes or numbers`),
     ]);
     validationArr.push([new ValidationRule(validator.notEmpty, '', crew.gender, `Enter a sex for ${name}`)]);
     validationArr.push([new ValidationRule(validator.validGender, '', crew.gender, `Enter a valid sex for ${name}`)]);

--- a/src/app/garfile/responsibleperson/validations.js
+++ b/src/app/garfile/responsibleperson/validations.js
@@ -46,16 +46,16 @@ module.exports.validations = (req) => {
     [
       new ValidationRule(validator.notEmpty, 'responsibleAddressLine1', responsibleAddressLine1, 'Enter address line 1 of the responsible person'),
       new ValidationRule(validator.isValidStringLength, 'responsibleAddressLine1', responsibleAddressLine1, `Address line 1 must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAddressValidCharacters, 'responsibleAddressLine1', responsibleAddressLine1, `Address line 1 must not contain special characters such as $ % or ä`),
+      new ValidationRule(validator.isAddressValidCharacters, 'responsibleAddressLine1', responsibleAddressLine1, `Address line 1 must not contain special characters such as $ % ' or ä`),
     ],
     [
       new ValidationRule(validator.isValidStringLength, 'responsibleAddressLine2', responsibleAddressLine2, `Address line 2 must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAddressValidCharacters, 'responsibleAddressLine2', responsibleAddressLine2, `Address line 2 must not contain special characters such as $ % or ä`),
+      new ValidationRule(validator.isAddressValidCharacters, 'responsibleAddressLine2', responsibleAddressLine2, `Address line 2 must not contain special characters such as $ % ' or ä`),
     ],
     [
       new ValidationRule(validator.notEmpty, 'responsibleTown', responsibleTown, 'Enter a town or city for the responsible person'),
       new ValidationRule(validator.isValidStringLength, 'responsibleTown', responsibleTown, `Town or city must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAddressValidCharacters, 'responsibleTown', responsibleTown, `Town or city must not contain special characters such as $ % or ä`),
+      new ValidationRule(validator.isAddressValidCharacters, 'responsibleTown', responsibleTown, `Town or city must not contain special characters such as $ % ' or ä`),
     ],
     [
       new ValidationRule(validator.validTextLength, 'responsiblePostcode', { value: responsiblePostcode, maxLength: MAX_POSTCODE_LENGTH }, `Postcode must be ${MAX_POSTCODE_LENGTH} characters or less`),

--- a/src/app/garfile/responsibleperson/validations.js
+++ b/src/app/garfile/responsibleperson/validations.js
@@ -36,8 +36,8 @@ module.exports.validations = (req) => {
     ],
     [
       new ValidationRule(validator.notEmpty, 'responsibleSurname', responsibleSurname, 'Enter a surname for the responsible person'),
-      new ValidationRule(validator.isValidStringLength, 'responsibleSurname', responsibleSurname, `Surname must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, 'responsibleSurname', responsibleSurname, `Surname must not contain special characters or numbers`),
+      new ValidationRule(validator.isValidStringLength, 'responsibleSurname', responsibleSurname, `Surname must be ${MAX_STRING_LENGTH} characters, apostrephes or less`),
+      new ValidationRule(validator.isAlpha, 'responsibleSurname', responsibleSurname, `Surname must not contain special characters, apostrephes or numbers`),
     ],
     [
       new ValidationRule(validator.validIntlPhone, 'responsibleContactNo', responsibleContactNo, i18n.__('validator_contact_number')),

--- a/src/app/garfile/responsibleperson/validations.js
+++ b/src/app/garfile/responsibleperson/validations.js
@@ -32,11 +32,11 @@ module.exports.validations = (req) => {
     [
       new ValidationRule(validator.notEmpty, 'responsibleGivenName', responsibleGivenName, 'Enter a given name for the responsible person'),
       new ValidationRule(validator.isValidStringLength, 'responsibleGivenName', responsibleGivenName, `Given name must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, 'responsibleGivenName', responsibleGivenName, `Given name must not contain special characters or numbers`),
+      new ValidationRule(validator.isAlpha, 'responsibleGivenName', responsibleGivenName, `Given name must not contain special characters, apostrephes or numbers`),
     ],
     [
       new ValidationRule(validator.notEmpty, 'responsibleSurname', responsibleSurname, 'Enter a surname for the responsible person'),
-      new ValidationRule(validator.isValidStringLength, 'responsibleSurname', responsibleSurname, `Surname must be ${MAX_STRING_LENGTH} characters, apostrephes or less`),
+      new ValidationRule(validator.isValidStringLength, 'responsibleSurname', responsibleSurname, `Surname must be ${MAX_STRING_LENGTH} characters or less`),
       new ValidationRule(validator.isAlpha, 'responsibleSurname', responsibleSurname, `Surname must not contain special characters, apostrephes or numbers`),
     ],
     [

--- a/src/app/people/validations.js
+++ b/src/app/people/validations.js
@@ -62,12 +62,12 @@ module.exports.validations = (req) => {
     [
       new ValidationRule(validator.notEmpty, 'firstName', req.body.firstName, 'Enter the given name of the person'),
       new ValidationRule(validator.isValidStringLength, 'firstName', req.body.firstName, `Given name must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, 'firstName', req.body.firstName, `Given name must not contain special characters or numbers`),
+      new ValidationRule(validator.isAlpha, 'firstName', req.body.firstName, `Given name must not contain special characters, apostrephes or numbers`),
     ],
     [
       new ValidationRule(validator.notEmpty, 'lastName', req.body.lastName, 'Enter the surname of the person'),
       new ValidationRule(validator.isValidStringLength, 'lastName', req.body.lastName, `Surname must be ${MAX_STRING_LENGTH} characters or less`),
-      new ValidationRule(validator.isAlpha, 'lastName', req.body.lastName, `Surname must not contain special characters or numbers`),
+      new ValidationRule(validator.isAlpha, 'lastName', req.body.lastName, `Surname must not contain special characters, apostrephes or numbers`),
     ],
     [
       new ValidationRule(validator.notEmpty, 'nationality', req.body.nationality, 'Enter the nationality of the person'),

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -669,12 +669,12 @@ function isAlphanumeric(input) {
 }
 
 function isAlpha(input) {
-  const alphaRegex = /^[a-z\s\'\-]+$/i;
+  const alphaRegex = /^[a-z\s\-]+$/i;
   return alphaRegex.test(input);
 }
 
 function isAddressValidCharacters(input) {
-  const addressRegex = /^[a-z\s\'\-\d]+$/i;
+  const addressRegex = /^[a-z\s\-\d]+$/i;
   return isEmpty(input) || addressRegex.test(input);
 }
 

--- a/src/test/validators.test.js
+++ b/src/test/validators.test.js
@@ -880,6 +880,10 @@ describe('Validator', () => {
 
         const stringWithNumberInIt = "Aaron Adam-Kingsbottom 3rd";
         expect(validator.isAlpha(stringWithNumberInIt)).to.eql(false);
+
+        const stringWithSingleQuote = "Aaron O'Kingsbottom";
+        expect(validator.isAlpha(stringWithSingleQuote)).to.eql(false);
+
     })
 
     it('Validates optional unprovided addresses which are valid', () => { 
@@ -901,13 +905,10 @@ describe('Validator', () => {
       expect(validator.isAddressValidCharacters(streetNameWithADash)).to.eql(true);
 
       const streetNameWithAnapostrophe = "Pullman's Lane";
-      expect(validator.isAddressValidCharacters(streetNameWithAnapostrophe)).to.eql(true);
+      expect(validator.isAddressValidCharacters(streetNameWithAnapostrophe)).to.eql(false);
 
       const houseNumber = "18";
       expect(validator.isAddressValidCharacters(houseNumber)).to.eql(true);
-
-      const postcode = "SE1 9BG";
-      expect(validator.isAddressValidCharacters(postcode)).to.eql(true);
     })
 
     it('Invalidates Addresses which are invalid', () => { 
@@ -924,6 +925,9 @@ describe('Validator', () => {
 
       const specialCharacterStreet = "LA'SW";
       expect(validator.isPostCodeValidCharacters(specialCharacterStreet)).to.eql(false);
+
+      const postcode = "SE1 9BG";
+      expect(validator.isPostCodeValidCharacters(postcode)).to.eql(true);
 
     });
   })


### PR DESCRIPTION
**What changes does this PR bring?**

Messages have been updated.
- tested via e2e tests (see sibling request https://gitlab.digital.homeoffice.gov.uk/egar/e2e-test/-/merge_requests/227/diffs).
- To fix AMG error changed by apostrephes in `firstname`, `Surname`, `operatorAddress1`,  `operatorAddress2`,  `operatorAddress3`, `operatorFirstName`, `operatorSurname`. (https://homeofficedigital.slack.com/archives/C061V6CD1R7/p1707407677281629).
- https://collaboration.homeoffice.gov.uk/jira/browse/FAIR-408

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [X] Have you built the code locally and confirmed its working?
- [X] Is the build confirmed to be passing on CI?
- [X] Have you added enough relevant unit tests for your change?
- [X] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
