### PR TITLE
Document fields all in Travel Document Details, Response Message column only for UK inbound journeys.

### DIFF
--- a/src/app/garfile/view/get.controller.js
+++ b/src/app/garfile/view/get.controller.js
@@ -83,7 +83,8 @@ module.exports = (req, res) => {
         garpeople: parsedPeople,
         garsupportingdocs: supportingDocuments,
         successMsg,
-        successHeader
+        successHeader,
+        isJourneyUKInbound: airportValidation.isJourneyUKInbound(parsedGar.departurePort, parsedGar.arrivalPort)
       }; 
       renderContext.showChangeLinks = true;
       if ((parsedGar.status.name === 'Submitted') || parsedGar.status.name === 'Cancelled') {

--- a/src/app/garfile/view/post.controller.js
+++ b/src/app/garfile/view/post.controller.js
@@ -74,7 +74,8 @@ module.exports = (req, res) => {
         garfile: parsedGar,
         garpeople: parsedPeople,
         garsupportingdocs: supportingDocuments,
-        showChangeLinks: true
+        showChangeLinks: true,
+        isJourneyUKInbound: airportValidation.isJourneyUKInbound(parsedGar.departurePort, parsedGar.arrivalPort)
       };
 
       if (parsedGar.status.name === 'Submitted' || parsedGar.status.name === 'Cancelled') {

--- a/src/common/templates/check-your-answers.njk
+++ b/src/common/templates/check-your-answers.njk
@@ -1,322 +1,342 @@
 {% import "common/templates/includes/banners.njk" as b %}
 
-  <div class="govuk-grid-column-full">
-    <dl id="departure" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{ __('heading_departure_details') }}
-        </dt>
-        {% if showChangeLinks %}
+<div class="govuk-grid-column-full">
+  <dl id="departure" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+    <div class="app-check-your-answers__contents">
+      <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+        {{ __('heading_departure_details') }}
+      </dt>
+      {% if showChangeLinks %}
         <dd style="border-bottom: none;" class="app-check-your-answers__change">
           <a href="/garfile/departure" id='departure-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{ __('heading_departure_details') }}</span>
+            {{__('change_prefix')}}
+            <span class="govuk-visually-hidden">{{ __('heading_departure_details') }}</span>
           </a>
         </dd>
-        {% endif %}
-      </div>
-    </dl>
-            {{ b.coa_designation_regulation_change(true) }}
-  
-    {% macro check_your_answers_row(label, value, id="") %}
-      <div class="app-check-your-answers__contents">
-        <dt class="app-check-your-answers__question">{{ label }}</dt>
-        <dd id="{{ id }}" class="app-check-your-answers__answer">{{ value }}</dd>
-      </div>
-    {% endmacro %}
-
-    {% macro check_your_answers_row_port_code(id, label, value) %}
-      {% if value.length > 4 %}
-        {# Hide the row #}
-      {% else %}
-        <div class="app-check-your-answers__contents">
-          <dt id="{{ id }}-label" class="app-check-your-answers__question">{{ label }}</dt>
-          <dd id="{{ id }}-value" class="app-check-your-answers__answer">{{ value }}</dd>
-        </div>
       {% endif %}
-      
-    {% endmacro %}
+    </div>
+  </dl>
+  {{ b.coa_designation_regulation_change(true) }}
 
-    {% macro check_your_answers_row_coordinates(id, label, latitude, longitude, __) %}
-      {% if latitude != undefined and latitude != '' %}
-        <div class="app-check-your-answers__contents">
-          <dt id="{{ id }}-label" class="app-check-your-answers__question">{{ label }}</dt>
-          <dd id="{{ id }}-value" class="app-check-your-answers__answer">
-            {{__('field_latitude')}}: {{ latitude }}
-            <br>
-            {{__('field_longitude')}}: {{ longitude }}
-          </dd>
-        </div>
-      {% endif %}
-    {% endmacro %}
+  {% macro check_your_answers_row(label, value, id = "") %}
+    <div class="app-check-your-answers__contents">
+      <dt class="app-check-your-answers__question">{{ label }}</dt>
+      <dd id="{{ id }}" class="app-check-your-answers__answer">{{ value }}</dd>
+    </div>
+  {% endmacro %}
 
-    <dl class="app-check-your-answers app-check-your-answers--short">
-      {{ check_your_answers_row(__('field_departure_date'), garfile.departureDate, id="departureDate") }}
-      {{ check_your_answers_row(__('field_departure_time'), garfile.departureTime, id="departureTime") }}
-      {{ check_your_answers_row_port_code('departurePort', __('field_departure_port'), garfile.departurePort) }}
-      {{ check_your_answers_row_coordinates('departureCoordinates', __('field_departure_coordinates'), garfile.departureLat, garfile.departureLong, __) }}
-    </dl>
-
-    {{ m.departure_warning_message(__) }}
-
-    <dl id="arrival" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+  {% macro check_your_answers_row_port_code(id, label, value) %}
+    {% if value.length > 4 %}
+      {# Hide the row #}
+    {% else %}
       <div class="app-check-your-answers__contents">
+        <dt id="{{ id }}-label" class="app-check-your-answers__question">{{ label }}</dt>
+        <dd id="{{ id }}-value" class="app-check-your-answers__answer">{{ value }}</dd>
+      </div>
+    {% endif %}
+
+  {% endmacro %}
+
+  {% macro check_your_answers_row_coordinates(id, label, latitude, longitude, __) %}
+    {% if latitude != undefined and latitude != '' %}
+      <div class="app-check-your-answers__contents">
+        <dt id="{{ id }}-label" class="app-check-your-answers__question">{{ label }}</dt>
+        <dd id="{{ id }}-value" class="app-check-your-answers__answer">
+          {{__('field_latitude')}}: {{ latitude }}
+          <br>
+          {{__('field_longitude')}}: {{ longitude }}
+        </dd>
+      </div>
+    {% endif %}
+  {% endmacro %}
+
+  <dl class="app-check-your-answers app-check-your-answers--short">
+    {{ check_your_answers_row(__('field_departure_date'), garfile.departureDate, id="departureDate") }}
+    {{ check_your_answers_row(__('field_departure_time'), garfile.departureTime, id="departureTime") }}
+    {{ check_your_answers_row_port_code('departurePort', __('field_departure_port'), garfile.departurePort) }}
+    {{ check_your_answers_row_coordinates('departureCoordinates', __('field_departure_coordinates'), garfile.departureLat, garfile.departureLong, __) }}
+  </dl>
+
+  {{ m.departure_warning_message(__) }}
+
+  <dl id="arrival" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+    <div class="app-check-your-answers__contents">
       {% if showChangeLinks %}
         <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
           {{__('heading_arrival_details')}}
         </dt>
         <dd style="border-bottom: none;" class="app-check-your-answers__change">
           <a href="/garfile/arrival" id='arrival-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_arrival_details')}}</span>
