### PR TITLE
NMSW-2691 - fixed the response code status issue

### DIFF
--- a/src/app/garfile/amg/checkin/pane.njk
+++ b/src/app/garfile/amg/checkin/pane.njk
@@ -5,10 +5,8 @@
 
   {% if (status === 'Complete') %}
     {% set statustitle = __('amg_status_check_response_code_' + checkin_code) if checkin_code else '' %}
-  {% elif(status === 'Pending') %}
-    {% set statustitle = 'Permission to travel pending' %}
   {% else %}
-    {% set statustitle = 'There was a problem requesting permission to travel for this passenger' %}
+    {% set statustitle = '' %}
   {% endif %}
 
   {% if person.amgCheckinResponseCode === '0B'%}
@@ -17,6 +15,8 @@
     {% set statusColor = 'valid-permission-to-travel'%}
   {% elif person.amgCheckinResponseCode === '0Z'%}
     {% set statusColor = 'authority-to-carry-granted'%}
+  {% else %}  
+    {% set statusColor = ''%}
   {% endif %}
 
   {% set statustitle = statustitle %}
@@ -24,24 +24,30 @@
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">
       <div>
+        {% if statusColor %}
         <div class="{{statusColor}} status-text"  title="{{statustitle}}">{{statustitle}}</div>
+        {% endif %}
       </div>
     </td>
     <td class="govuk-table__cell">{{person.firstName}}
       {{person.lastName}}</td>
     <td class="govuk-table__cell">
         <div>
-            {% if checkin_code === travelPermissionCodes.NO_BOARD %} 
-              Pilots, operators and agents will receive a NO BOARD response via a call and email when Authority to Carry (ATC) has been refused.
-            {% elif(checkin_code === travelPermissionCodes.VALID) %}
+          {% if checkin_code | length and(checkin_code === travelPermissionCodes.NO_BOARD or checkin_code | first === '0') %}
+              {% if checkin_code === travelPermissionCodes.NO_BOARD %} 
+                Pilots, operators and agents will receive a NO BOARD response via a call and email when Authority to Carry (ATC) has been refused.
+              {% elif(checkin_code === travelPermissionCodes.VALID) %}
+                <p class="govuk-body">
+                  No action required.
+                </p>
+              {% else %}
               <p class="govuk-body">
-                No action required.
+                You must check if this individual has a valid passport or travel document.
               </p>
-            {% else %}
-            <p class="govuk-body">
-              You must check if this individual has a valid passport or travel document.
-            </p>
-            {% endif %}
+              {% endif %}
+          {% else %}
+            There was an error processing the permission to travel for this person.
+          {% endif %}
         </div>
     </td>
   </tr>

--- a/src/common/templates/check-your-answers.njk
+++ b/src/common/templates/check-your-answers.njk
@@ -157,9 +157,15 @@
                         {% set statusColor = 'valid-permission-to-travel'%}
                       {% elif person.amgCheckinResponseCode === '0Z'%}
                         {% set statusColor = 'authority-to-carry-granted'%}
+                      {% else %}  
+                        {% set statusColor = '' %}
                       {% endif %}
-                      <td class="govuk-table__cell"><div class="{{statusColor}} status-text">{{__('amg_status_check_response_code_' + person.amgCheckinResponseCode)if person.amgCheckinResponseCode}}</div></td>
-                      {%endif%}
+                      <td class="govuk-table__cell">
+                        {% if statusColor %}
+                          <div class="{{statusColor}} status-text">{{__('amg_status_check_response_code_' + person.amgCheckinResponseCode)if person.amgCheckinResponseCode}}</div>
+                        {% endif%}
+                      </td>  
+                      {% endif%}
                     </tr>
                     <tr class="govuk-table__row">
                       <td class="govuk-table__cell" colspan="{{8 if isJourneyUKInbound else 7}}">


### PR DESCRIPTION
**What changes does this PR bring?**
The fix for the different statuses colours display on GAR Summary page and Passenger Checks page.

![image](https://github.com/user-attachments/assets/01c111c3-43a3-41ed-bebb-334c69ec8cd0)
![image](https://github.com/user-attachments/assets/d42c57fa-5ca5-4ee0-82ee-4a6bc116c085)
![image](https://github.com/user-attachments/assets/9aad82a6-ac27-4f65-8766-cfedb3f5841c)


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
