### PR TITLE
nmsw-3429: The old annotation of 'kubernetes.io/ingress.class:' is deprecated an…

### DIFF
--- a/ops/kube/public-site-external-ingress.yml
+++ b/ops/kube/public-site-external-ingress.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cert-manager.io/solver: http01
   annotations:
-    kubernetes.io/ingress.class: "nginx-external"
+   # kubernetes.io/ingress.class: "nginx-external" # This is deprecated and replaced by the ingressClassName field in spec.
     cert-manager.io/enabled: "true"
     ingress.kubernetes.io/force-ssl-redirect: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -27,6 +27,7 @@ spec:
   - hosts:
     - {{ .PUBLIC_SITE_EXTERNAL_URL }}
     secretName: public-site-external-tls
+  ingressClassName: nginx-external  
   rules:
   - host: {{ .PUBLIC_SITE_EXTERNAL_URL }}
     http:

--- a/ops/kube/public-site-internal-ingress.yml
+++ b/ops/kube/public-site-internal-ingress.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cert-manager.io/solver: route53
   annotations:
-    kubernetes.io/ingress.class: "nginx-internal"
+    # kubernetes.io/ingress.class: "nginx-internal" # This is deprecated and replaced by the ingressClassName field in spec.
     cert-manager.io/enabled: "true"
     ingress.kubernetes.io/force-ssl-redirect: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -27,6 +27,7 @@ spec:
   - hosts:
     - {{ .PUBLIC_SITE_INTERNAL_URL }}
     secretName: public-site-internal-tls
+  ingressClassName: nginx-internal  
   rules:
   - host: {{ .PUBLIC_SITE_INTERNAL_URL }}
     http:


### PR DESCRIPTION
The old annotation of 'kubernetes.io/ingress.class:' is deprecated and replaced with 'spec.ingressClassName'

**What changes does this PR bring?**


**Definition of Done**
The following need to be checked off as they are complete as part of the
PR process. If you are unable to mark off an item as complete, then state
in the comments why this is the case.
- [ ] Have you built the code locally and confirmed its working?
- [ ] Is the build confirmed to be passing on CI?
- [ ] Have you added enough relevant unit tests for your change?
- [ ] Have you added enough relevant E2E tests for your change?
- [ ] Have you updated any relevant documentation as part of this change?
- [ ] Has this change been tested against the Acceptance Criteria?
- [ ] Have you considered how this will be deployed in SIT/Staging/Production?