+            {{__('change_prefix')}}
+            <span class="govuk-visually-hidden">{{__('heading_arrival_details')}}</span>
           </a>
         </dd>
-        {% endif %}
-      </div>
-    </dl>
-    {{ b.coa_designation_regulation_change(false) }}
+      {% endif %}
+    </div>
+  </dl>
+  {{ b.coa_designation_regulation_change(false) }}
 
-    <dl class="app-check-your-answers app-check-your-answers--short">
-      {{ check_your_answers_row(__('field_arrival_date'), garfile.arrivalDate) }}
-      {{ check_your_answers_row(__('field_arrival_time'), garfile.arrivalTime) }}
-      {{ check_your_answers_row_port_code('arrivalPort', __('field_arrival_port'), garfile.arrivalPort) }}
-      {{ check_your_answers_row_coordinates('arrivalCoordinates', __('field_arrival_coordinates'), garfile.arrivalLat, garfile.arrivalLong, __) }}
-    </dl>
+  <dl class="app-check-your-answers app-check-your-answers--short">
+    {{ check_your_answers_row(__('field_arrival_date'), garfile.arrivalDate) }}
+    {{ check_your_answers_row(__('field_arrival_time'), garfile.arrivalTime) }}
+    {{ check_your_answers_row_port_code('arrivalPort', __('field_arrival_port'), garfile.arrivalPort) }}
+    {{ check_your_answers_row_coordinates('arrivalCoordinates', __('field_arrival_coordinates'), garfile.arrivalLat, garfile.arrivalLong, __) }}
+  </dl>
 
