### PR TITLE
Sturgate Airfield set to be British and not in Hungary

### DIFF
--- a/src/common/utils/airport_codes.json
+++ b/src/common/utils/airport_codes.json
@@ -51405,9 +51405,9 @@
   {
     "id": "EGCS",
     "id2": "EGCS",
-    "british": false,
+    "british": true,
     "crownDependency": false,
-    "label": "Sturgate Airfield (Hungary) (EGCS)"
+    "label": "Sturgate Airfield (EGCS)"
   },
   {
     "id": "NIS",


### PR DESCRIPTION

![image](https://github.com/UKHomeOffice/egar-public-site-ui/assets/112489564/06e57707-4d12-448b-872b-b1c1bbc1a08a)
