### PR TITLE
Feature fair 487 v

### DIFF
--- a/src/common/models/Cookie.class.js
+++ b/src/common/models/Cookie.class.js
@@ -684,8 +684,8 @@ class Cookie {
     const craftBaseLatLong = destination.craftBase.match(/^[\+\-]?[\d.]+ [\+\-]?[\d.]+$/);
     if (craftBaseLatLong) {
       const [craftBaseLat, craftBaseLong] = craftBaseLatLong[0].split(' ');
-      destination.craftBaseLat = trimToDecimalPlaces(craftBaseLat, 4);
-      destination.craftBaseLong = trimToDecimalPlaces(craftBaseLong, 4);
+      destination.craftBaseLat = trimToDecimalPlaces(craftBaseLat, 6);
+      destination.craftBaseLong = trimToDecimalPlaces(craftBaseLong, 6);
       destination.portChoice = 'No';
       return;
     }

--- a/src/common/templates/includes/location.njk
+++ b/src/common/templates/includes/location.njk
@@ -65,20 +65,31 @@
 
 {% macro lat_long(lat, long, prefix, errors, __) %}
 
+    <style type="text/css">
+
+        #{{ prefix }}Long:invalid{
+            background-color:#ff9baf;
+        }
+        #{{ prefix }}Lat:invalid{
+            background-color:#ff9baf;
+        }
+
+    
+    </style>
     {# Start location coords #}
     {# Latitude #}
     <div class="govuk-form-group {{ m.form_group_class(prefix + 'Lat', errors) }}">
         <label class="govuk-label" for="{{ prefix }}Lat">{{__('field_latitude')}}</label>
         {{ m.hint(prefix + 'Latitude', __('field_latitude_hint')) }}
         {{ m.error_message(prefix + 'Lat', errors, __) }}
-        <input class="govuk-input govuk-date-input__input" id="{{ prefix }}Lat" name="{{ prefix }}Lat" type="number" step="0.000001" max="90" min="-90" value="{{ lat }}">
+        <input class="govuk-input govuk-date-input__input" id="{{ prefix }}Lat" name="{{ prefix }}Lat" type="text"  maxlength="11" pattern="^[+\-]?\d*\.?\d{6}$" title="Enter a numeric value with 6 decimal places ranging from -180 to 180" value="{{ lat }}">
     </div>
     {# Longitude #}
     <div class="govuk-form-group {{ m.form_group_class(prefix + 'Long', errors) }}">
         <label class="govuk-label" for="{{ prefix }}Long">{{__('field_longitude')}}</label>
         {{ m.hint(prefix + 'Longitude', __('field_longitude_hint')) }}
         {{ m.error_message(prefix + 'Long', errors, __) }}
-        <input class="govuk-input govuk-date-input__input" id="{{ prefix }}Long" name="{{ prefix }}Long" type="text" step="0.000001" max="180" min="-180" value="{{ long }}">
+        <input class="govuk-input govuk-date-input__input" id="{{ prefix }}Long" name="{{ prefix }}Long" type="text" maxlength="11" pattern="^[+\-]?\d*\.?\d{6}$" title="Enter a numeric value with 6 decimal places ranging from -90 to 90" value="{{ long }}">
     </div>
     {# End location coords #}
 

--- a/src/common/templates/includes/macros.njk
+++ b/src/common/templates/includes/macros.njk
@@ -105,8 +105,7 @@
   settings
 #}
 {% macro gar_id_screen_reader(garid) %}
-  {% for letter in garid.split('') %}{{ letter }}
-    <span class="govuk-visually-hidden">{{'dash' if letter == '-'}},</span>{% endfor %}
+  {% for letter in garid.split('') %}{{ letter }}<span class="govuk-visually-hidden">{{'dash' if letter == '-'}},</span>{% endfor %}
 {% endmacro %}
 
 {% macro hint(id, hint) %}


### PR DESCRIPTION
- craftBase no longer truncated to 4 chars, 6 instead
- lat long values with trailing 0s no longer have those 0s truncated
- screen reader function does not display GAR submission reference with extra spaces