### PR TITLE
Feature/fair 408 departure ports are prevented from being too long

### DIFF
--- a/src/app/api/uploadgar/post.controller.js
+++ b/src/app/api/uploadgar/post.controller.js
@@ -62,10 +62,10 @@ const checkFileIsGAR = (req, res, worksheet) => {
 
 // Define cell configurations for ExcelParser and parse from file read into memory
 const cellMap = {
-  arrivalPort: { location: 'B3' },
+  arrivalPort: { location: 'B3', transform: [transformers.trimWhitespace] },
   arrivalDate: { location: 'D3' },
   arrivalTime: { location: 'F3', raw: true },
-  departurePort: { location: 'B4' },
+  departurePort: { location: 'B4', transform: [transformers.trimWhitespace] },
   departureDate: { location: 'D4' },
   departureTime: { location: 'F4', raw: true },
   registration: { location: 'B5', raw: true },

--- a/src/app/api/uploadgar/validations.js
+++ b/src/app/api/uploadgar/validations.js
@@ -39,8 +39,10 @@ function getCrewFieldLabel(key) { //NOSONAR
 
 module.exports.validations = (voyageObj, crewArr, passengersArr) => {
   const validationArr = [
+    [new ValidationRule(validator.isValidAirportCode, '', voyageObj.arrivalPort, 'Arrival port should be an ICAO or IATA code')],
     [new ValidationRule(validator.notEmpty, '', voyageObj.arrivalPort, 'Enter a value for the arrival port')],
     [new ValidationRule(validator.preventZ, '', voyageObj.arrivalPort, 'Add ICAO/IATA or Latitude/Longitude Co-ordinates for the location')],
+    [new ValidationRule(validator.isValidAirportCode, '', voyageObj.departurePort, 'Departure port should be an ICAO or IATA code')],
     [new ValidationRule(validator.notEmpty, '', voyageObj.departurePort, 'Enter a value for the departure port')],
     [new ValidationRule(validator.preventZ, '', voyageObj.departurePort, 'Add ICAO/IATA or Latitude/Longitude Co-ordinates for the location')],
     [new ValidationRule(airportValidation.includesOneBritishAirport, '', [voyageObj.departurePort, voyageObj.arrivalPort], airportValidation.notBritishMsg)],

--- a/src/app/garfile/arrival/post.controller.js
+++ b/src/app/garfile/arrival/post.controller.js
@@ -69,6 +69,7 @@ const buildValidations = (voyage) => {
   // Define port validations
   const arrivalPortValidation = [
     new ValidationRule(validator.notEmpty, 'arrivalPort', voyage.arrivalPort, portCodeMsg),
+    new ValidationRule(validator.isValidAirportCode, 'arrivalPort', voyage.arrivalPort, 'Arrival port should be an ICAO or IATA code')
   ];
 
   // Define latitude validations

--- a/src/app/garfile/departure/post.controller.js
+++ b/src/app/garfile/departure/post.controller.js
@@ -28,6 +28,7 @@ const createValidationChains = (voyage) => {
   // Define port validations
   const departurePortValidation = [
     new ValidationRule(validator.notEmpty, 'departurePort', voyage.departurePort, __('field_departure_port_code_validation')),
+    new ValidationRule(validator.isValidAirportCode, 'departurePort', voyage.departurePort, 'Departure port should be an ICAO or IATA code')
   ];
 
   // Define latitude validations

--- a/src/common/utils/autocomplete.js
+++ b/src/common/utils/autocomplete.js
@@ -32,9 +32,31 @@ function getCountryFromCode(countryCode) {
   return countryFromCode === undefined ? countryCode : countryFromCode.label;
 }
 
+/**
+ * generate list of airport codes from the airport list
+ * @param {Array<Object>}
+ * @returns {Array<String>} List of airport codes
+ */
+function listOfAirportCodes(airportList) {
+  const airportCodes = [];
+
+  airportList.forEach((airport) => {
+    const iataCode = airport.id
+    const icaoCode = airport.id2;
+    airportCodes.push(iataCode);
+    airportCodes.push(icaoCode);
+  });
+
+  return airportCodes
+}
+
+const airportCodeList = listOfAirportCodes(airportList);
+
+
 module.exports = {
   generateCountryList,
   getCountryFromCode,
   countryList,
   airportList,
+  airportCodeList
 };

--- a/src/common/utils/transformers.js
+++ b/src/common/utils/transformers.js
@@ -80,6 +80,10 @@ function toUpper(aStr) {
   return typeof aStr !== "string" ? aStr : aStr.toUpperCase();
 }
 
+function trimWhitespace(aStr) {
+  return typeof aStr !== "string" ? aStr : aStr.trim();
+}
+
 module.exports = {
   transformPerson,
   titleCase,
@@ -89,4 +93,5 @@ module.exports = {
   docTypeOrUndefined,
   unknownToUnspecified,
   toUpper,
+  trimWhitespace
 };

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -7,6 +7,7 @@ const visitReasonValues = require('../seeddata/egar_visit_reason_options.json');
 const genderValues = require('../seeddata/egar_gender_choice.json');
 const { MAX_STRING_LENGTH, MAX_REGISTRATION_LENGTH, MAX_EMAIL_LENGTH, USER_FIRST_NAME_CHARACTER_COUNT, USER_SURNAME_CHARACTER_COUNT } = require('../config/index');
 const logger = require('../../common/utils/logger')(__filename);
+const { airportCodeList } = require('../../common/utils/autocomplete');
 
 /**
  * Check if the string has leading spaces
@@ -691,6 +692,15 @@ function preventZ(value) {
   return true;
 }
 
+/**
+ * Verify that airport code is accurate
+ * @param {String} airportCode expected to be an  IATA (length 3) or ICAO (length 4) orcode
+ * @returns {Bool}
+ */
+function isValidAirportCode(airportCode) {
+  return airportCodeList.includes(airportCode);
+}
+
 module.exports = {
   hasOnlySymbols,
   hasLeadingSpace,
@@ -751,5 +761,6 @@ module.exports = {
   isAlphanumeric,
   isAlpha,
   isAddressValidCharacters,
-  isPostCodeValidCharacters
+  isPostCodeValidCharacters,
+  isValidAirportCode
 };

--- a/src/test/api/uploadgar/post.controller.test.js
+++ b/src/test/api/uploadgar/post.controller.test.js
@@ -268,6 +268,7 @@ describe('API upload GAR post controller', () => {
 
         expect(req.session.save).to.have.been.called;
         expect(req.session.failureMsg).to.eql([
+          new ValidationRule(validator.isValidAirportCode, '', null, 'Arrival port should be an ICAO or IATA code'),
           new ValidationRule(validator.notEmpty, '', null,  'Enter a value for the arrival port'),
         ]);
       });
@@ -438,7 +439,7 @@ describe('API upload GAR post controller', () => {
             arrivalPort: 'BFS',
             arrivalDate: '2022-05-31',
             arrivalTime: 'Arrival Time',
-            departurePort: 'Departure Port',
+            departurePort: 'LGW',
             departureDate: '2022-05-30',
             departureTime: 'Departure Time',
             registration: 'Registration',

--- a/src/test/api/uploadgar/workbook-data.js
+++ b/src/test/api/uploadgar/workbook-data.js
@@ -8,10 +8,10 @@ module.exports = {
     Sheets: {
       Sheet1: {
         C1: { v: '     GENERAL AVIATION REPORT (GAR) -  January 2015' },
-        B3: { v: 'BFS' },
+        B3: { v: 'BFS' }, // Arrival Port
         D3: { v: '2022-05-31' },
         F3: { w: 'Arrival Time' },
-        B4: { v: 'Departure Port' },
+        B4: { v: 'LGW' }, // Departure Port
         D4: { v: '2022-05-30' },
         F4: { w: 'Departure Time' },
         B5: { w: 'Registration' },
@@ -54,10 +54,10 @@ module.exports = {
     Sheets: {
       Valid1: {
         C1: { v: '     GENERAL AVIATION REPORT (GAR) -  January 2015' },
-        B3: { v: 'BFS' },
+        B3: { v: 'BFS' }, // Arrival Port
         D3: { v: '2022-05-31' },
         F3: { w: 'Arrival Time' },
-        B4: { v: 'Departure Port' },
+        B4: { v: 'LGW' }, // Departure Port
         D4: { v: '2022-05-30' },
         F4: { w: 'Departure Time' },
         B5: { w: 'Registration' },

--- a/src/test/validators.test.js
+++ b/src/test/validators.test.js
@@ -930,5 +930,16 @@ describe('Validator', () => {
       expect(validator.isPostCodeValidCharacters(postcode)).to.eql(true);
 
     });
+
+    it('Validates airport code list accurate detects codes which are in and not in the list', ()  => {
+      expect(validator.isValidAirportCode('LGW')).to.eql(true);
+      expect(validator.isValidAirportCode('EGXJ')).to.eql(true);
+      expect(validator.isValidAirportCode('LAX')).to.eql(true);
+      expect(validator.isValidAirportCode('EHWO')).to.eql(true);
+
+      expect(validator.isValidAirportCode('Not An airport code')).to.eql(false);
+      expect(validator.isValidAirportCode('12345')).to.eql(false);
+
+    })
   })
 });


### PR DESCRIPTION
**What changes does this PR bring?**

This change prevents the departure and arrival port from not being too long when submitting excel or non excel.
- adds validation.
- prevents common whitespace error via trimming (do confirm this).

Pull requests:
* https://github.com/UKHomeOffice/egar-public-site-ui/pull/444
* https://gitlab.digital.homeoffice.gov.uk/egar/data-access-api/-/merge_requests/251
* https://gitlab.digital.homeoffice.gov.uk/egar/e2e-test/-/merge_requests/230

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [x] Is the build confirmed to be passing on CI?
- [x] Have you added enough relevant unit tests for your change?
- [x] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