-    <dl id="aircraft" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{__('heading_aircraft_details')}}
-        </dt>
-        {% if showChangeLinks %}
+  <dl id="aircraft" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+    <div class="app-check-your-answers__contents">
+      <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+        {{__('heading_aircraft_details')}}
+      </dt>
+      {% if showChangeLinks %}
         <dd style="border-bottom: none;" class="app-check-your-answers__change">
           <a href="/garfile/craft" id='aircraft-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_aircraft_details')}}</span>
+            {{__('change_prefix')}}
+            <span class="govuk-visually-hidden">{{__('heading_aircraft_details')}}</span>
           </a>
         </dd>
-        {% endif %}
-      </div>
-    </dl>
+      {% endif %}
+    </div>
+  </dl>
 
-    <dl class="app-check-your-answers app-check-your-answers--short">
-      {{ check_your_answers_row(__('field_aircraft_registration'), garfile.registration) }}
-      {{ check_your_answers_row(__('field_aircraft_type'), garfile.craftType) }}
-      {{ check_your_answers_row(__('field_aircraft_base'), garfile.craftBase) }}
-    </dl>
+  <dl class="app-check-your-answers app-check-your-answers--short">
+    {{ check_your_answers_row(__('field_aircraft_registration'), garfile.registration) }}
+    {{ check_your_answers_row(__('field_aircraft_type'), garfile.craftType) }}
+    {{ check_your_answers_row(__('field_aircraft_base'), garfile.craftBase) }}
+  </dl>
 
-    <dl id="manifest" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{__('heading_manifest_details')}}
-          <p class="govuk-body-s" style="white-space: nowrap;"><mark>{{__('expired_passport_warning')}}</mark></p>
-            {% if showChangeLinks %}
-            <html>
-              <head>
-                 <p><b>Click</b>
+  <dl id="manifest" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+    <div class="app-check-your-answers__contents">
+      <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+        {{__('heading_manifest_details')}}
+        <p class="govuk-body-s" style="white-space: nowrap;">
+          <mark>{{__('expired_passport_warning')}}</mark>
+        </p>
+        {% if showChangeLinks %}
+          <html>
+            <head>
+              <p>
+                <b>Click</b>
               </head>
-             <body> 
-               <a href="/garfile/manifest">
+              <body>
+                <a href="/garfile/manifest">
                        here
                </a>
-               <head>
-               <b>to add a person from current manifest to people.</b>
-               <head>
-             </body>
-            </html>
-          {% endif %}
-        </dt>
-        {% if showChangeLinks %}
-        <dd style="border-bottom: none;" class="app-check-your-answers__change">
-          <a href="/garfile/manifest" id='manifest-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_manifest_details')}}</span>
-          </a>
-        </dd>
-        {% endif %}
-      </div>
-    </dl>
+                <head>
+                  <b>to add a person from current manifest to people.</b>
+                  <head></body>
+                </html>
+              {% endif %}
+            </dt>
+            {% if showChangeLinks %}
+              <dd style="border-bottom: none;" class="app-check-your-answers__change">
+                <a href="/garfile/manifest" id='manifest-change'>
+                  {{__('change_prefix')}}
+                  <span class="govuk-visually-hidden">{{__('heading_manifest_details')}}</span>
+                </a>
+              </dd>
+            {% endif %}
+          </div>
+        </dl>
+        <div class="govuk-form-group {{ m.form_group_class('manifestTable', errors) }}">
+          {{ m.error_message('manifestTable', errors, __) }}
 
