### PR TITLE
NMSW-2797 ~ 2025.02.26 ~ old creation issues

### DIFF
--- a/src/app/garfile/amend/get.controller.js
+++ b/src/app/garfile/amend/get.controller.js
@@ -4,5 +4,6 @@ const CookieModel = require('../../../common/models/Cookie.class');
 module.exports = (req, res) => {
   logger.debug('In garfile / amend get controller');
   const cookie = new CookieModel(req);
+
   res.render('app/garfile/amend/index', { cookie });
 };

--- a/src/app/garfile/amend/post.controller.js
+++ b/src/app/garfile/amend/post.controller.js
@@ -2,17 +2,33 @@ const logger = require('../../../common/utils/logger')(__filename);
 const CookieModel = require('../../../common/models/Cookie.class');
 const garApi = require('../../../common/services/garApi');
 
-module.exports = (req, res) => {
+module.exports = async (req, res) => {
   const cookie = new CookieModel(req);
-  logger.debug(`In garfile / amend post controller - User: ${cookie.getUserDbId()} editing GAR: ${cookie.getGarId()}`);
 
-  garApi.patch(cookie.getGarId(), 'Draft', {})
-    .then(() => {
+  try {
+    const newCreatedDate = new Date().toISOString();
+    const garId = cookie.getGarId();
+    const createdDate = cookie.getGarCreatedDate();
 
-      req.session.successMsg = 'You may now amend the GAR and resubmit it.';
-      req.session.successHeader = 'GAR Amendment';
-      req.session.save(() => {
-        res.redirect('/garfile/view');
-      });
-    })
+    logger.debug(`In garfile / amend post controller - User: ${cookie.getUserDbId()} editing GAR: ${garId}`);
+    logger.info(`gar ${garId} old createdDate ${createdDate} is going to be ${newCreatedDate}`);
+
+    await garApi.patch(garId, 'Draft', { createdDate: newCreatedDate });
+    cookie.setGarCreatedDate(newCreatedDate);
+
+    req.session.successHeader = 'GAR Amendment';
+    req.session.save(() => {
+      res.redirect('/garfile/view');
+    });
+  } catch (err) {
+    logger.error(err);
+    res.render('app/garfile/amend/index', {
+      cookie,
+      errors: [
+        {
+          message: 'Something went wrong trying to amend the GAR. Please try again or contact support',
+        },
+      ],
+    });
+  }
 };

--- a/src/app/garfile/view/index.njk
+++ b/src/app/garfile/view/index.njk
@@ -25,7 +25,7 @@
     </div>
      
     <div class="govuk-grid-column-full">
-      {% if successMsg and successHeader !== 'GAR Amendment' %}
+      {% if successMsg %}
         {% include "common/templates/includes/success-action.njk" %}
       {% endif %}
     </div>

--- a/src/app/garfile/view/post.controller.js
+++ b/src/app/garfile/view/post.controller.js
@@ -65,9 +65,11 @@ module.exports = (req, res) => {
         return;
       }
       
-      cookie.setCbpId(parsedGar.cbpId)
+      cookie.setCbpId(parsedGar.cbpId);
       cookie.setGarId(parsedGar.garId);
       cookie.setGarStatus(parsedGar.status.name);
+      cookie.setGarCreatedDate(parsedGar.createdDate);
+
       logger.info(`Retrieved GAR id: ${parsedGar.garId}`);
 
       // Maybe not necessary but delete the ids as the template does not need them

--- a/src/common/models/Cookie.class.js
+++ b/src/common/models/Cookie.class.js
@@ -90,6 +90,7 @@ class Cookie {
         id: null,
         status: null,
         cbpId: null,
+        createdDate: null,
         craft: {
           registration: null,
           craftType: null,
@@ -178,6 +179,14 @@ class Cookie {
 
   getGarId() {
     return this.session.gar.id;
+  }
+
+  getGarCreatedDate() {
+    return this.session.gar.createdDate;
+  }
+  
+  setGarCreatedDate(createdDate) {
+    this.session.gar.createdDate = createdDate;
   }
 
   setAddPersonId(id) {


### PR DESCRIPTION
- the scenario this triggers is:
  - The cronjob delete all gars which created_date is 6 months old.
  - However, this means if you amend an old gar as template, it will be deleted when perhaps you wanted to use it for amends.
  - Therefore, createdDate should be reset, so you don't delete that old gar, it is a new gar.
- created gate to cookie only so you can access it for the logs, see if an old gar created date change in reset times.

**What changes does this PR bring?**


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
