### PR TITLE
Feature/hsts fair 385

### DIFF
--- a/ops/kube/public-site-deployment.yml
+++ b/ops/kube/public-site-deployment.yml
@@ -45,7 +45,7 @@ spec:
             - name: ENABLE_UUID_PARAM
               value: "FALSE"
             - name: ADD_NGINX_SERVER_CFG
-              value: "add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\" always;"
+              value: "add_header Strict-Transport-Security \"max-age=999931536000; includeSubDomains\" always;"
             - name: CLIENT_MAX_BODY_SIZE
               value: '20'
             - name: STATSD_METRICS

--- a/ops/kube/public-site-deployment.yml
+++ b/ops/kube/public-site-deployment.yml
@@ -45,7 +45,7 @@ spec:
             - name: ENABLE_UUID_PARAM
               value: "FALSE"
             - name: ADD_NGINX_SERVER_CFG
-              value: "add_header Strict-Transport-Security \"max-age=999931536000; includeSubDomains\" always;"
+              value: "add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\" always;"
             - name: CLIENT_MAX_BODY_SIZE
               value: '20'
             - name: STATSD_METRICS

--- a/ops/kube/public-site-external-ingress.yml
+++ b/ops/kube/public-site-external-ingress.yml
@@ -20,6 +20,8 @@ metadata:
     ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:!SHA1:!SHA256:!SHA384:EECDH+TLSv1.2+HIGH'
     ingress.kubernetes.io/ssl-prefer-server-ciphers: "true"
     ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
 spec:
   tls:
   - hosts:

--- a/ops/kube/public-site-internal-ingress.yml
+++ b/ops/kube/public-site-internal-ingress.yml
@@ -20,8 +20,8 @@ metadata:
     ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:!SHA1:!SHA256:!SHA384:EECDH+TLSv1.2+HIGH'
     ingress.kubernetes.io/ssl-prefer-server-ciphers: 'true'
     ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
-    ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
+    # ingress.kubernetes.io/configuration-snippet: |
+    #   more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
 spec:
   tls:
   - hosts:

--- a/ops/kube/public-site-internal-ingress.yml
+++ b/ops/kube/public-site-internal-ingress.yml
@@ -20,6 +20,8 @@ metadata:
     ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:!SHA1:!SHA256:!SHA384:EECDH+TLSv1.2+HIGH'
     ingress.kubernetes.io/ssl-prefer-server-ciphers: 'true'
     ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
 spec:
   tls:
   - hosts:

--- a/ops/kube/public-site-internal-ingress.yml
+++ b/ops/kube/public-site-internal-ingress.yml
@@ -20,8 +20,8 @@ metadata:
     ingress.kubernetes.io/ssl-ciphers: '!aNULL:!EXPORT56:!SHA1:!SHA256:!SHA384:EECDH+TLSv1.2+HIGH'
     ingress.kubernetes.io/ssl-prefer-server-ciphers: 'true'
     ingress.kubernetes.io/ssl-protocols: TLSv1.2 TLSv1.3
-    # ingress.kubernetes.io/configuration-snippet: |
-    #   more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains";
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
**What changes does this PR bring?**

Adds a HSTS policy, of 2 years, includeSubDomains, not preload as it is not part of specification.
* Now part of [FAIR 457](https://collaboration.homeoffice.gov.uk/jira/browse/FAIR-457) (previously part of FAIR 385), avoided the Content Security Policy parts as I was not able to get reporting to work.
* Even so, it would be a separate ticket anyway.
* Previously, done via [force-ssl-redirect](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#server-side-https-enforcement-through-redirect), but max age was not as high as desired.

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
