### PR TITLE
FAIR-538 ~ 2024.07.31 ~ updated the text for iata code error

### DIFF
--- a/src/app/api/uploadgar/validations.js
+++ b/src/app/api/uploadgar/validations.js
@@ -46,10 +46,10 @@ module.exports.validations = (voyageObj, crewArr, passengersArr) => {
   const validationArr = [
     [new ValidationRule(validator.isValidAirportCode, '', voyageObj.arrivalPort, 'Arrival port should be an ICAO or IATA code')],
     [new ValidationRule(validator.notEmpty, '', voyageObj.arrivalPort, 'Enter a value for the arrival port')],
-    [new ValidationRule(validator.preventZ, '', voyageObj.arrivalPort, 'Add ICAO/IATA or Latitude/Longitude Co-ordinates for the location')],
+    [new ValidationRule(validator.preventZ, '', voyageObj.arrivalPort, `Arrival Port: ${__('prevent_zzzz_or_yyyy_message')}`)],
     [new ValidationRule(validator.isValidAirportCode, '', voyageObj.departurePort, 'Departure port should be an ICAO or IATA code')],
     [new ValidationRule(validator.notEmpty, '', voyageObj.departurePort, 'Enter a value for the departure port')],
-    [new ValidationRule(validator.preventZ, '', voyageObj.departurePort, 'Add ICAO/IATA or Latitude/Longitude Co-ordinates for the location')],
+    [new ValidationRule(validator.preventZ, '', voyageObj.departurePort, `Departure Port: ${__('prevent_zzzz_or_yyyy_message')}`)],
     [new ValidationRule(airportValidation.includesOneBritishAirport, '', [voyageObj.departurePort, voyageObj.arrivalPort], airportValidation.notBritishMsg)],
     [new ValidationRule(validator.notEmpty, '', voyageObj.arrivalTime, 'Enter a value for the arrival time')],
     [new ValidationRule(validator.notEmpty, '', voyageObj.departureTime, 'Enter a value for the departure time')],

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -536,5 +536,5 @@
 	"responsible_person_no_records_create_new": "No saved responsible person records found. Create a new one in the Responsible Person tab.",
 	"heading_edit_responsible_person": "Edit responsible person",
 	"caption_responsible_person_details": "Select the details of a responsible person you have previously added",
-	"prevent_zzzz_or_yyyy_message": "Add ICAO/IATA for the location. ZZZZ or YYYY are not accepted values."
+	"prevent_zzzz_or_yyyy_message": "Add ICAO/IATA codes for the location. ZZZZ or YYYY are not accepted codes."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -535,5 +535,6 @@
 	"responsible_person_no_records": "There are no saved responsible person records",
 	"responsible_person_no_records_create_new": "No saved responsible person records found. Create a new one in the Responsible Person tab.",
 	"heading_edit_responsible_person": "Edit responsible person",
-	"caption_responsible_person_details": "Select the details of a responsible person you have previously added"
+	"caption_responsible_person_details": "Select the details of a responsible person you have previously added",
+	"prevent_zzzz_or_yyyy_message": "Add ICAO/IATA for the location. ZZZZ or YYYY are not accepted values."
 }


### PR DESCRIPTION
**What changes does this PR bring?**

This pull request fixes the latitude and longitude error text.
* FAIR 538, departure and arrival code error for ZZZZ or YYYY is not explicit and tells the users to add a altitude or longitude coordinates.
* this change updates the text to not say that.


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
