### PR TITLE
NMSW-3033 added download template link to fix the download issue

### DIFF
--- a/src/app/home/index.njk
+++ b/src/app/home/index.njk
@@ -54,7 +54,7 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{__('heading_create_gar')}}</h1>
       <p class="govuk-body-l">{{__('create_gar_caption_1')}}
-        <a href="/documents/GAR_Template_Apr_2024_v6.6_SDS.xlsx">
+        <a href="https://assets.publishing.service.gov.uk/media/660fba8263b7f8001fde18e2/GAR_Template_Apr_2024_v6.6_SDS_.xlsx">
           <span class="govuk-visually-hidden">{{__('heading_create_gar')}}
           </span>{{__('create_gar_caption_link')}}</a>{{__('create_gar_caption_2')}}</p>
       <a id="start_now" class="govuk-button govuk-button--start" href="/garfile/home">{{__('button_start_now')}}</a>


### PR DESCRIPTION
**What changes does this PR bring?**
In this PR added fix to download template url issue.  replace existing url code with below URL:

https://assets.publishing.service.gov.uk/media/660fba8263b7f8001fde18e2/GAR_Template_Apr_2024_v6.6_SDS_.xlsx

https://jira.bics-collaboration.homeoffice.gov.uk/browse/NMSW-3033

**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [x] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [x] Has this change been tested against the Acceptance Criteria?
- [x] Have you considered how this will be deployed in SIT/Staging/Production?