-    <div class="govuk-form-group {{ m.form_group_class('manifestTable', errors) }}">
-      {{ m.error_message('manifestTable', errors, __) }}
+          <table class="govuk-table" id="manifestTable">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col">{{__('field_surname')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_given_name')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_dob')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_nationality')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_gender')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_birth_place')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_person_type_short')}}</th>
+                {% if isJourneyUKInbound %}
+                  <th class="govuk-table__header" scope="col">{{__('field_upt_response')}}</th>
+                {% endif %}
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              {% if garpeople.items | length %}
+                {% for person in garpeople.items%}
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{person.lastName}}</td>
+                    <td class="govuk-table__cell">{{person.firstName}}</td>
+                    <td class="govuk-table__cell">{{person.dateOfBirth}}</td>
+                    <td class="govuk-table__cell">{{person.nationality | upper}}</td>
+                    <td class="govuk-table__cell">{{person.gender}}</td>
+                    <td class="govuk-table__cell">{{person.placeOfBirth}}</td>
+                    <td class="govuk-table__cell">{{person.peopleType.name}}</td>
+                    {% if isJourneyUKInbound %}
+                      <td class="govuk-table__cell">{{__('amg_status_check_response_code_' + person.amgCheckinResponseCode) if person.amgCheckinResponseCode}}</td>
+                      {%endif%}
+                    </tr>
+                    <tr class="govuk-table__row">
+                      <td class="govuk-table__cell" colspan="{{8 if isJourneyUKInbound else 7}}">
+                        <div>
+                          <details class="govuk-details" data-module="govuk-details">
+                            <summary class="govuk-details__summary" aria-controls="details-content-{{ loop.index }}" aria-expanded="false" title="{{__('further_information_for', person.firstName, person.lastName)}}">
+                              <span id="further-information-{{ loop.index }}" class="govuk-details__summary-text">{{__('label_manifest_further_personal_details')}}</span>
+                            </summary>
+                            <div class="govuk-details__text" id="details-content-{{ loop.index }}" aria-hidden="true">
+                              <table class="govuk-table">
+                                <tbody class="govuk-table__body">
+                                  <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell">{{__('field_travel_document_type')}}</td>
+                                    <td class="govuk-table__cell">{{person.documentType}}</td>
+                                  </tr>
+                                  <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell">{{__('field_travel_document_issuing_state')}}</td>
+                                    <td class="govuk-table__cell">{{person.issuingState | upper}}</td>
+                                  </tr>
+                                  <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell">{{__('field_travel_document_number')}}</td>
+                                    <td class="govuk-table__cell">{{person.documentNumber}}</td>
+                                  </tr>
+                                  <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell">{{__('field_document_expiry_date')}}</td>
+                                    <td class="govuk-table__cell">{{person.documentExpiryDate}}</td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                          </details>
+                        </div>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                {% else %}
+                  {{ m.empty_table_message(__('manifest_no_records')) }}
+                {% endif %}
+              </tbody>
+            </table>
+          </div>
 
-      <table class="govuk-table" id="manifestTable">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">{{__('field_surname')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_given_name')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_dob')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_nationality')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_travel_document_number')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_document_expiry_date')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_gender')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_birth_place')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_person_type_short')}}</th>
-            <th class="govuk-table__header" scope="col">{{__('field_upt_response')}}</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        {% if garpeople.items | length %}
-          {% for person in garpeople.items%}
-            <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{person.lastName}}</td>
-            <td class="govuk-table__cell">{{person.firstName}}</td>
-            <td class="govuk-table__cell">{{person.dateOfBirth}}</td>
-            <td class="govuk-table__cell">{{person.nationality | upper}}</td>
-            <td class="govuk-table__cell">{{person.documentNumber}}</td>
-            <td class="govuk-table__cell">{{person.documentExpiryDate}}</td>
-            <td class="govuk-table__cell">{{person.gender}}</td>
-            <td class="govuk-table__cell">{{person.placeOfBirth}}</td>
-            <td class="govuk-table__cell">{{person.peopleType.name}}</td>
-            <td class="govuk-table__cell">{{__('amg_status_check_response_code_' + person.amgCheckinResponseCode) if person.amgCheckinResponseCode}}</td>
-            </tr>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell" colspan="6">
-                <div>
-                  <details class="govuk-details" data-module="govuk-details">
-                    <summary class="govuk-details__summary" aria-controls="details-content-{{ loop.index }}" aria-expanded="false" title="{{__('further_information_for', person.firstName, person.lastName)}}">
-                      <span id="further-information-{{ loop.index }}" class="govuk-details__summary-text">{{__('label_manifest_further_personal_details')}}</span>
-                    </summary>
-                    <div class="govuk-details__text" id="details-content-{{ loop.index }}" aria-hidden="true">
-                      <table class="govuk-table">
-                        <tbody class="govuk-table__body">
-                          <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">{{__('field_travel_document_type')}}</td>
-                            <td class="govuk-table__cell">{{person.documentType}}</td>
-                          </tr>
-                          <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">{{__('field_travel_document_issuing_state')}}</td>
-                            <td class="govuk-table__cell">{{person.issuingState | upper}}</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </details>
-                </div>
-              </td>
-            </tr>
-          {% endfor %}
-        {% else %}
-          {{ m.empty_table_message(__('manifest_no_records')) }}
-        {% endif %}
-        </tbody>
-      </table>
-    </div>
+          <dl id="responsiblePerson" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+            <div class="app-check-your-answers__contents">
+              <dt style="width: 500px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+                {{__('heading_responsible_person_details')}}
+              </dt>
+              {% if showChangeLinks %}
+                <dd style="border-bottom: none;" class="app-check-your-answers__change">
+                  <a href="/garfile/responsibleperson" id='responsible-person-change'>
+                    {{__('change_prefix')}}
+                    <span class="govuk-visually-hidden">{{__('heading_responsible_person_details')}}</span>
+                  </a>
+                </dd>
+              {% endif %}
+            </div>
+          </dl>
 
