### PR TITLE
NMSW-4753 Add polyfill for APK concurrency issue

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,8 @@ steps:
       registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
       tags:
         - ${DRONE_COMMIT}
+    depends_on:
+      - build
     when:
       event:
         - push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:24-alpine3.23  AS development
 
-RUN apk update \
-    && apk upgrade --update-cache --available \
-    && apk add curl
+RUN apk upgrade --no-cache && \
+    apk add --no-cache curl
 
 RUN mkdir -p /public-site/ && \
     mkdir -p /var/log/nodejs/ && \


### PR DESCRIPTION
## What changes does this PR bring?

- Updates and simplifies the `apk upgrade` command to ignore caching
- depends the `publish-to-ecr step` on the build step to avoid a potential concurrency issue with repository download/update in APK during Docker builds

This is possibly not an ideal solution to this issue as there are two build phases in a deploy to sit pipeline (the `build` step itself and the build that automatically occurs when `publish-to-ecr` happens), however this brings SGAR in line with other pipelines we have had to do this with. We can investigate if a better long term solution exists with a general review of the pipelines.

## issue in Drone terminal

publish-to-ecr step fails on APK update/upgrade/install curl
<img width="1372" height="717" alt="Screenshot 2026-05-06 at 10 50 19" src="https://github.com/user-attachments/assets/4ee2c804-d238-4342-b463-c96119089c99" />

build step fails on same. Probably the same root issue but not logged in the same way
<img width="1375" height="713" alt="Screenshot 2026-05-06 at 10 51 21" src="https://github.com/user-attachments/assets/872d7a6a-0d5d-4f33-88b3-d2f7dd81524b" />

