### PR TITLE
NMSW-4753: Remove one login SMS guidance

### DIFF
--- a/src/app/help/index.njk
+++ b/src/app/help/index.njk
@@ -235,22 +235,6 @@ GAR | Help
           </p>
         </div>
       </details>
-
-      <h2 class="govuk-heading-m" id="one-login-sms-issues">Help resolving the GOV.UK One Login international SMS Issue</h2>
-      <p class="govuk-body">
-        Some international users are currently unable to receive security codes by SMS from GOV.UK One Login to sign in to the Submit a GAR service. If you are experiencing this issue, you can resolve it in one of the following ways:
-      </p>
-
-      <h3 class="govuk-heading-s">Change the way you receive security codes</h3>
-      <p class="govuk-body-m"><a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login support team (opens in new tab on GOV.UK)</a> to change the method that you use to receive security codes to sign in from SMS to an authenticator app. They will do this by deleting and recreating your account with your existing email.</p>
-      <p class="govuk-body-m">This option will not delete your Submit a GAR account and you will keep all of the information in your account. </p>
-      <p class="govuk-body-m">This process can take between 3 and 5 days.</p>
-      <p class="govuk-body-m">Once your account has been recreated, you’ll need to contact the Submit a GAR support team to relink your account by email at <a href="mailto:GARSupport@Homeoffice.gov.uk">GARSupport@Homeoffice.gov.uk</a>.</p>
-
-      <h3 class="govuk-heading-s">Create a new account</h3>
-      <p class="govuk-body-m">Create a new GOV.UK One Login account using a different email address and choose the authenticator app option for receiving security codes.</p>
-      <p class="govuk-body-m">This will create a new account for you on the Submit a GAR service. You will not have access to your existing Submit a GAR account.</p>
-      <p class="govuk-body-m">You will be able to submit a GAR as soon as your new account has been created.</p>
     </div>
   </div>
 

--- a/src/app/user/login/index.njk
+++ b/src/app/user/login/index.njk
@@ -16,34 +16,19 @@
 {% endblock %}
 
 {% block content %}
-
-  {% set html %}
-    <p class="govuk-body">There is a problem affecting some international users who are unable to receive a security code by SMS from GOV.UK One Login when trying to sign in to this service.</p>
-
-    <p class="govuk-body">If you are experiencing this issue, read our guidance on <a href="/help#one-login-sms-issues" class="govuk-link">how to resolve the GOV.UK One Login international SMS issue</a>.</p>
-  {% endset %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        {{
-          m.govNotificationBannerBlue({
-            html: html
-          })
-        }}
-          <h1 class="govuk-heading-xl">{{ __('button_sign_in') }}</h1>
-          <p class="govuk-body">You need to sign in to this service using GOV.UK One Login. You'll be able to create a GOV.UK One Login if you do not already have one.</p>
-          <div class="govuk-inset-text">
-            <p class="govuk-body">You should use the same email address to create your GOV.UK One Login that you use for your SGAR account. This is so you keep the existing information in your account.</p>
-            <p class="govuk-body">You should also setup an authenticator app as your primary or backup method for receiving security codes. This will ensure you are able to login to your account if there are any problems with receiving security codes by SMS.</p>
-          </div>
-
-          <a
-            href="{{oneLoginAuthUrl}}"
-            role="button"
-            class="govuk-button govuk-!-margin-top-2"
-            >Sign in or create your GOV.UK One Login</a>
+      <h1 class="govuk-heading-xl">{{ __('button_sign_in') }}</h1>
+      <p class="govuk-body">You need to sign in to this service using GOV.UK One Login. You'll be able to create a GOV.UK One Login if you do not already have one.</p>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">You should use the same email address to create your GOV.UK One Login that you use for your SGAR account. This is so you keep the existing information in your account.</p>
+        <p class="govuk-body">You should also setup an authenticator app as your primary or backup method for receiving security codes. This will ensure you are able to login to your account if there are any problems with receiving security codes by SMS.</p>
+      </div>
+      <a
+        href="{{oneLoginAuthUrl}}"
+        role="button"
+        class="govuk-button govuk-!-margin-top-2"
+      >Sign in or create your GOV.UK One Login</a>
     </div>
   </div>
-
 {% endblock %}


### PR DESCRIPTION
## What changes does this PR bring?

Removes the One Login non-UK mobile issue guidance from sign-in and help and guidance pages.

The guidance is outdated and business has asked for it to be removed to avoid confusion.

**Note that this PR has `main` as its target branch as it will bypass the GovUK frontent V4-V5 feature work that is being tested in the dev branch and environment**