-    <dl id="responsiblePerson" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 500px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{__('heading_responsible_person_details')}}
-        </dt>
-        {% if showChangeLinks %}
-        <dd style="border-bottom: none;" class="app-check-your-answers__change">
-          <a href="/garfile/responsibleperson" id='responsible-person-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_responsible_person_details')}}</span>
-          </a>
-        </dd>
-        {% endif %}
-      </div>
-    </dl>
+          <dl class="app-check-your-answers app-check-your-answers--short">
+            {{ check_your_answers_row(__('field_given_name'), garfile.responsibleGivenName) }}
+            {{ check_your_answers_row(__('field_surname'), garfile.responsibleSurname) }}
 
-    <dl class="app-check-your-answers app-check-your-answers--short">
-      {{ check_your_answers_row(__('field_given_name'), garfile.responsibleGivenName) }}
-      {{ check_your_answers_row(__('field_surname'), garfile.responsibleSurname) }}
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                {{__('field_address')}}
+              </dt>
+              <dd class="app-check-your-answers__answer">
+                {{garfile.responsibleAddressLine1}}
+                <br>
+                {{garfile.responsibleAddressLine2}}
+                <br>
+                {{ garfile.responsibleCountryLabel }}
+                <br>
+                {{garfile.responsiblePostcode}}
+                <br>
+              </dd>
+            </div>
+            {{ check_your_answers_row(__('field_contact_details'), garfile.responsibleContactNo) }}
+            {{ check_your_answers_row(__('field_email'), garfile.responsibleEmail ) }}
 
-      <div class="app-check-your-answers__contents">
-        <dt class="app-check-your-answers__question">
-          {{__('field_address')}}
-        </dt>
-        <dd class="app-check-your-answers__answer">
-          {{garfile.responsibleAddressLine1}} <br>
-          {{garfile.responsibleAddressLine2}} <br>
-          {{ garfile.responsibleCountryLabel }} <br>
-          {{garfile.responsiblePostcode}} <br>
-        </dd>
-      </div>
-      {{ check_your_answers_row(__('field_contact_details'), garfile.responsibleContactNo) }}
-      {{ check_your_answers_row(__('field_email'), garfile.responsibleEmail ) }}
+            {% if garfile.fixedBasedOperator != 'Other' %}
+              {{ check_your_answers_row(__('field_fbo_question'), garfile.fixedBasedOperator) }}
+            {% endif %}
+            {% if garfile.fixedBasedOperator === 'Other' %}
+              {{ check_your_answers_row(__('field_fbo_question_review'), garfile.fixedBasedOperatorAnswer | truncate(50)) }}
+            {% endif %}
+          </dl>
 
