### PR TITLE
NMSW-3308 Hide create account link when one login is active

### DIFF
--- a/src/app/user/login/_partials/index.njk
+++ b/src/app/user/login/_partials/index.njk
@@ -74,11 +74,12 @@
           >Sign in or Create your GOV.UK One Login</a>
       {% endif %}
 
-
+      {% if ONE_LOGIN_SHOW_ONE_LOGIN == false and viewOnLoginPageForTest == false %}
       <h2 class="govuk-heading-m">{{ __('create_account_caption') }}</h2>
       <p class="govuk-body">
         <a href="/user/register">{{ __('title_create_account') }}</a>
       </p>
+      {% endif %}
 
       <input type="hidden" name="_csrf" value="{{csrfToken}}" />
     </form>


### PR DESCRIPTION
MR for defect under https://jira.bics-collaboration.homeoffice.gov.uk/browse/NMSW-3308

Hides the create link shown here 
<img width="995" height="428" alt="image" src="https://github.com/user-attachments/assets/cb2492a5-5bae-48aa-bd01-d18a539344e6" />
