### PR TITLE
updated events page

### DIFF
--- a/src/app/welcome/index.njk
+++ b/src/app/welcome/index.njk
@@ -134,9 +134,10 @@ Create GAR | Start
 					</p>
 					<ul class="govuk-list govuk-list--bullet">
 						<li>
-							<a href="https://www.eventbrite.co.uk/e/home-office-fbis-general-aviation-engagement-event-sgar-tickets-815678535457?aff=oddtdtcreator">
+						No upcoming events.
+							{# <a href="https://www.eventbrite.co.uk/e/home-office-fbis-general-aviation-engagement-event-sgar-tickets-815678535457?aff=oddtdtcreator">
 								<time datetime="2024-02-20">2024-02-20 (pm)</time></a>&nbsp;
-							<a href="https://app.sli.do/event/tkSCpuWXtKsn1KNGXMZ6hg/live/questions">[slido link]</a>
+							<a href="https://app.sli.do/event/tkSCpuWXtKsn1KNGXMZ6hg/live/questions">[slido link]</a> #}
 						</li>
 					</ul>
 				</section>


### PR DESCRIPTION
Removed old link from events page.

![image](https://github.com/UKHomeOffice/egar-public-site-ui/assets/112489564/fbcee2fb-f518-4a71-8786-35a40f6b01fd)