-      {% if garfile.fixedBasedOperator != 'Other' %}
-        {{ check_your_answers_row(__('field_fbo_question'), garfile.fixedBasedOperator) }}
-      {% endif %}
-      {% if garfile.fixedBasedOperator === 'Other' %}
-        {{ check_your_answers_row(__('field_fbo_question_review'), garfile.fixedBasedOperatorAnswer | truncate(50)) }}
-      {% endif %}
-    </dl>
+          <dl id="customs" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+            <div class="app-check-your-answers__contents">
+              <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+                {{__('heading_customs')}}
+              </dt>
+              {% if showChangeLinks %}
+                <dd style="border-bottom: none;" class="app-check-your-answers__change">
+                  <a href="/garfile/customs" id='customs-change'>
+                    {{__('change_prefix')}}
+                    <span class="govuk-visually-hidden">{{__('heading_customs')}}</span>
+                  </a>
+                </dd>
+              {% endif %}
+            </div>
+          </dl>
 
-    <dl id="customs" class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 200px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{__('heading_customs')}}
-        </dt>
-        {% if showChangeLinks %}
-        <dd style="border-bottom: none;" class="app-check-your-answers__change">
-          <a href="/garfile/customs" id='customs-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_customs')}}</span>
-          </a>
-        </dd>
-        {% endif %}
-      </div>
-    </dl>
+          <dl class="app-check-your-answers app-check-your-answers--short">
+            {{ check_your_answers_row(__('field_intention_review'), garfile.intentionValue) }}
+            {% if garfile.intentionValue === 'Yes' %}
+              {{ check_your_answers_row(__('field_prohibited_goods_review'), garfile.prohibitedGoods) }}
+              {% if garfile.prohibitedGoods === 'Yes' %}
+                {{ check_your_answers_row(__('field_goods_declaration_review'), garfile.goodsDeclaration | truncate(50)) }}
+              {% endif %}
 
-    <dl class="app-check-your-answers app-check-your-answers--short">
-      {{ check_your_answers_row(__('field_intention_review'), garfile.intentionValue) }}
-      {% if garfile.intentionValue === 'Yes' %}
-        {{ check_your_answers_row(__('field_prohibited_goods_review'), garfile.prohibitedGoods) }}
-        {% if garfile.prohibitedGoods === 'Yes' %}
-          {{ check_your_answers_row(__('field_goods_declaration_review'), garfile.goodsDeclaration | truncate(50)) }}
-        {% endif %}
+              {{ check_your_answers_row(__('field_baggage_review'), garfile.baggage) }}
+              {% if garfile.baggage === 'Yes' %}
+                {{ check_your_answers_row(__('field_baggage_declaration_review'), garfile.baggageDeclaration | truncate(50)) }}
+              {% endif %}
 
-        {{ check_your_answers_row(__('field_baggage_review'), garfile.baggage) }}
-        {% if garfile.baggage === 'Yes' %}
-          {{ check_your_answers_row(__('field_baggage_declaration_review'), garfile.baggageDeclaration | truncate(50)) }}
-        {% endif %}
+              {{ check_your_answers_row(__('field_continental_shelf_review'), garfile.continentalShelf ) }}
+              {% if garfile.continentalShelf === 'Yes' %}
+                {{ check_your_answers_row(__('field_continental_shelf_declaration_review'), garfile.continentalShelfDeclaration | truncate(50)) }}
+              {% endif %}
+            {% endif %}
+            {% if garfile.passengerTravellingReason != "" %}
+              {{ check_your_answers_row(__('passenger_travelling_reason_review'), garfile.passengerTravellingReason | truncate(50)) }}
+            {% endif %}
+            {{ check_your_answers_row(__('field_visit_reason_review'), garfile.visitReason | uncamelCase) }}
+            {% if garfile.supportingInformation != "" %}
+              {{ check_your_answers_row(__('field_supporting_information_review'), garfile.supportingInformation | truncate(50)) }}
+            {% endif %}
+          </dl>
 
-        {{ check_your_answers_row(__('field_continental_shelf_review'), garfile.continentalShelf ) }}
-        {% if garfile.continentalShelf === 'Yes' %}
-          {{ check_your_answers_row(__('field_continental_shelf_declaration_review'), garfile.continentalShelfDeclaration | truncate(50)) }}
-        {% endif %}
-      {% endif %}
-      {% if garfile.passengerTravellingReason != "" %}
-        {{ check_your_answers_row(__('passenger_travelling_reason_review'), garfile.passengerTravellingReason | truncate(50)) }}
-      {% endif %}
-      {{ check_your_answers_row(__('field_visit_reason_review'), garfile.visitReason | uncamelCase) }}
-      {% if garfile.supportingInformation != "" %}
-        {{ check_your_answers_row(__('field_supporting_information_review'), garfile.supportingInformation | truncate(50)) }}
-      {% endif %}
-    </dl>
+          <dl class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
+            <div class="app-check-your-answers__contents">
+              <dt style="width: 400px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
+                {{__('heading_supporting_documentation_details')}}
+              </dt>
+              {% if showChangeLinks %}
+                <dd style="border-bottom: none;" class="app-check-your-answers__change">
+                  <a href="/garfile/supportingdocuments" id='supporting-documents-change'>
+                    {{__('change_prefix')}}
+                    <span class="govuk-visually-hidden">{{__('heading_supporting_documentation_details')}}</span>
+                  </a>
+                </dd>
+              {% endif %}
+            </div>
+          </dl>
 
-    <dl class="app-check-your-answers app-check-your-answers--short" style="margin-bottom: 0;">
-      <div class="app-check-your-answers__contents">
-        <dt style="width: 400px; border-bottom: none;" class="govuk-heading-m app-check-your-answers__question">
-          {{__('heading_supporting_documentation_details')}}
-        </dt>
-        {% if showChangeLinks %}
-        <dd style="border-bottom: none;" class="app-check-your-answers__change">
-          <a href="/garfile/supportingdocuments" id='supporting-documents-change'>
-            {{__('change_prefix')}}<span class="govuk-visually-hidden">{{__('heading_supporting_documentation_details')}}</span>
-          </a>
-        </dd>
-        {% endif %}
-      </div>
-    </dl>
-
-		<table class="govuk-table">
-			<thead class="govuk-table__head">
-				<tr class="govuk-table__row">
-					<th class="govuk-table__header" scope="col">{{__('field_file_name')}}</th>
-					<th class="govuk-table__header" scope="col">{{__('field_file_size')}}</th>
-					<th class="govuk-table__header" scope="col">{{__('field_file_status')}}</th>
-				</tr>
-			</thead>
-			<tbody class="govuk-table__body">
-      {% if garsupportingdocs.items | length %}
-        {% for file in garsupportingdocs.items %}
-				<tr class="govuk-table__row">
-					<td class="govuk-table__cell">{{file.fileName}}</td>
-					<td class="govuk-table__cell">{{file.size}}</td>
-					<td class="govuk-table__cell">{{__('field_file_status_done')}}</td>
-				</tr>
-				{% endfor %}
-      {% else %}
-        {{ m.empty_table_message(__('supportingdocuments_no_records')) }}
-      {% endif %}
-			</tbody>
-		</table>
-  </div>
+          <table class="govuk-table">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col">{{__('field_file_name')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_file_size')}}</th>
+                <th class="govuk-table__header" scope="col">{{__('field_file_status')}}</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              {% if garsupportingdocs.items | length %}
+                {% for file in garsupportingdocs.items %}
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{file.fileName}}</td>
+                    <td class="govuk-table__cell">{{file.size}}</td>
+                    <td class="govuk-table__cell">{{__('field_file_status_done')}}</td>
+                  </tr>
+                {% endfor %}
+              {% else %}
+                {{ m.empty_table_message(__('supportingdocuments_no_records')) }}
+              {% endif %}
+            </tbody>
+          </table>
+        </div>


### PR DESCRIPTION
This update aligns the manifest view page with updates to the edit page so that all travel document fields are in the 'Travel Document Details' section.

It also removes the Response Message column, if isJourneyUKInbound is false.

![image](https://github.com/UKHomeOffice/egar-public-site-ui/assets/112489564/8531d3ad-db3b-4fff-b6fd-63104bc85306)
